### PR TITLE
chore(release): bump to 0.9.15

### DIFF
--- a/provider-shell/Sources/CoCoreShell/Resources/Info.plist
+++ b/provider-shell/Sources/CoCoreShell/Resources/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleName</key>
 	<string>cocore</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.14</string>
+	<string>0.9.15</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -22,7 +22,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>914</string>
+	<string>915</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/provider/Cargo.lock
+++ b/provider/Cargo.lock
@@ -277,7 +277,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cocore-provider"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "anyhow",
  "asn1-rs",

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cocore-provider"
-version = "0.9.14"
+version = "0.9.15"
 edition = "2021"
 description = "cocore provider agent: runs hardened compute and publishes signed receipts to AT Protocol."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Version bump for the **v0.9.15** notarized release (already cut + published). Keeps main from lagging the tag. Ships the provisioning-UX overhaul (issues #1–#6 / PRs #7/#8/#9) to installed machines. Release: https://github.com/graze-social/cocore/releases/tag/v0.9.15