### PR TITLE
provider: per-model scheduling + overprovisioning guard (agent side)

### DIFF
--- a/provider/src/advisor.rs
+++ b/provider/src/advisor.rs
@@ -109,6 +109,11 @@ impl AdvisorClient {
         // reload — compared to THIS set (not what loaded) so a model that
         // won't fit RAM doesn't look like a perpetual change.
         desired_at_start: &[String],
+        // Per-model schedules + the full configured set they apply to. The
+        // serve loop watches for a window boundary (a model's active state
+        // flipping) and restarts to reload the new active set.
+        model_schedules: &crate::schedule::ModelSchedules,
+        configured_models: &[String],
     ) -> Result<()> {
         tracing::info!(url = %self.url, "connecting to advisor");
         let (ws, _resp) =
@@ -178,6 +183,9 @@ impl AdvisorClient {
             tracing::info!("owner has this machine stopped; not serving");
             return Ok(());
         }
+        // The per-model active set this serve loaded against. A schedule
+        // window opening/closing changes it; we restart to reload (below).
+        let active_at_start = model_schedules.active_now(configured_models);
         let mut active_reads = FuturesUnordered::new();
         let mut active_poll = tokio::time::interval(std::time::Duration::from_secs(30));
         active_poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -278,6 +286,22 @@ impl AdvisorClient {
                 // `active_reads` (below), never inline, so it can't stall
                 // ping handling.
                 _ = active_poll.tick() => {
+                    // Per-model schedule boundary: if a window opened or closed
+                    // since this serve started, the active set changed — reload
+                    // by restarting (engines are built once per serve). Local +
+                    // cheap, and independent of the PDS read, so it works even
+                    // without a provider_rkey. Skipped entirely when no per-model
+                    // schedules are set (the common case).
+                    if !model_schedules.is_empty() {
+                        let active_now = model_schedules.active_now(configured_models);
+                        if models_changed(&active_now, &active_at_start) {
+                            tracing::info!(
+                                from = ?active_at_start, to = ?active_now,
+                                "a model's schedule window changed the active set; restarting to reload engines"
+                            );
+                            std::process::exit(3);
+                        }
+                    }
                     if active_reads.is_empty() {
                         if let Some(rk) = provider_rkey {
                             active_reads.push(read_provider_control(pds, rk));

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -716,6 +716,17 @@ async fn cmd_serve(advisor_url: &str) -> Result<()> {
         std::env::set_var("COCORE_INFERENCE_MODELS", desired_at_start.join(","));
     }
 
+    // Per-model schedules + the full configured set they apply to. The serve
+    // loop reloads (restarts) when a window boundary flips the active set;
+    // `build_engines` narrows to the currently-active subset on each build.
+    let model_schedules = cocore_provider::schedule::ModelSchedules::from_env();
+    let configured_models: Vec<String> = std::env::var("COCORE_INFERENCE_MODELS")
+        .unwrap_or_default()
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+
     // Provisioning observability (#2/#3/#5): tell the tray we're coming up
     // and stream download progress while `build_engines` (which can spend
     // many minutes downloading weights) runs. Cleared on success; replaced
@@ -989,6 +1000,8 @@ async fn cmd_serve(advisor_url: &str) -> Result<()> {
                             &engines,
                             provider_rkey.as_deref(),
                             &desired_at_start,
+                            &model_schedules,
+                            &configured_models,
                         )
                         .await;
                     let lived = connected_at.elapsed();
@@ -1048,7 +1061,7 @@ async fn cmd_serve(advisor_url: &str) -> Result<()> {
                         );
                         let client = AdvisorClient::new(advisor_url);
                         tokio::select! {
-                            res = client.run(register.clone(), &*signer, &enc, &pds, attestation, &eng, provider_rkey.as_deref(), &desired_at_start) => {
+                            res = client.run(register.clone(), &*signer, &enc, &pds, attestation, &eng, provider_rkey.as_deref(), &desired_at_start, &model_schedules, &configured_models) => {
                                 if let Err(e) = res {
                                     tracing::warn!(error = %e, "advisor run ended; reconnecting within window in 5s");
                                 }
@@ -1323,6 +1336,19 @@ fn build_engines(
         .filter(|s| !s.is_empty())
         .collect();
 
+    // Per-model scheduling: narrow to the models whose time window is open
+    // right now (a model with no per-model window stays on). Applied here —
+    // the single point every build flows through (startup, whole-app window
+    // re-open, health rebuild) — so the loaded set always matches the clock.
+    let schedules = cocore_provider::schedule::ModelSchedules::from_env();
+    let configured: Vec<String> = if schedules.is_empty() {
+        configured
+    } else {
+        let active = schedules.active_now(&configured);
+        tracing::info!(active = ?active, "per-model schedule: loading the models whose window is open now");
+        active
+    };
+
     // RAM-fit guard. Skip catalog models whose conservative `min_ram_gb`
     // floor exceeds this machine's memory before spending a spawn + cold
     // weight download on a load that can only OOM. We judge ONLY models
@@ -1354,6 +1380,26 @@ fn build_engines(
                 !over_floor
             })
             .collect()
+    };
+
+    // Overprovisioning guard. Even when each model individually fits its
+    // floor, the SUM of a concurrent set can exceed RAM — a 7B + 3B on a
+    // 16 GB Mac, or two models a per-model schedule lands in the same hour.
+    // Prune largest-first until the summed floors fit; pruned models are
+    // surfaced like too-large ones. Bypassed by COCORE_IGNORE_RAM_FLOOR.
+    let configured: Vec<String> = if ignore_ram_floor {
+        configured
+    } else {
+        let (kept, over_budget) = cocore_provider::pricing::fit_within_budget(&configured, ram_gb);
+        for m in &over_budget {
+            tracing::warn!(
+                model = %m,
+                ram_gb,
+                "skipping model to stay within the RAM budget — the concurrent set's summed floors exceed this machine's memory (set COCORE_IGNORE_RAM_FLOOR=1 to override)"
+            );
+        }
+        too_large.extend(over_budget);
+        kept
     };
 
     let mut failed: Vec<String> = vec![];

--- a/provider/src/pricing.rs
+++ b/provider/src/pricing.rs
@@ -131,6 +131,68 @@ pub fn pickable_for_machine(ram_gb: u32) -> Vec<&'static ModelRate> {
         .collect()
 }
 
+/// The catalog RAM floor for a model id, or `None` for an off-catalog
+/// (custom MLX) model whose footprint we can't reason about.
+pub fn min_ram_gb(model_id: &str) -> Option<u32> {
+    RATES
+        .iter()
+        .find(|r| r.model_id == model_id)
+        .map(|r| r.min_ram_gb)
+}
+
+/// Overprovisioning guard. Pick the subset of `models` whose summed
+/// catalog RAM floors fit within `ram_gb`, dropping the LARGEST models
+/// first until the rest fit. Returns `(kept, dropped)`, `kept` in the
+/// original order.
+///
+/// Why: the per-model RAM guard only checks each model against its floor
+/// individually, so a 7B (16 GB floor) AND a 3B (8 GB) could both be
+/// configured on a 16 GB Mac and OOM. Per-model scheduling makes this
+/// sharper (overlapping windows load several at once), so we sum the
+/// concurrent set here. Off-catalog models have no known floor — they're
+/// always KEPT and contribute 0 to the budget (we can't reason about
+/// them; let the subprocess arbitrate rather than guess). `stub` is free.
+/// Ties break by model id so the result is deterministic.
+pub fn fit_within_budget(models: &[String], ram_gb: u32) -> (Vec<String>, Vec<String>) {
+    // Largest-known-floor first; unknown/stub (floor 0) sort last and are
+    // never chosen as a prune victim.
+    let mut by_size: Vec<usize> = (0..models.len()).collect();
+    by_size.sort_by(|&a, &b| {
+        let ra = min_ram_gb(&models[a]).unwrap_or(0);
+        let rb = min_ram_gb(&models[b]).unwrap_or(0);
+        rb.cmp(&ra).then_with(|| models[a].cmp(&models[b]))
+    });
+    let mut keep = vec![true; models.len()];
+    loop {
+        let used: u32 = (0..models.len())
+            .filter(|&i| keep[i])
+            .map(|i| min_ram_gb(&models[i]).unwrap_or(0))
+            .sum();
+        if used <= ram_gb {
+            break;
+        }
+        // Drop the largest still-kept model that has a known floor > 0.
+        let victim = by_size
+            .iter()
+            .copied()
+            .find(|&i| keep[i] && min_ram_gb(&models[i]).unwrap_or(0) > 0);
+        match victim {
+            Some(i) => keep[i] = false,
+            None => break, // only unknown/stub left — nothing safe to prune.
+        }
+    }
+    let mut kept = Vec::new();
+    let mut dropped = Vec::new();
+    for (i, m) in models.iter().enumerate() {
+        if keep[i] {
+            kept.push(m.clone());
+        } else {
+            dropped.push(m.clone());
+        }
+    }
+    (kept, dropped)
+}
+
 /// Look up the rate for a model id; falls back to the stub rate so
 /// receipts always carry _some_ price.
 pub fn rate_for(model_id: &str) -> &'static ModelRate {
@@ -361,5 +423,42 @@ mod tests {
         assert_eq!(estimate_tokens(b"abcd"), 1);
         assert_eq!(estimate_tokens(b"abcde"), 2);
         assert_eq!(estimate_tokens(&vec![0u8; 401]), 101);
+    }
+
+    fn sv(v: &[&str]) -> Vec<String> {
+        v.iter().map(|x| x.to_string()).collect()
+    }
+
+    #[test]
+    fn fit_within_budget_prunes_largest_first() {
+        // 7B (16 GB floor) + 3B (8 GB) on a 16 GB Mac → drop the 7B, keep 3B.
+        let models = sv(&[
+            "mlx-community/Qwen2.5-7B-Instruct-4bit",
+            "mlx-community/Qwen2.5-3B-Instruct-4bit",
+        ]);
+        let (kept, dropped) = fit_within_budget(&models, 16);
+        assert_eq!(kept, sv(&["mlx-community/Qwen2.5-3B-Instruct-4bit"]));
+        assert_eq!(dropped, sv(&["mlx-community/Qwen2.5-7B-Instruct-4bit"]));
+    }
+
+    #[test]
+    fn fit_within_budget_keeps_all_when_fitting() {
+        let models = sv(&[
+            "mlx-community/Qwen2.5-3B-Instruct-4bit",
+            "mlx-community/Qwen2.5-0.5B-Instruct-4bit",
+        ]); // 8 + 4 = 12 ≤ 16
+        let (kept, dropped) = fit_within_budget(&models, 16);
+        assert_eq!(kept, models);
+        assert!(dropped.is_empty());
+    }
+
+    #[test]
+    fn fit_within_budget_never_prunes_unknown_or_stub() {
+        // Off-catalog (unknown floor) + stub contribute 0 and are always kept,
+        // even on a tiny RAM budget.
+        let models = sv(&["custom/whatever-4bit", "stub"]);
+        let (kept, dropped) = fit_within_budget(&models, 1);
+        assert_eq!(kept, models);
+        assert!(dropped.is_empty());
     }
 }

--- a/provider/src/schedule.rs
+++ b/provider/src/schedule.rs
@@ -12,6 +12,7 @@
 //! "don't compete with my daytime use" knob, not a billing boundary.
 
 use chrono::{Local, Timelike};
+use std::collections::HashMap;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ServeWindow {
@@ -63,6 +64,67 @@ impl ServeWindow {
     /// outside the window.
     pub fn seconds_until_open(&self) -> u64 {
         seconds_until_hour(self.start)
+    }
+}
+
+/// Per-model serve windows, parsed from `COCORE_MODEL_SCHEDULES` — a JSON
+/// object mapping model id → `{"start": h, "end": h}` (hours 0–23, local
+/// time, end exclusive, wrap supported). A model NOT present is "always
+/// on" (subject only to the whole-agent [`ServeWindow`]). Written by the
+/// menu-bar app's per-model Schedule UI. A malformed/out-of-range entry is
+/// dropped (that model stays always-on) — a bad schedule must never brick
+/// serving.
+#[derive(Clone, Debug, Default)]
+pub struct ModelSchedules {
+    windows: HashMap<String, ServeWindow>,
+}
+
+impl ModelSchedules {
+    pub fn from_env() -> ModelSchedules {
+        match std::env::var("COCORE_MODEL_SCHEDULES") {
+            Ok(raw) => Self::parse(&raw),
+            Err(_) => ModelSchedules::default(),
+        }
+    }
+
+    pub fn parse(raw: &str) -> ModelSchedules {
+        let Ok(obj) = serde_json::from_str::<HashMap<String, serde_json::Value>>(raw) else {
+            return ModelSchedules::default();
+        };
+        let mut windows = HashMap::new();
+        for (model, v) in obj {
+            let start = v.get("start").and_then(serde_json::Value::as_u64);
+            let end = v.get("end").and_then(serde_json::Value::as_u64);
+            if let (Some(s), Some(e)) = (start, end) {
+                if let (Ok(s), Ok(e)) = (u8::try_from(s), u8::try_from(e)) {
+                    if let Some(w) = ServeWindow::new(s, e) {
+                        windows.insert(model, w);
+                    }
+                }
+            }
+        }
+        ModelSchedules { windows }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.windows.is_empty()
+    }
+
+    /// The subset of `models` that should be loaded right now (local time):
+    /// a model with no per-model window is always active; a scheduled one
+    /// is active only while its window is open. Input order preserved.
+    pub fn active_now(&self, models: &[String]) -> Vec<String> {
+        self.active_at(local_hour(), models)
+    }
+
+    /// Active subset at a specific `hour` (0–23). Split out from
+    /// [`active_now`] so it's unit-testable without mocking the clock.
+    pub fn active_at(&self, hour: u8, models: &[String]) -> Vec<String> {
+        models
+            .iter()
+            .filter(|m| self.windows.get(*m).is_none_or(|w| w.contains(hour)))
+            .cloned()
+            .collect()
     }
 }
 
@@ -132,5 +194,27 @@ mod tests {
         assert_eq!(parse_hour("24"), None);
         assert_eq!(parse_hour(""), None);
         assert_eq!(parse_hour("x"), None);
+    }
+
+    fn s(v: &[&str]) -> Vec<String> {
+        v.iter().map(|x| x.to_string()).collect()
+    }
+
+    #[test]
+    fn model_schedules_active_by_hour() {
+        let sched = ModelSchedules::parse(r#"{"A":{"start":9,"end":17},"B":{"start":22,"end":8}}"#);
+        let models = s(&["A", "B", "C"]); // C has no schedule → always on
+        assert_eq!(sched.active_at(12, &models), s(&["A", "C"])); // A daytime open, B closed
+        assert_eq!(sched.active_at(23, &models), s(&["B", "C"])); // B overnight open, A closed
+        assert_eq!(sched.active_at(8, &models), s(&["C"])); // both closed (8 is exclusive end of B, before A)
+    }
+
+    #[test]
+    fn model_schedules_malformed_keeps_models_always_on() {
+        assert!(ModelSchedules::parse("not json").is_empty());
+        // out-of-range start + empty window → both dropped, models stay always-on.
+        let sched = ModelSchedules::parse(r#"{"A":{"start":25,"end":2},"B":{"start":5,"end":5}}"#);
+        assert!(sched.is_empty());
+        assert_eq!(sched.active_at(3, &s(&["A", "B"])), s(&["A", "B"]));
     }
 }


### PR DESCRIPTION
The agent half of **per-model scheduling** (users asked to schedule individual models, not just the whole app). The tray UI that writes the config is a follow-up PR; this PR is the engine + the "don't overprovision" logic.

## What
- **`schedule.rs` → `ModelSchedules`**: parsed from `COCORE_MODEL_SCHEDULES`, a JSON map `{"model-id": {"start": 9, "end": 17}, …}` (hours 0–23, local time, end-exclusive, midnight-wrap supported — reuses the existing `ServeWindow`). A model with **no** window is always-on; a malformed/out-of-range entry is dropped (stays always-on) so a bad schedule can't brick serving. `active_now()` returns the subset whose window is open right now.
- **`build_engines` narrows to the active subset** on every build — startup, whole-app window re-open, and health rebuild all flow through it — so the loaded set always tracks the clock.
- **Boundary reload**: a 30s check in the serve loop restarts (`exit(3)`, the same reload path as an owner model edit) when a window opens/closes and flips the active set. Skipped entirely when no schedules are set.
- **Overprovisioning guard (`pricing::fit_within_budget`)**: prunes largest-first until the concurrent set's summed RAM floors fit the machine. This fixes a pre-existing hole — two models that each fit their floor (7B + 3B on 16 GB, or two scheduled into the same hour) would OOM. Off-catalog/`stub` models have unknown footprints and are never pruned.

## Design notes
- Schedules are **local agent config** (env var), matching how the whole-app serve window already works — **no lexicon change**.
- Reload is a **full restart** (reusing the hardened `exit(3)` path), not an in-process swap — deliberately low-risk; I did not rewrite the serve loop.

## Verification
`cargo build --locked`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`, and `cargo test --lib` (86 passed, 5 new) all clean. The schedule parsing, active-set-by-hour, and the prune are unit-tested; the boundary-reload path needs a live agent to exercise end-to-end.