### PR TITLE
tray: stop the provisioning-failure reason from ballooning the menu

### DIFF
--- a/provider-shell/Sources/CoCoreShell/MenuBarController.swift
+++ b/provider-shell/Sources/CoCoreShell/MenuBarController.swift
@@ -167,13 +167,15 @@ final class MenuBarController {
         menu.addItem(disabled("Earnings (24h): \(creditsDisplay(state.creditsLast24h))"))
 
         menu.addItem(.separator())
-        if provision?.phase == "failed", let msg = provision?.faultMessage {
-            // Provisioning failed (e.g. a model download that gave up, or a
-            // non-MLX repo). Surface it with the agent's content-safe reason +
-            // a one-click restart, instead of leaving the operator guessing.
-            menu.addItem(disabled("⚠ Couldn't start serving"))
-            menu.addItem(disabled(String(msg.prefix(180))))
+        if provision?.phase == "failed" {
+            // Provisioning failed (a model that gave up downloading, didn't
+            // fit RAM, or isn't MLX). The at-a-glance line above already flags
+            // it; offer a one-click restart and point at the window for the
+            // full reason. We deliberately DON'T put the fault message here —
+            // NSMenu items don't wrap, so a long reason balloons the whole
+            // menu. The wrapped detail lives in Open cocore… → Status.
             menu.addItem(action(title: "Restart serving", #selector(restartServing)))
+            menu.addItem(disabled("Open cocore… → Status for the reason"))
             menu.addItem(.separator())
         }
         if badStanding {

--- a/provider-shell/Sources/CoCoreShell/StatusView.swift
+++ b/provider-shell/Sources/CoCoreShell/StatusView.swift
@@ -25,6 +25,16 @@ struct StatusRows: View {
         }
         Section("Serving") {
             LabeledContent("State", value: servingText)
+            // The full provisioning-failure reason lives here (not the menu,
+            // where a long single line can't wrap and balloons the window).
+            if let p = MenuBarController.provisionStatus(), p.phase == "failed",
+                let msg = p.faultMessage
+            {
+                Text(msg)
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
             LabeledContent("Trust level", value: state.trustLevel.rawValue)
             if let exp = state.attestationExpiresAt {
                 LabeledContent("Attestation expires", value: exp.formatted(.dateTime))


### PR DESCRIPTION
The full `engineFault` message added to the menu in #9 made the menu-bar window **insanely wide** — NSMenu items don't wrap, so a 180-char "needs more RAM than this machine's 8GB…" line stretched the whole menu.

**Fix:** keep the menu terse (the existing "⚠ Provisioning failed — not serving" at-a-glance line + a **Restart serving** action + an "Open cocore… → Status for the reason" pointer), and move the full reason into the window's **Status** section as a wrapping SwiftUI `Text`.

`swift build` clean.