### PR TITLE
provisioning observability: agent status marker + tray display (#2, #3, #5)

### DIFF
--- a/provider-shell/Sources/CoCoreShell/MenuBarController.swift
+++ b/provider-shell/Sources/CoCoreShell/MenuBarController.swift
@@ -131,24 +131,51 @@ final class MenuBarController {
         // PROCESS, so it stays true — this is what makes a remote stop
         // visible locally instead of still reading "Serving".
         let remotelyPaused = Self.isRemotelyPaused()
-        let effectiveServing = state.serving && !scheduledIdle && !remotelyPaused
+        // While the agent is still downloading/loading a model the PROCESS is
+        // alive (state.serving == true), but it isn't actually serving yet.
+        // The provisioning marker is the truth here — show it instead of
+        // "serving and earning" so the app doesn't claim earnings prematurely.
+        let provision = Self.provisionStatus()
+        let provisioning = provision?.phase == "provisioning"
+        let effectiveServing =
+            state.serving && !scheduledIdle && !remotelyPaused && !provisioning
 
         menu.addItem(.separator())
         // At-a-glance state + the one metric worth a glance. Everything
         // else — identity detail, models, preferences, profile, bug report,
         // sign out, uninstall, version — moved into the "Open cocore…"
         // window so the menu stays short.
-        menu.addItem(disabled(
-            remotelyPaused
-                ? "⏸ Stopped from the console"
-                : (scheduledIdle
-                    ? "✓ Set up — idle until \(PreferencesView.hourLabel(sched.start)) (scheduled)"
-                    : (effectiveServing
-                        ? "✓ You're set up — serving and earning credits"
-                        : "Next: choose “Start serving” below to begin earning"))))
+        let atAGlance: String
+        if remotelyPaused {
+            atAGlance = "⏸ Stopped from the console"
+        } else if provisioning {
+            let bytes = provision?.bytesDownloaded ?? 0
+            atAGlance =
+                bytes > 0
+                ? "⏳ Provisioning… downloading model (\(Self.provisionMB(bytes)))"
+                : "⏳ Provisioning a model… (not earning yet)"
+        } else if provision?.phase == "failed" {
+            atAGlance = "⚠ Provisioning failed — not serving"
+        } else if scheduledIdle {
+            atAGlance = "✓ Set up — idle until \(PreferencesView.hourLabel(sched.start)) (scheduled)"
+        } else if effectiveServing {
+            atAGlance = "✓ You're set up — serving and earning credits"
+        } else {
+            atAGlance = "Next: choose “Start serving” below to begin earning"
+        }
+        menu.addItem(disabled(atAGlance))
         menu.addItem(disabled("Earnings (24h): \(creditsDisplay(state.creditsLast24h))"))
 
         menu.addItem(.separator())
+        if provision?.phase == "failed", let msg = provision?.faultMessage {
+            // Provisioning failed (e.g. a model download that gave up, or a
+            // non-MLX repo). Surface it with the agent's content-safe reason +
+            // a one-click restart, instead of leaving the operator guessing.
+            menu.addItem(disabled("⚠ Couldn't start serving"))
+            menu.addItem(disabled(String(msg.prefix(180))))
+            menu.addItem(action(title: "Restart serving", #selector(restartServing)))
+            menu.addItem(.separator())
+        }
         if badStanding {
             // The advisor stopped routing jobs here. Surface it loudly with
             // a one-click restart, plus the specific reason / remediation the
@@ -725,6 +752,36 @@ final class MenuBarController {
         guard lines.count >= 2 else { return nil }
         let reason = lines[1].trimmingCharacters(in: .whitespacesAndNewlines)
         return reason.isEmpty ? nil : reason
+    }
+
+    /// Provisioning state the agent reports while bringing a model online,
+    /// from `~/.cocore/provision-status.json` (see `write_provision_status`).
+    /// nil when absent — the agent cleared it because it's serving (or the
+    /// machine is stopped). A marker older than 1h is ignored so a crashed
+    /// agent can't pin "Provisioning…" on forever.
+    struct ProvisionStatus {
+        let phase: String  // "provisioning" | "failed"
+        let bytesDownloaded: UInt64
+        let faultMessage: String?
+    }
+    static func provisionStatus() -> ProvisionStatus? {
+        let path = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".cocore/provision-status.json").path
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: path),
+            let mtime = attrs[.modificationDate] as? Date,
+            Date().timeIntervalSince(mtime) < 3600,
+            let data = FileManager.default.contents(atPath: path),
+            let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let phase = obj["phase"] as? String
+        else { return nil }
+        let bytes = (obj["bytesDownloaded"] as? NSNumber)?.uint64Value ?? 0
+        let fault = (obj["fault"] as? [String: Any])?["message"] as? String
+        return ProvisionStatus(phase: phase, bytesDownloaded: bytes, faultMessage: fault)
+    }
+
+    /// Content-safe human download size for the provisioning line.
+    static func provisionMB(_ bytes: UInt64) -> String {
+        String(format: "%.0f MB", Double(bytes) / (1024 * 1024))
     }
 
     /// Map the marker's reason to a one-line, operator-facing remediation.

--- a/provider-shell/Sources/CoCoreShell/StatusView.swift
+++ b/provider-shell/Sources/CoCoreShell/StatusView.swift
@@ -52,6 +52,16 @@ struct StatusRows: View {
         if sched.limited && !sched.within {
             return "Idle until \(PreferencesView.hourLabel(sched.start)) (scheduled)"
         }
+        // The agent is still bringing a model online — the process is up but
+        // it isn't serving yet, so don't claim "Serving".
+        if let p = MenuBarController.provisionStatus() {
+            if p.phase == "provisioning" {
+                return p.bytesDownloaded > 0
+                    ? "Provisioning… (\(MenuBarController.provisionMB(p.bytesDownloaded)) downloaded)"
+                    : "Provisioning…"
+            }
+            if p.phase == "failed" { return "Provisioning failed" }
+        }
         return state.serving ? "Serving" : "Not serving"
     }
 }

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -711,7 +711,64 @@ async fn cmd_serve(advisor_url: &str) -> Result<()> {
         std::env::set_var("COCORE_INFERENCE_MODELS", desired_at_start.join(","));
     }
 
+    // Provisioning observability (#2/#3/#5): tell the tray we're coming up
+    // and stream download progress while `build_engines` (which can spend
+    // many minutes downloading weights) runs. Cleared on success; replaced
+    // with the fault on failure. A background thread polls the HF cache
+    // size so the marker carries live "downloaded N bytes".
+    let provisioning_models: Vec<String> = std::env::var("COCORE_INFERENCE_MODELS")
+        .unwrap_or_default()
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty() && s != "stub")
+        .collect();
+    let monitor_stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let monitor = if provisioning_models.is_empty() {
+        clear_provision_status();
+        None
+    } else {
+        write_provision_status(
+            "provisioning",
+            &provisioning_models,
+            model_download_bytes(&provisioning_models),
+            None,
+        );
+        let models = provisioning_models.clone();
+        let stop = std::sync::Arc::clone(&monitor_stop);
+        Some(std::thread::spawn(move || {
+            while !stop.load(std::sync::atomic::Ordering::Relaxed) {
+                let bytes = model_download_bytes(&models);
+                write_provision_status("provisioning", &models, bytes, None);
+                // ~2s between updates, but wake promptly to stop.
+                for _ in 0..8 {
+                    if stop.load(std::sync::atomic::Ordering::Relaxed) {
+                        break;
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(250));
+                }
+            }
+        }))
+    };
+
     let (engines, engine_fault) = build_engines(profile.ram_gb);
+
+    // Stop the progress monitor and record the outcome for the tray: clear
+    // the marker on success (tray shows normal serving), or write the fault
+    // so the tray can surface "Provisioning failed: …".
+    monitor_stop.store(true, std::sync::atomic::Ordering::Relaxed);
+    if let Some(h) = monitor {
+        let _ = h.join();
+    }
+    match &engine_fault {
+        Some(f) => write_provision_status(
+            "failed",
+            &provisioning_models,
+            model_download_bytes(&provisioning_models),
+            Some(f),
+        ),
+        None => clear_provision_status(),
+    }
+
     // Advertise the LIVE set, not every registered engine: `live_models()`
     // filters to engines whose `ready()` holds, so a child that failed to
     // come up (or has already died by the time we publish) never lands in
@@ -1021,6 +1078,9 @@ async fn cmd_serve(advisor_url: &str) -> Result<()> {
         _ = serve => {}
         _ = wait_for_shutdown_signal() => {
             tracing::info!("graceful shutdown signal received — marking provider offline");
+            // Don't leave a stale "provisioning"/"failed" marker behind for a
+            // machine the owner just stopped.
+            clear_provision_status();
             if provider_rkey.is_some() {
                 // Flip `serving` to false WITHOUT clobbering the owner /
                 // console-authored switches. Our in-memory `provider_record`
@@ -1089,6 +1149,89 @@ async fn wait_for_shutdown_signal() {
     #[cfg(not(unix))]
     {
         let _ = tokio::signal::ctrl_c().await;
+    }
+}
+
+// ── Provisioning status marker (agent → tray) ──────────────────────
+//
+// `~/.cocore/provision-status.json` — written while the agent is
+// bringing a model online (downloading weights + loading) so the
+// menu-bar app can show a real "Provisioning…" state with download
+// progress, and surface a fault if it fails, instead of claiming
+// "Serving" the moment the process is alive. Best-effort + content-free
+// (model ids + byte counts only). The tray polls it like bad-standing-at.
+
+fn provision_status_path() -> Option<std::path::PathBuf> {
+    let home = std::env::var("HOME").ok().filter(|h| !h.is_empty())?;
+    Some(
+        std::path::Path::new(&home)
+            .join(".cocore")
+            .join("provision-status.json"),
+    )
+}
+
+/// Total bytes of the configured models' HuggingFace cache dirs (incl.
+/// in-progress `.incomplete` blobs) — the download-progress signal.
+fn model_download_bytes(models: &[String]) -> u64 {
+    let Ok(home) = std::env::var("HOME") else {
+        return 0;
+    };
+    if home.is_empty() {
+        return 0;
+    }
+    let hub = std::path::Path::new(&home)
+        .join(".cache")
+        .join("huggingface")
+        .join("hub");
+    let mut total = 0u64;
+    for m in models {
+        let dir = hub.join(format!("models--{}", m.replace('/', "--")));
+        total = total.saturating_add(provision_dir_size(&dir));
+    }
+    total
+}
+
+/// Recursively sum regular-file sizes under `dir` (best-effort). Uses
+/// `symlink_metadata` so HF's `snapshots/*` symlinks aren't double-
+/// counted — only the real `blobs/` files (completed + `.incomplete`).
+fn provision_dir_size(dir: &std::path::Path) -> u64 {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    let mut total = 0u64;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        match std::fs::symlink_metadata(&path) {
+            Ok(md) if md.is_dir() => total = total.saturating_add(provision_dir_size(&path)),
+            Ok(md) if md.is_file() => total = total.saturating_add(md.len()),
+            _ => {}
+        }
+    }
+    total
+}
+
+/// Write the provisioning marker. `phase` is "provisioning" or "failed".
+/// Best-effort; content-free (ids + byte counts + an optional fault
+/// code/message, all already public on the provider record).
+fn write_provision_status(phase: &str, models: &[String], bytes: u64, fault: Option<&EngineFault>) {
+    let Some(path) = provision_status_path() else {
+        return;
+    };
+    let body = serde_json::json!({
+        "phase": phase,
+        "models": models,
+        "bytesDownloaded": bytes,
+        "updatedAt": chrono::Utc::now().to_rfc3339(),
+        "fault": fault.map(|f| serde_json::json!({ "code": f.code, "message": f.message })),
+    });
+    let _ = std::fs::write(path, body.to_string());
+}
+
+/// Remove the provisioning marker (engine is up + serving, or the
+/// machine stopped) so the tray falls back to its normal serving state.
+fn clear_provision_status() {
+    if let Some(path) = provision_status_path() {
+        let _ = std::fs::remove_file(path);
     }
 }
 


### PR DESCRIPTION
Closes #2, #3, #5. Also fixes the tray-display half of #4 ("Serving" while provisioning).

The tray only knew **process-alive**, so it said "Serving and earning" the moment the agent started — even mid-20GB-download — and showed nothing on a provisioning failure. The provider record's `provisioning`/`engineFault` never reached the app (the tray doesn't read PDS).

## Agent → tray channel (`~/.cocore/provision-status.json`)
`provider/src/main.rs` now writes a marker while bringing a model online (mirrors the existing `bad-standing-at` pattern):
- `phase`: `provisioning` | `failed`
- `models`, live `bytesDownloaded` — a background thread polls the model's HF cache dir size (incl. `.incomplete` blobs) during `build_engines`
- `fault` (code + message) on failure
- Cleared on successful serve and on graceful shutdown. Content-free + best-effort.

## Tray display
`MenuBarController` + `StatusView` read the marker and show:
- **#5** — "⏳ Provisioning… downloading model (N MB)" instead of "serving and earning"; the Status tab shows "Provisioning…" not "Serving".
- **#2** — live downloaded-MB in that line.
- **#3** — "⚠ Couldn't start serving" + the agent's content-safe reason + a Restart button on failure.

## Verification
`cargo build/clippy(-D warnings)/fmt/test` (81 passed) + `swift build` all clean. The LSUIElement app can't be GUI-tested by CI; needs a click-test on the installed build during a real cold provision + a notarized release to ship.