### PR TITLE
feat(account): API key lifecycle over XRPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,10 @@ docs/                  install, deploy, and the ADRs behind the big decisions
 Lexicon NSIDs live under `dev.cocore.*`: `compute.{provider,job,attestation,
 receipt,settlement}` for the work itself, `compute.exchangePolicy` for the
 published rules, and `account.{tokenGrant,tokenPatronage}` for the auditable
-co-op trail. Lexicons only ever change **additively** — existing fields never
-change meaning; new behavior is a new optional field or a new NSID.
+co-op trail. The `account.{create,list,revoke,delete}ApiKey` methods expose
+API-key lifecycle over XRPC so you can automate access ([`docs/api-keys.md`](docs/api-keys.md)).
+Lexicons only ever change **additively** — existing fields never change
+meaning; new behavior is a new optional field or a new NSID.
 
 ## Hack on it
 

--- a/docs/api-keys.md
+++ b/docs/api-keys.md
@@ -1,0 +1,148 @@
+# API keys
+
+cocore API keys are bearer tokens that let scripts, agents, and other
+automation act for your account without driving a browser session. The same
+key authenticates inference (`dev.cocore.inference.*`), the record proxy
+(`dev.cocore.proxy.*`), and the key-management endpoints documented here.
+
+A key looks like `cocore-<43 url-safe base64 chars>` — 256 bits of entropy.
+The server stores only a SHA-256 hash plus a short displayable `prefix`
+(e.g. `cocore-AbCd1234`); the full secret is shown **exactly once**, at
+creation, and is unrecoverable afterward.
+
+These endpoints are served by the console at
+`https://console.cocore.dev/api/xrpc/<nsid>` and are defined by lexicons
+under `dev.cocore.account.*` (published as resolvable
+`com.atproto.lexicon.schema` records, see [`lexicons/README.md`](../lexicons/README.md)).
+
+## Authentication
+
+Every key-management endpoint accepts either credential:
+
+- **`Authorization: Bearer cocore-...`** — an existing API key. This is the
+  automation path: mint one key from the console UI, then create, list,
+  revoke, and delete the rest headlessly.
+- **Console session cookie** — what the signed-in web UI sends.
+
+The owning DID is derived from whichever credential you present, and every
+operation is scoped to that DID — you can only ever touch your own keys. A
+missing or invalid credential returns `401` with `{ "error": "AuthRequired" }`.
+
+> **Bootstrapping.** Creating your *first* key needs a credential you didn't
+> mint via the API: sign in to the console and create one key under
+> **Account → API keys**, or let `cocore agent pair` mint one for a machine.
+> After that, that key can create every subsequent key over the API.
+
+## Endpoints
+
+Base URL: `https://console.cocore.dev/api/xrpc`
+
+### `dev.cocore.account.createApiKey` — mint a key
+
+`POST`. Body `{ name: string, expiresAt?: string | null }`. Returns the new
+key's metadata plus the one-time `secret`.
+
+```sh
+curl -sS -X POST \
+  'https://console.cocore.dev/api/xrpc/dev.cocore.account.createApiKey' \
+  -H 'Authorization: Bearer cocore-YOUR-EXISTING-KEY' \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"ci-runner","expiresAt":"2027-01-01T00:00:00Z"}'
+```
+
+```json
+{
+  "key": {
+    "id": "9b1c…",
+    "did": "did:plc:…",
+    "name": "ci-runner",
+    "prefix": "cocore-AbCd1234",
+    "createdAt": "2026-06-19T12:00:00.000Z",
+    "expiresAt": "2027-01-01T00:00:00.000Z"
+  },
+  "secret": "cocore-AbCd1234…the-full-43-char-secret"
+}
+```
+
+Store `secret` now; it is never returned again. Omit `expiresAt` (or send
+`null`) for a key that never expires on its own.
+
+### `dev.cocore.account.listApiKeys` — list your keys
+
+`GET`. No parameters — the account is taken from your credential. Returns
+every key, newest first. Secrets are never included.
+
+```sh
+curl -sS \
+  'https://console.cocore.dev/api/xrpc/dev.cocore.account.listApiKeys' \
+  -H 'Authorization: Bearer cocore-YOUR-KEY'
+```
+
+```json
+{
+  "keys": [
+    {
+      "id": "9b1c…",
+      "did": "did:plc:…",
+      "name": "ci-runner",
+      "prefix": "cocore-AbCd1234",
+      "createdAt": "2026-06-19T12:00:00.000Z",
+      "lastUsedAt": "2026-06-19T12:05:00.000Z"
+    }
+  ]
+}
+```
+
+A revoked key stays in the list with `revokedAt` set, until it's deleted.
+
+### `dev.cocore.account.revokeApiKey` — revoke a key
+
+`POST`. Body `{ id: string }` (the `id` from create/list). The key stops
+authenticating immediately; the row is retained with `revokedAt` set so it
+remains visible for audit. Idempotent — revoking an unknown or
+already-revoked key returns `{ "revoked": false }`.
+
+```sh
+curl -sS -X POST \
+  'https://console.cocore.dev/api/xrpc/dev.cocore.account.revokeApiKey' \
+  -H 'Authorization: Bearer cocore-YOUR-KEY' \
+  -H 'Content-Type: application/json' \
+  -d '{"id":"9b1c…"}'
+```
+
+```json
+{ "revoked": true }
+```
+
+### `dev.cocore.account.deleteApiKey` — delete a key
+
+`POST`. Body `{ id: string }`. Hard-deletes the row (no audit-trail recovery).
+Prefer `revokeApiKey` for most flows; use this to clean up revoked or expired
+keys you no longer want listed. Idempotent — deleting an unknown key returns
+`{ "deleted": false }`.
+
+```sh
+curl -sS -X POST \
+  'https://console.cocore.dev/api/xrpc/dev.cocore.account.deleteApiKey' \
+  -H 'Authorization: Bearer cocore-YOUR-KEY' \
+  -H 'Content-Type: application/json' \
+  -d '{"id":"9b1c…"}'
+```
+
+```json
+{ "deleted": true }
+```
+
+## Errors
+
+| Status | Body                              | Meaning                                            |
+| ------ | --------------------------------- | -------------------------------------------------- |
+| `401`  | `{ "error": "AuthRequired" }`     | No valid session cookie or bearer key presented.   |
+| `400`  | `{ "error": "InvalidRequest" }`   | Malformed JSON, or a field failed validation.      |
+
+## A note on scope
+
+A bearer key can mint and delete other keys for the same account, so treat
+it like a password. Revoke any key you suspect is leaked — that severs every
+capability it carried (inference, the proxy, and key management alike) in one
+step, while leaving a `revokedAt` audit marker behind.

--- a/lexicons/README.md
+++ b/lexicons/README.md
@@ -20,6 +20,28 @@ work.
 | `dev.cocore.compute.receipt`                    | provider    | Signed proof a job was completed; strong-refs job + attestation. |
 | `dev.cocore.compute.settlement`                 | exchange    | Signed proof of payment; strong-refs receipt + authorization. |
 
+## Namespace: `dev.cocore.account`
+
+Records and methods scoped to a cocore account rather than a unit of work.
+
+| NSID                                | Type      | Purpose                                                              |
+| ----------------------------------- | --------- | -------------------------------------------------------------------- |
+| `dev.cocore.account.defs`           | defs      | Shared object definitions for account methods (e.g. `apiKeyView`).   |
+| `dev.cocore.account.profile`        | record    | A user's cocore-side profile.                                        |
+| `dev.cocore.account.friend`         | record    | A directed trust edge between two accounts.                          |
+| `dev.cocore.account.tokenGrant`     | record    | An auditable co-op token grant.                                      |
+| `dev.cocore.account.tokenPatronage` | record    | An auditable co-op patronage record.                                 |
+| `dev.cocore.account.createApiKey`   | procedure | Mint a new API key; returns the secret exactly once.                 |
+| `dev.cocore.account.listApiKeys`    | query     | List the authenticated account's API keys (no secrets).             |
+| `dev.cocore.account.revokeApiKey`   | procedure | Revoke a key (soft; keeps the row for audit).                        |
+| `dev.cocore.account.deleteApiKey`   | procedure | Hard-delete a key row.                                               |
+
+The API-key methods are served by the console at
+`/api/xrpc/<nsid>` and authenticate with either a console session or an
+existing `Authorization: Bearer cocore-...` key. See
+[`docs/api-keys.md`](../docs/api-keys.md) for the full guide and curl
+examples.
+
 ## Verification chain
 
 A complete unit of work, fully verified by an outside party with no API

--- a/lexicons/dev/cocore/account/createApiKey.json
+++ b/lexicons/dev/cocore/account/createApiKey.json
@@ -1,0 +1,50 @@
+{
+  "lexicon": 1,
+  "id": "dev.cocore.account.createApiKey",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Mint a new cocore API key for the authenticated account. Authenticate with either a console session cookie or an existing `Authorization: Bearer cocore-...` key. The full secret is returned exactly once in `secret` and is never retrievable again — only its SHA-256 hash is stored. Use the returned key to authenticate subsequent automated requests (inference, the record proxy, and these key-management methods themselves).",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 100,
+              "description": "Human-readable label so the owner can tell their keys apart."
+            },
+            "expiresAt": {
+              "type": "string",
+              "format": "datetime",
+              "description": "Optional RFC3339 expiry. Omit (or send null) for a key that never expires on its own."
+            }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["key", "secret"],
+          "properties": {
+            "key": {
+              "type": "ref",
+              "ref": "dev.cocore.account.defs#apiKeyView"
+            },
+            "secret": {
+              "type": "string",
+              "description": "The full plaintext key (`cocore-<43 url-safe base64 chars>`). Shown exactly once; store it now."
+            }
+          }
+        }
+      },
+      "errors": [
+        { "name": "AuthRequired", "description": "No valid session cookie or bearer key was presented." }
+      ]
+    }
+  }
+}

--- a/lexicons/dev/cocore/account/defs.json
+++ b/lexicons/dev/cocore/account/defs.json
@@ -1,0 +1,52 @@
+{
+  "lexicon": 1,
+  "id": "dev.cocore.account.defs",
+  "description": "Shared type definitions for dev.cocore.account.* methods.",
+  "defs": {
+    "apiKeyView": {
+      "type": "object",
+      "description": "Public metadata for a single API key. Never contains the secret — the full key is returned exactly once, by createApiKey, and is unrecoverable afterwards. The server persists only a SHA-256 hash of the secret plus the displayable `prefix`.",
+      "required": ["id", "did", "name", "prefix", "createdAt"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Stable identifier for this key. Pass it to revokeApiKey / deleteApiKey."
+        },
+        "did": {
+          "type": "string",
+          "format": "did",
+          "description": "DID of the account that owns this key."
+        },
+        "name": {
+          "type": "string",
+          "maxLength": 100,
+          "description": "Human-readable label set at creation time."
+        },
+        "prefix": {
+          "type": "string",
+          "description": "First characters of the key (e.g. `cocore-AbCd1234`), stored in plaintext so a key can be recognised in a list without revealing the secret."
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "When the key was minted."
+        },
+        "expiresAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Optional expiry. Absent means the key never expires on its own."
+        },
+        "revokedAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Set when the key was revoked. A revoked key no longer authenticates but the row survives for audit until deleteApiKey removes it."
+        },
+        "lastUsedAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Last time the key successfully authenticated a request. Absent if never used."
+        }
+      }
+    }
+  }
+}

--- a/lexicons/dev/cocore/account/deleteApiKey.json
+++ b/lexicons/dev/cocore/account/deleteApiKey.json
@@ -1,0 +1,41 @@
+{
+  "lexicon": 1,
+  "id": "dev.cocore.account.deleteApiKey",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Hard-delete one of the authenticated account's API keys, removing the row entirely (no audit trail recovery afterwards). For most flows revokeApiKey is preferable; use this to clean up revoked or expired keys you no longer want listed. Scoped to the caller's DID. Idempotent: deleting an unknown key returns `deleted: false`.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 200,
+              "description": "The `id` of the key to delete (from createApiKey or listApiKeys)."
+            }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["deleted"],
+          "properties": {
+            "deleted": {
+              "type": "boolean",
+              "description": "True if a key owned by the caller was deleted by this call; false if no matching key existed."
+            }
+          }
+        }
+      },
+      "errors": [
+        { "name": "AuthRequired", "description": "No valid session cookie or bearer key was presented." }
+      ]
+    }
+  }
+}

--- a/lexicons/dev/cocore/account/listApiKeys.json
+++ b/lexicons/dev/cocore/account/listApiKeys.json
@@ -1,0 +1,29 @@
+{
+  "lexicon": 1,
+  "id": "dev.cocore.account.listApiKeys",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "List every API key belonging to the authenticated account, most-recently-created first. The owning DID is derived from the credential presented (session cookie or `Authorization: Bearer cocore-...`); there is no way to list another account's keys. Secrets are never returned — see `apiKeyView`.",
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["keys"],
+          "properties": {
+            "keys": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "dev.cocore.account.defs#apiKeyView"
+              }
+            }
+          }
+        }
+      },
+      "errors": [
+        { "name": "AuthRequired", "description": "No valid session cookie or bearer key was presented." }
+      ]
+    }
+  }
+}

--- a/lexicons/dev/cocore/account/revokeApiKey.json
+++ b/lexicons/dev/cocore/account/revokeApiKey.json
@@ -1,0 +1,41 @@
+{
+  "lexicon": 1,
+  "id": "dev.cocore.account.revokeApiKey",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Revoke one of the authenticated account's API keys. The key stops authenticating immediately, but the row is retained with `revokedAt` set so it stays visible in listApiKeys as a revoked key (audit trail). Use deleteApiKey to remove it entirely. Scoped to the caller's DID — you cannot revoke another account's key. Idempotent: revoking an already-revoked or unknown key returns `revoked: false`.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 200,
+              "description": "The `id` of the key to revoke (from createApiKey or listApiKeys)."
+            }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["revoked"],
+          "properties": {
+            "revoked": {
+              "type": "boolean",
+              "description": "True if a live key owned by the caller was revoked by this call; false if no matching unrevoked key existed."
+            }
+          }
+        }
+      },
+      "errors": [
+        { "name": "AuthRequired", "description": "No valid session cookie or bearer key was presented." }
+      ]
+    }
+  }
+}

--- a/packages/console/src/lib/xrpc-key-auth.server.ts
+++ b/packages/console/src/lib/xrpc-key-auth.server.ts
@@ -1,0 +1,78 @@
+// Shared request authentication for the dev.cocore.account.* API-key
+// management XRPC endpoints.
+//
+// These endpoints are reachable two ways, so that they work both from
+// the signed-in console UI and from automation:
+//
+//   1. Console session cookie — what the browser sends. Lets the
+//      account page drive the same surface a script would.
+//   2. `Authorization: Bearer cocore-...` — an existing API key. This
+//      is the automation path: mint one key from the console once,
+//      then create/list/revoke/delete the rest headlessly.
+//
+// Both resolve to the owning DID; everything downstream is scoped to
+// that DID so a caller can only ever touch their own keys.
+
+import { type ApiKeyRow, resolveBearerKey } from "@/lib/api-keys.server.ts";
+import { getAtprotoSessionForRequest } from "@/middleware/auth.server.ts";
+
+export interface XrpcCaller {
+  did: string;
+  /** How the caller authenticated — useful for diagnostics. */
+  via: "bearer" | "session";
+}
+
+function readBearer(request: Request): string | null {
+  const h = request.headers.get("authorization");
+  if (!h) return null;
+  const m = /^Bearer\s+(.+)$/i.exec(h);
+  return m ? m[1]!.trim() : null;
+}
+
+/** Resolve the calling account's DID from a bearer API key (preferred,
+ *  cheap) or, failing that, a console session cookie. Returns null when
+ *  neither credential is present or valid; the caller should respond 401. */
+export async function resolveXrpcCaller(request: Request): Promise<XrpcCaller | null> {
+  const bearer = readBearer(request);
+  if (bearer) {
+    const resolved = resolveBearerKey(bearer);
+    if (resolved) return { did: resolved.did, via: "bearer" };
+    // A presented-but-invalid bearer token is an explicit 401, not a
+    // silent fall-through to cookie auth.
+    return null;
+  }
+
+  const session = await getAtprotoSessionForRequest(request);
+  if (session) return { did: session.did, via: "session" };
+
+  return null;
+}
+
+/** Shape an internal {@link ApiKeyRow} into the wire form described by
+ *  `dev.cocore.account.defs#apiKeyView`: never includes the secret, and
+ *  drops null optional fields so the JSON matches the lexicon (absent,
+ *  not null). */
+export function apiKeyView(row: ApiKeyRow): Record<string, unknown> {
+  const view: Record<string, unknown> = {
+    id: row.id,
+    did: row.did,
+    name: row.name,
+    prefix: row.prefix,
+    createdAt: row.createdAt,
+  };
+  if (row.expiresAt) view.expiresAt = row.expiresAt;
+  if (row.revokedAt) view.revokedAt = row.revokedAt;
+  if (row.lastUsedAt) view.lastUsedAt = row.lastUsedAt;
+  return view;
+}
+
+export function xrpcJson(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+export function xrpcError(status: number, error: string, message?: string): Response {
+  return xrpcJson(message ? { error, message } : { error }, status);
+}

--- a/packages/console/src/lib/xrpc-key-auth.test.ts
+++ b/packages/console/src/lib/xrpc-key-auth.test.ts
@@ -1,0 +1,48 @@
+import { test } from "vitest";
+import assert from "node:assert/strict";
+
+import type { ApiKeyRow } from "./api-keys.server.ts";
+
+import { apiKeyView, resolveXrpcCaller } from "./xrpc-key-auth.server.ts";
+
+const baseRow: ApiKeyRow = {
+  id: "key-1",
+  did: "did:plc:alice",
+  name: "laptop",
+  prefix: "cocore-AbCd1234",
+  createdAt: "2026-06-19T00:00:00.000Z",
+  expiresAt: null,
+  revokedAt: null,
+  lastUsedAt: null,
+};
+
+test("apiKeyView exposes required fields and never the secret/hash", () => {
+  const view = apiKeyView(baseRow);
+  assert.deepEqual(view, {
+    id: "key-1",
+    did: "did:plc:alice",
+    name: "laptop",
+    prefix: "cocore-AbCd1234",
+    createdAt: "2026-06-19T00:00:00.000Z",
+  });
+  // No secret-bearing fields ever leak onto the wire.
+  assert.equal("hash" in view, false);
+  assert.equal("secret" in view, false);
+});
+
+test("apiKeyView omits null optionals but includes present ones", () => {
+  const view = apiKeyView({
+    ...baseRow,
+    expiresAt: "2027-01-01T00:00:00.000Z",
+    revokedAt: "2026-07-01T00:00:00.000Z",
+    lastUsedAt: "2026-06-20T00:00:00.000Z",
+  });
+  assert.equal(view.expiresAt, "2027-01-01T00:00:00.000Z");
+  assert.equal(view.revokedAt, "2026-07-01T00:00:00.000Z");
+  assert.equal(view.lastUsedAt, "2026-06-20T00:00:00.000Z");
+});
+
+test("resolveXrpcCaller returns null when no credential is presented", async () => {
+  const req = new Request("https://console.cocore.dev/api/xrpc/dev.cocore.account.listApiKeys");
+  assert.equal(await resolveXrpcCaller(req), null);
+});

--- a/packages/console/src/routeTree.gen.ts
+++ b/packages/console/src/routeTree.gen.ts
@@ -51,6 +51,10 @@ import { Route as ApiXrpcDevDotcocoreDotinferenceDotdispatchRouteImport } from '
 import { Route as ApiXrpcDevDotcocoreDotdevicePairDotstartRouteImport } from './routes/api/xrpc/dev[.]cocore[.]devicePair[.]start'
 import { Route as ApiXrpcDevDotcocoreDotdevicePairDotpollRouteImport } from './routes/api/xrpc/dev[.]cocore[.]devicePair[.]poll'
 import { Route as ApiXrpcDevDotcocoreDotdevicePairDotconfirmRouteImport } from './routes/api/xrpc/dev[.]cocore[.]devicePair[.]confirm'
+import { Route as ApiXrpcDevDotcocoreDotaccountDotrevokeApiKeyRouteImport } from './routes/api/xrpc/dev[.]cocore[.]account[.]revokeApiKey'
+import { Route as ApiXrpcDevDotcocoreDotaccountDotlistApiKeysRouteImport } from './routes/api/xrpc/dev[.]cocore[.]account[.]listApiKeys'
+import { Route as ApiXrpcDevDotcocoreDotaccountDotdeleteApiKeyRouteImport } from './routes/api/xrpc/dev[.]cocore[.]account[.]deleteApiKey'
+import { Route as ApiXrpcDevDotcocoreDotaccountDotcreateApiKeyRouteImport } from './routes/api/xrpc/dev[.]cocore[.]account[.]createApiKey'
 import { Route as ApiV1ModelsRouteImport } from './routes/api/v1/models'
 import { Route as ApiInternalWipeEverythingRouteImport } from './routes/api/internal/wipe-everything'
 import { Route as ApiInternalWipeRouteImport } from './routes/api/internal/wipe'
@@ -298,6 +302,30 @@ const ApiXrpcDevDotcocoreDotdevicePairDotconfirmRoute =
     path: '/api/xrpc/dev.cocore.devicePair.confirm',
     getParentRoute: () => rootRouteImport,
   } as any)
+const ApiXrpcDevDotcocoreDotaccountDotrevokeApiKeyRoute =
+  ApiXrpcDevDotcocoreDotaccountDotrevokeApiKeyRouteImport.update({
+    id: '/api/xrpc/dev.cocore.account.revokeApiKey',
+    path: '/api/xrpc/dev.cocore.account.revokeApiKey',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiXrpcDevDotcocoreDotaccountDotlistApiKeysRoute =
+  ApiXrpcDevDotcocoreDotaccountDotlistApiKeysRouteImport.update({
+    id: '/api/xrpc/dev.cocore.account.listApiKeys',
+    path: '/api/xrpc/dev.cocore.account.listApiKeys',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiXrpcDevDotcocoreDotaccountDotdeleteApiKeyRoute =
+  ApiXrpcDevDotcocoreDotaccountDotdeleteApiKeyRouteImport.update({
+    id: '/api/xrpc/dev.cocore.account.deleteApiKey',
+    path: '/api/xrpc/dev.cocore.account.deleteApiKey',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiXrpcDevDotcocoreDotaccountDotcreateApiKeyRoute =
+  ApiXrpcDevDotcocoreDotaccountDotcreateApiKeyRouteImport.update({
+    id: '/api/xrpc/dev.cocore.account.createApiKey',
+    path: '/api/xrpc/dev.cocore.account.createApiKey',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiV1ModelsRoute = ApiV1ModelsRouteImport.update({
   id: '/api/v1/models',
   path: '/api/v1/models',
@@ -490,6 +518,10 @@ export interface FileRoutesByFullPath {
   '/api/internal/wipe': typeof ApiInternalWipeRoute
   '/api/internal/wipe-everything': typeof ApiInternalWipeEverythingRoute
   '/api/v1/models': typeof ApiV1ModelsRoute
+  '/api/xrpc/dev.cocore.account.createApiKey': typeof ApiXrpcDevDotcocoreDotaccountDotcreateApiKeyRoute
+  '/api/xrpc/dev.cocore.account.deleteApiKey': typeof ApiXrpcDevDotcocoreDotaccountDotdeleteApiKeyRoute
+  '/api/xrpc/dev.cocore.account.listApiKeys': typeof ApiXrpcDevDotcocoreDotaccountDotlistApiKeysRoute
+  '/api/xrpc/dev.cocore.account.revokeApiKey': typeof ApiXrpcDevDotcocoreDotaccountDotrevokeApiKeyRoute
   '/api/xrpc/dev.cocore.devicePair.confirm': typeof ApiXrpcDevDotcocoreDotdevicePairDotconfirmRoute
   '/api/xrpc/dev.cocore.devicePair.poll': typeof ApiXrpcDevDotcocoreDotdevicePairDotpollRoute
   '/api/xrpc/dev.cocore.devicePair.start': typeof ApiXrpcDevDotcocoreDotdevicePairDotstartRoute
@@ -558,6 +590,10 @@ export interface FileRoutesByTo {
   '/api/internal/wipe': typeof ApiInternalWipeRoute
   '/api/internal/wipe-everything': typeof ApiInternalWipeEverythingRoute
   '/api/v1/models': typeof ApiV1ModelsRoute
+  '/api/xrpc/dev.cocore.account.createApiKey': typeof ApiXrpcDevDotcocoreDotaccountDotcreateApiKeyRoute
+  '/api/xrpc/dev.cocore.account.deleteApiKey': typeof ApiXrpcDevDotcocoreDotaccountDotdeleteApiKeyRoute
+  '/api/xrpc/dev.cocore.account.listApiKeys': typeof ApiXrpcDevDotcocoreDotaccountDotlistApiKeysRoute
+  '/api/xrpc/dev.cocore.account.revokeApiKey': typeof ApiXrpcDevDotcocoreDotaccountDotrevokeApiKeyRoute
   '/api/xrpc/dev.cocore.devicePair.confirm': typeof ApiXrpcDevDotcocoreDotdevicePairDotconfirmRoute
   '/api/xrpc/dev.cocore.devicePair.poll': typeof ApiXrpcDevDotcocoreDotdevicePairDotpollRoute
   '/api/xrpc/dev.cocore.devicePair.start': typeof ApiXrpcDevDotcocoreDotdevicePairDotstartRoute
@@ -630,6 +666,10 @@ export interface FileRoutesById {
   '/api/internal/wipe': typeof ApiInternalWipeRoute
   '/api/internal/wipe-everything': typeof ApiInternalWipeEverythingRoute
   '/api/v1/models': typeof ApiV1ModelsRoute
+  '/api/xrpc/dev.cocore.account.createApiKey': typeof ApiXrpcDevDotcocoreDotaccountDotcreateApiKeyRoute
+  '/api/xrpc/dev.cocore.account.deleteApiKey': typeof ApiXrpcDevDotcocoreDotaccountDotdeleteApiKeyRoute
+  '/api/xrpc/dev.cocore.account.listApiKeys': typeof ApiXrpcDevDotcocoreDotaccountDotlistApiKeysRoute
+  '/api/xrpc/dev.cocore.account.revokeApiKey': typeof ApiXrpcDevDotcocoreDotaccountDotrevokeApiKeyRoute
   '/api/xrpc/dev.cocore.devicePair.confirm': typeof ApiXrpcDevDotcocoreDotdevicePairDotconfirmRoute
   '/api/xrpc/dev.cocore.devicePair.poll': typeof ApiXrpcDevDotcocoreDotdevicePairDotpollRoute
   '/api/xrpc/dev.cocore.devicePair.start': typeof ApiXrpcDevDotcocoreDotdevicePairDotstartRoute
@@ -701,6 +741,10 @@ export interface FileRouteTypes {
     | '/api/internal/wipe'
     | '/api/internal/wipe-everything'
     | '/api/v1/models'
+    | '/api/xrpc/dev.cocore.account.createApiKey'
+    | '/api/xrpc/dev.cocore.account.deleteApiKey'
+    | '/api/xrpc/dev.cocore.account.listApiKeys'
+    | '/api/xrpc/dev.cocore.account.revokeApiKey'
     | '/api/xrpc/dev.cocore.devicePair.confirm'
     | '/api/xrpc/dev.cocore.devicePair.poll'
     | '/api/xrpc/dev.cocore.devicePair.start'
@@ -769,6 +813,10 @@ export interface FileRouteTypes {
     | '/api/internal/wipe'
     | '/api/internal/wipe-everything'
     | '/api/v1/models'
+    | '/api/xrpc/dev.cocore.account.createApiKey'
+    | '/api/xrpc/dev.cocore.account.deleteApiKey'
+    | '/api/xrpc/dev.cocore.account.listApiKeys'
+    | '/api/xrpc/dev.cocore.account.revokeApiKey'
     | '/api/xrpc/dev.cocore.devicePair.confirm'
     | '/api/xrpc/dev.cocore.devicePair.poll'
     | '/api/xrpc/dev.cocore.devicePair.start'
@@ -840,6 +888,10 @@ export interface FileRouteTypes {
     | '/api/internal/wipe'
     | '/api/internal/wipe-everything'
     | '/api/v1/models'
+    | '/api/xrpc/dev.cocore.account.createApiKey'
+    | '/api/xrpc/dev.cocore.account.deleteApiKey'
+    | '/api/xrpc/dev.cocore.account.listApiKeys'
+    | '/api/xrpc/dev.cocore.account.revokeApiKey'
     | '/api/xrpc/dev.cocore.devicePair.confirm'
     | '/api/xrpc/dev.cocore.devicePair.poll'
     | '/api/xrpc/dev.cocore.devicePair.start'
@@ -884,6 +936,10 @@ export interface RootRouteChildren {
   ApiInternalWipeRoute: typeof ApiInternalWipeRoute
   ApiInternalWipeEverythingRoute: typeof ApiInternalWipeEverythingRoute
   ApiV1ModelsRoute: typeof ApiV1ModelsRoute
+  ApiXrpcDevDotcocoreDotaccountDotcreateApiKeyRoute: typeof ApiXrpcDevDotcocoreDotaccountDotcreateApiKeyRoute
+  ApiXrpcDevDotcocoreDotaccountDotdeleteApiKeyRoute: typeof ApiXrpcDevDotcocoreDotaccountDotdeleteApiKeyRoute
+  ApiXrpcDevDotcocoreDotaccountDotlistApiKeysRoute: typeof ApiXrpcDevDotcocoreDotaccountDotlistApiKeysRoute
+  ApiXrpcDevDotcocoreDotaccountDotrevokeApiKeyRoute: typeof ApiXrpcDevDotcocoreDotaccountDotrevokeApiKeyRoute
   ApiXrpcDevDotcocoreDotdevicePairDotconfirmRoute: typeof ApiXrpcDevDotcocoreDotdevicePairDotconfirmRoute
   ApiXrpcDevDotcocoreDotdevicePairDotpollRoute: typeof ApiXrpcDevDotcocoreDotdevicePairDotpollRoute
   ApiXrpcDevDotcocoreDotdevicePairDotstartRoute: typeof ApiXrpcDevDotcocoreDotdevicePairDotstartRoute
@@ -1199,6 +1255,34 @@ declare module '@tanstack/react-router' {
       path: '/api/xrpc/dev.cocore.devicePair.confirm'
       fullPath: '/api/xrpc/dev.cocore.devicePair.confirm'
       preLoaderRoute: typeof ApiXrpcDevDotcocoreDotdevicePairDotconfirmRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/xrpc/dev.cocore.account.revokeApiKey': {
+      id: '/api/xrpc/dev.cocore.account.revokeApiKey'
+      path: '/api/xrpc/dev.cocore.account.revokeApiKey'
+      fullPath: '/api/xrpc/dev.cocore.account.revokeApiKey'
+      preLoaderRoute: typeof ApiXrpcDevDotcocoreDotaccountDotrevokeApiKeyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/xrpc/dev.cocore.account.listApiKeys': {
+      id: '/api/xrpc/dev.cocore.account.listApiKeys'
+      path: '/api/xrpc/dev.cocore.account.listApiKeys'
+      fullPath: '/api/xrpc/dev.cocore.account.listApiKeys'
+      preLoaderRoute: typeof ApiXrpcDevDotcocoreDotaccountDotlistApiKeysRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/xrpc/dev.cocore.account.deleteApiKey': {
+      id: '/api/xrpc/dev.cocore.account.deleteApiKey'
+      path: '/api/xrpc/dev.cocore.account.deleteApiKey'
+      fullPath: '/api/xrpc/dev.cocore.account.deleteApiKey'
+      preLoaderRoute: typeof ApiXrpcDevDotcocoreDotaccountDotdeleteApiKeyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/xrpc/dev.cocore.account.createApiKey': {
+      id: '/api/xrpc/dev.cocore.account.createApiKey'
+      path: '/api/xrpc/dev.cocore.account.createApiKey'
+      fullPath: '/api/xrpc/dev.cocore.account.createApiKey'
+      preLoaderRoute: typeof ApiXrpcDevDotcocoreDotaccountDotcreateApiKeyRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/v1/models': {
@@ -1521,6 +1605,14 @@ const rootRouteChildren: RootRouteChildren = {
   ApiInternalWipeRoute: ApiInternalWipeRoute,
   ApiInternalWipeEverythingRoute: ApiInternalWipeEverythingRoute,
   ApiV1ModelsRoute: ApiV1ModelsRoute,
+  ApiXrpcDevDotcocoreDotaccountDotcreateApiKeyRoute:
+    ApiXrpcDevDotcocoreDotaccountDotcreateApiKeyRoute,
+  ApiXrpcDevDotcocoreDotaccountDotdeleteApiKeyRoute:
+    ApiXrpcDevDotcocoreDotaccountDotdeleteApiKeyRoute,
+  ApiXrpcDevDotcocoreDotaccountDotlistApiKeysRoute:
+    ApiXrpcDevDotcocoreDotaccountDotlistApiKeysRoute,
+  ApiXrpcDevDotcocoreDotaccountDotrevokeApiKeyRoute:
+    ApiXrpcDevDotcocoreDotaccountDotrevokeApiKeyRoute,
   ApiXrpcDevDotcocoreDotdevicePairDotconfirmRoute:
     ApiXrpcDevDotcocoreDotdevicePairDotconfirmRoute,
   ApiXrpcDevDotcocoreDotdevicePairDotpollRoute:

--- a/packages/console/src/routes/api/xrpc/dev[.]cocore[.]account[.]createApiKey.ts
+++ b/packages/console/src/routes/api/xrpc/dev[.]cocore[.]account[.]createApiKey.ts
@@ -1,0 +1,65 @@
+// POST /api/xrpc/dev.cocore.account.createApiKey
+//
+// Mint a new cocore API key for the authenticated account and return
+// the full secret exactly once. Authenticate with a console session
+// cookie or an existing `Authorization: Bearer cocore-...` key — the
+// latter is the automation path (mint one key from the console UI,
+// then manage the rest headlessly).
+//
+// Body:    { name: string, expiresAt?: string | null }
+// Returns: 200 { key: apiKeyView, secret } | 400 | 401
+//
+// Lexicon: dev.cocore.account.createApiKey
+
+import { createFileRoute } from "@tanstack/react-router";
+
+import { createKey } from "@/lib/api-keys.server.ts";
+import { apiKeyView, resolveXrpcCaller, xrpcError, xrpcJson } from "@/lib/xrpc-key-auth.server.ts";
+
+interface RawBody {
+  name?: unknown;
+  expiresAt?: unknown;
+}
+
+function parseBody(raw: RawBody): { name: string; expiresAt: string | null } | string {
+  if (typeof raw.name !== "string" || raw.name.length < 1 || raw.name.length > 100) {
+    return "name must be a string of 1–100 characters";
+  }
+  if (raw.expiresAt !== undefined && raw.expiresAt !== null && typeof raw.expiresAt !== "string") {
+    return "expiresAt must be an RFC3339 string, null, or omitted";
+  }
+  if (typeof raw.expiresAt === "string" && Number.isNaN(Date.parse(raw.expiresAt))) {
+    return "expiresAt must be a valid RFC3339 datetime";
+  }
+  return {
+    name: raw.name,
+    expiresAt: typeof raw.expiresAt === "string" ? raw.expiresAt : null,
+  };
+}
+
+export const Route = createFileRoute("/api/xrpc/dev.cocore.account.createApiKey")({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        const caller = await resolveXrpcCaller(request);
+        if (!caller) return xrpcError(401, "AuthRequired", "session cookie or bearer key required");
+
+        let raw: RawBody;
+        try {
+          raw = (await request.json()) as RawBody;
+        } catch {
+          return xrpcError(400, "InvalidRequest", "body must be JSON");
+        }
+        const parsed = parseBody(raw);
+        if (typeof parsed === "string") return xrpcError(400, "InvalidRequest", parsed);
+
+        const created = createKey({
+          did: caller.did,
+          name: parsed.name,
+          expiresAt: parsed.expiresAt,
+        });
+        return xrpcJson({ key: apiKeyView(created.key), secret: created.secret }, 200);
+      },
+    },
+  },
+});

--- a/packages/console/src/routes/api/xrpc/dev[.]cocore[.]account[.]deleteApiKey.ts
+++ b/packages/console/src/routes/api/xrpc/dev[.]cocore[.]account[.]deleteApiKey.ts
@@ -1,0 +1,48 @@
+// POST /api/xrpc/dev.cocore.account.deleteApiKey
+//
+// Hard-delete one of the authenticated account's API keys, removing the
+// row entirely (no audit-trail recovery). Prefer revokeApiKey for most
+// flows; use this to clean up revoked or expired keys. Scoped to the
+// caller's DID.
+//
+// Body:    { id: string }
+// Returns: 200 { deleted: boolean } | 400 | 401
+//
+// Lexicon: dev.cocore.account.deleteApiKey
+
+import { createFileRoute } from "@tanstack/react-router";
+
+import { deleteKey } from "@/lib/api-keys.server.ts";
+import { resolveXrpcCaller, xrpcError, xrpcJson } from "@/lib/xrpc-key-auth.server.ts";
+
+interface RawBody {
+  id?: unknown;
+}
+
+function parseId(raw: RawBody): string | null {
+  if (typeof raw.id !== "string" || raw.id.length < 1 || raw.id.length > 200) return null;
+  return raw.id;
+}
+
+export const Route = createFileRoute("/api/xrpc/dev.cocore.account.deleteApiKey")({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        const caller = await resolveXrpcCaller(request);
+        if (!caller) return xrpcError(401, "AuthRequired", "session cookie or bearer key required");
+
+        let raw: RawBody;
+        try {
+          raw = (await request.json()) as RawBody;
+        } catch {
+          return xrpcError(400, "InvalidRequest", "body must be JSON");
+        }
+        const id = parseId(raw);
+        if (id === null) return xrpcError(400, "InvalidRequest", "id must be a 1–200 char string");
+
+        const deleted = deleteKey({ id, did: caller.did });
+        return xrpcJson({ deleted }, 200);
+      },
+    },
+  },
+});

--- a/packages/console/src/routes/api/xrpc/dev[.]cocore[.]account[.]listApiKeys.ts
+++ b/packages/console/src/routes/api/xrpc/dev[.]cocore[.]account[.]listApiKeys.ts
@@ -1,0 +1,29 @@
+// GET /api/xrpc/dev.cocore.account.listApiKeys
+//
+// List every API key owned by the authenticated account, newest first.
+// The owning DID comes from the presented credential (session cookie or
+// `Authorization: Bearer cocore-...`); there is no parameter to list
+// another account's keys. Secrets are never returned.
+//
+// Returns: 200 { keys: apiKeyView[] } | 401
+//
+// Lexicon: dev.cocore.account.listApiKeys
+
+import { createFileRoute } from "@tanstack/react-router";
+
+import { listKeysForDid } from "@/lib/api-keys.server.ts";
+import { apiKeyView, resolveXrpcCaller, xrpcError, xrpcJson } from "@/lib/xrpc-key-auth.server.ts";
+
+export const Route = createFileRoute("/api/xrpc/dev.cocore.account.listApiKeys")({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const caller = await resolveXrpcCaller(request);
+        if (!caller) return xrpcError(401, "AuthRequired", "session cookie or bearer key required");
+
+        const keys = listKeysForDid(caller.did).map(apiKeyView);
+        return xrpcJson({ keys }, 200);
+      },
+    },
+  },
+});

--- a/packages/console/src/routes/api/xrpc/dev[.]cocore[.]account[.]revokeApiKey.ts
+++ b/packages/console/src/routes/api/xrpc/dev[.]cocore[.]account[.]revokeApiKey.ts
@@ -1,0 +1,47 @@
+// POST /api/xrpc/dev.cocore.account.revokeApiKey
+//
+// Revoke one of the authenticated account's API keys. The key stops
+// authenticating immediately; the row survives with `revokedAt` set so
+// it stays visible in listApiKeys for audit. Scoped to the caller's DID.
+//
+// Body:    { id: string }
+// Returns: 200 { revoked: boolean } | 400 | 401
+//
+// Lexicon: dev.cocore.account.revokeApiKey
+
+import { createFileRoute } from "@tanstack/react-router";
+
+import { revokeKey } from "@/lib/api-keys.server.ts";
+import { resolveXrpcCaller, xrpcError, xrpcJson } from "@/lib/xrpc-key-auth.server.ts";
+
+interface RawBody {
+  id?: unknown;
+}
+
+function parseId(raw: RawBody): string | null {
+  if (typeof raw.id !== "string" || raw.id.length < 1 || raw.id.length > 200) return null;
+  return raw.id;
+}
+
+export const Route = createFileRoute("/api/xrpc/dev.cocore.account.revokeApiKey")({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        const caller = await resolveXrpcCaller(request);
+        if (!caller) return xrpcError(401, "AuthRequired", "session cookie or bearer key required");
+
+        let raw: RawBody;
+        try {
+          raw = (await request.json()) as RawBody;
+        } catch {
+          return xrpcError(400, "InvalidRequest", "body must be JSON");
+        }
+        const id = parseId(raw);
+        if (id === null) return xrpcError(400, "InvalidRequest", "id must be a 1–200 char string");
+
+        const revoked = revokeKey({ id, did: caller.did });
+        return xrpcJson({ revoked }, 200);
+      },
+    },
+  },
+});

--- a/packages/console/src/routes/lexicons.$nsid.ts
+++ b/packages/console/src/routes/lexicons.$nsid.ts
@@ -18,7 +18,12 @@
 
 import { createFileRoute } from "@tanstack/react-router";
 
+import accountCreateApiKey from "../../../../lexicons/dev/cocore/account/createApiKey.json" with { type: "json" };
+import accountDefs from "../../../../lexicons/dev/cocore/account/defs.json" with { type: "json" };
+import accountDeleteApiKey from "../../../../lexicons/dev/cocore/account/deleteApiKey.json" with { type: "json" };
+import accountListApiKeys from "../../../../lexicons/dev/cocore/account/listApiKeys.json" with { type: "json" };
 import accountProfile from "../../../../lexicons/dev/cocore/account/profile.json" with { type: "json" };
+import accountRevokeApiKey from "../../../../lexicons/dev/cocore/account/revokeApiKey.json" with { type: "json" };
 import attestation from "../../../../lexicons/dev/cocore/compute/attestation.json" with { type: "json" };
 import defs from "../../../../lexicons/dev/cocore/compute/defs.json" with { type: "json" };
 import dispute from "../../../../lexicons/dev/cocore/compute/dispute.json" with { type: "json" };
@@ -32,7 +37,12 @@ import settlement from "../../../../lexicons/dev/cocore/compute/settlement.json"
 import termsAcceptance from "../../../../lexicons/dev/cocore/compute/termsAcceptance.json" with { type: "json" };
 
 const REGISTRY: Record<string, unknown> = {
+  "dev.cocore.account.createApiKey": accountCreateApiKey,
+  "dev.cocore.account.defs": accountDefs,
+  "dev.cocore.account.deleteApiKey": accountDeleteApiKey,
+  "dev.cocore.account.listApiKeys": accountListApiKeys,
   "dev.cocore.account.profile": accountProfile,
+  "dev.cocore.account.revokeApiKey": accountRevokeApiKey,
   "dev.cocore.compute.attestation": attestation,
   "dev.cocore.compute.defs": defs,
   "dev.cocore.compute.dispute": dispute,

--- a/packages/console/src/routes/lexicons.index.ts
+++ b/packages/console/src/routes/lexicons.index.ts
@@ -13,7 +13,12 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 const NSIDS = [
+  "dev.cocore.account.createApiKey",
+  "dev.cocore.account.defs",
+  "dev.cocore.account.deleteApiKey",
+  "dev.cocore.account.listApiKeys",
   "dev.cocore.account.profile",
+  "dev.cocore.account.revokeApiKey",
   "dev.cocore.compute.attestation",
   "dev.cocore.compute.defs",
   "dev.cocore.compute.dispute",


### PR DESCRIPTION
## What

Exposes API-key **creation, listing, revocation, and deletion** as
`dev.cocore.account.*` XRPC methods so people can automate access to that
side of the system instead of driving the console UI.

The lifecycle logic (`createKey`/`listKeysForDid`/`revokeKey`/`deleteKey`,
plus `resolveBearerKey`) already existed in `packages/console`; this PR puts
a lexicon-defined XRPC surface in front of it.

## Lexicons (the spec, written first)

New under `lexicons/dev/cocore/account/`:

| NSID | Type | Purpose |
| --- | --- | --- |
| `dev.cocore.account.defs` | defs | `apiKeyView` — the secret-free wire shape |
| `dev.cocore.account.createApiKey` | procedure | mint a key; returns `secret` exactly once |
| `dev.cocore.account.listApiKeys` | query | list the caller's keys (no secrets) |
| `dev.cocore.account.revokeApiKey` | procedure | soft-revoke (keeps row for audit) |
| `dev.cocore.account.deleteApiKey` | procedure | hard-delete a key row |

All five validate against `lexicon.garden` and have been **published** as
`com.atproto.lexicon.schema` records under `cocore.dev`
(`did:plc:5quuhkmwe2q4k3azfsgg7kdz`) and confirmed resolvable:

```
$ curl '.../resolveLexicon?nsid=dev.cocore.account.createApiKey' → id: dev.cocore.account.createApiKey
```

They're also registered in the `/lexicons` registry + index so the JSON is
publicly fetchable, and they appear on the console's lexicon docs.

## Endpoints

Served by the console at `/api/xrpc/<nsid>` (matching the existing
`dev.cocore.proxy.*` / `dev.cocore.inference.*` routes):

- `POST /api/xrpc/dev.cocore.account.createApiKey`
- `GET  /api/xrpc/dev.cocore.account.listApiKeys`
- `POST /api/xrpc/dev.cocore.account.revokeApiKey`
- `POST /api/xrpc/dev.cocore.account.deleteApiKey`

### Auth

A shared helper (`lib/xrpc-key-auth.server.ts`) resolves the caller from
**either** an existing `Authorization: Bearer cocore-...` key (the automation
path) **or** a console session cookie (so the web UI / bootstrap works).
Every operation is scoped to the resolved DID — you can only touch your own
keys. Bootstrapping the first key is via the console UI or `cocore agent pair`,
documented in the guide.

## Docs

- `docs/api-keys.md` — full guide: key format, auth model, bootstrapping, and
  curl examples for all four endpoints.
- `lexicons/README.md` — new `dev.cocore.account` namespace table.
- `README.md` — one-line pointer.

## Tests / checks

- `tsc --noEmit` passes clean.
- `oxlint` + `oxfmt --check` clean on all new files.
- Added `xrpc-key-auth.test.ts` covering `apiKeyView` (required fields,
  null-optional omission, no secret leak) and the no-credential `401` path.

> Note: this machine can't run the DB-backed / `@/`-alias vitest suites
> (unbuilt `better-sqlite3` native binding + a local rolldown `tsconfigPaths`
> resolution gap that also breaks unmodified tests like `chat-crypto.test.ts`).
> Those are pre-existing environmental issues, not regressions from this PR;
> the new test follows the same conventions as the existing `@/`-importing
> tests and runs wherever they do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)