### PR TITLE
chore(release): bump to 0.9.16

### DIFF
--- a/provider-shell/Sources/CoCoreShell/Resources/Info.plist
+++ b/provider-shell/Sources/CoCoreShell/Resources/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleName</key>
 	<string>cocore</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.15</string>
+	<string>0.9.16</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -22,7 +22,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>915</string>
+	<string>916</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/provider/Cargo.lock
+++ b/provider/Cargo.lock
@@ -277,7 +277,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cocore-provider"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "asn1-rs",

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cocore-provider"
-version = "0.9.15"
+version = "0.9.16"
 edition = "2021"
 description = "cocore provider agent: runs hardened compute and publishes signed receipts to AT Protocol."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Ships per-model scheduling (PRs #11/#12) to installed machines:
- each model can have its own serve hours (COCORE_MODEL_SCHEDULES); the agent loads only the models whose window is open now and reloads at boundaries
- overprovisioning guard: the agent prunes the concurrent set to fit RAM (fixing the old two-models-that-don't-fit-together OOM hole) and the tray warns which hour exceeds memory

Version bumped in all three places (Cargo.toml, Cargo.lock, Info.plist Short+Bundle 0.9.16/916).