### PR TITLE
tray: rebrand display name to "co/core" + harden menu states

### DIFF
--- a/provider-shell/Sources/CoCoreShell/MainTabView.swift
+++ b/provider-shell/Sources/CoCoreShell/MainTabView.swift
@@ -1,8 +1,8 @@
-// MainWindow: the single window the tray's "Open cocore…" opens. It folds
+// MainWindow: the single window the tray's "Open co/core…" opens. It folds
 // what used to be separate Status / Models / Preferences windows plus the
 // About housekeeping (version, updates, bug report, uninstall) into one
 // window, so the status-bar menu can stay short — the menu keeps only the
-// serving toggle, the at-a-glance lines, contextual alerts, "Open cocore…",
+// serving toggle, the at-a-glance lines, contextual alerts, "Open co/core…",
 // and Quit.
 //
 // Why AppKit toolbar tabs (NSTabViewController `.toolbar`) instead of a
@@ -83,7 +83,7 @@ final class MainWindowController {
                         onUninstall: onUninstall)),
             ]
             let w = NSWindow(contentViewController: tabs)
-            w.title = "cocore"
+            w.title = "co/core"
             w.styleMask = [.titled, .closable, .miniaturizable]
             // `.preference` centers the tab toolbar under the title — the
             // standard preferences-window layout, and what gives the tabs
@@ -109,10 +109,10 @@ final class MainWindowController {
         host.sizingOptions = []
         // NSTabViewController titles the window from the selected pane's
         // controller — leaving it nil reads "Untitled", and using the tab
-        // label makes the title flip per tab. Pin every pane to "cocore" so
+        // label makes the title flip per tab. Pin every pane to "co/core" so
         // the window stays consistently branded; the toolbar buttons still
         // carry their own labels (set on the NSTabViewItem below).
-        host.title = "cocore"
+        host.title = "co/core"
         let item = NSTabViewItem(viewController: host)
         item.label = label
         item.image = NSImage(systemSymbolName: symbol, accessibilityDescription: label)
@@ -198,7 +198,7 @@ private struct AboutTab: View {
                     .foregroundStyle(.secondary)
             }
             Section {
-                Button("Uninstall cocore…", role: .destructive, action: onUninstall)
+                Button("Uninstall co/core…", role: .destructive, action: onUninstall)
             }
         }
         .formStyle(.grouped)

--- a/provider-shell/Sources/CoCoreShell/MenuBarController.swift
+++ b/provider-shell/Sources/CoCoreShell/MenuBarController.swift
@@ -50,7 +50,7 @@ final class MenuBarController {
         self.updater = updater
         self.item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         item.button?.image = MenuBarController.brandImage()
-        item.button?.toolTip = "cocore"
+        item.button?.toolTip = "co/core"
         refreshServing()
         rebuildMenu()
 
@@ -112,12 +112,12 @@ final class MenuBarController {
         if let s = state.session {
             menu.addItem(disabled("Signed in as \(s.handle)"))
         } else {
-            menu.addItem(disabled("Welcome to cocore"))
-            menu.addItem(disabled("Step 1: sign in to turn this Mac into a provider."))
+            menu.addItem(disabled("Welcome to co/core"))
+            menu.addItem(disabled("Sign in to turn this Mac into a provider."))
             menu.addItem(.separator())
             menu.addItem(action(title: "Sign in with ATProto…", #selector(signIn)))
             menu.addItem(.separator())
-            menu.addItem(action(title: "Quit", #selector(quit)))
+            menu.addItem(action(title: "Quit co/core", #selector(quit)))
             item.menu = menu
             return
         }
@@ -143,7 +143,7 @@ final class MenuBarController {
         menu.addItem(.separator())
         // At-a-glance state + the one metric worth a glance. Everything
         // else — identity detail, models, preferences, profile, bug report,
-        // sign out, uninstall, version — moved into the "Open cocore…"
+        // sign out, uninstall, version — moved into the "Open co/core…"
         // window so the menu stays short.
         let atAGlance: String
         if remotelyPaused {
@@ -173,9 +173,9 @@ final class MenuBarController {
             // it; offer a one-click restart and point at the window for the
             // full reason. We deliberately DON'T put the fault message here —
             // NSMenu items don't wrap, so a long reason balloons the whole
-            // menu. The wrapped detail lives in Open cocore… → Status.
+            // menu. The wrapped detail lives in Open co/core… → Status.
             menu.addItem(action(title: "Restart serving", #selector(restartServing)))
-            menu.addItem(disabled("Open cocore… → Status for the reason"))
+            menu.addItem(disabled("Open co/core… → Status for the reason"))
             menu.addItem(.separator())
         }
         if badStanding {
@@ -213,11 +213,15 @@ final class MenuBarController {
         // up to date, a routine "Check for updates…" (also in the Help tab).
         addUpdateItems(to: menu)
         menu.addItem(.separator())
-        menu.addItem(action(title: "Open cocore…", #selector(openMainWindow)))
-        if let err = state.lastError {
-            menu.addItem(disabled("⚠ \(err)"))
+        menu.addItem(action(title: "Open co/core…", #selector(openMainWindow)))
+        if let err = state.lastError, !err.isEmpty {
+            // Catch-all for a surfaced error (e.g. a failed sign-in). Clip it
+            // so a raw, multi-line error string can't balloon the menu — it
+            // stays one tidy line like the rest, and the full detail lives in
+            // the window / logs.
+            menu.addItem(disabled("⚠ \(Self.clip(err))"))
         }
-        menu.addItem(action(title: "Quit cocore", #selector(quit)))
+        menu.addItem(action(title: "Quit co/core", #selector(quit)))
         item.menu = menu
     }
 
@@ -304,7 +308,7 @@ final class MenuBarController {
             return true
         }
         image.isTemplate = !hasDot
-        image.accessibilityDescription = hasDot ? "cocore — status" : "cocore"
+        image.accessibilityDescription = hasDot ? "co/core — status" : "co/core"
         return image
     }
 
@@ -312,6 +316,15 @@ final class MenuBarController {
         let it = NSMenuItem(title: s, action: nil, keyEquivalent: "")
         it.isEnabled = false
         return it
+    }
+
+    /// Clip a variable-length string to one tidy menu line. The contextual
+    /// state lines are ~45–55 chars; anything an upstream error throws at us
+    /// (a raw pairing/update error) gets trimmed to an ellipsis so it can
+    /// never balloon the menu the way a long, non-wrapping NSMenu item does.
+    static func clip(_ s: String, _ cap: Int = 60) -> String {
+        let t = s.trimmingCharacters(in: .whitespacesAndNewlines)
+        return t.count > cap ? String(t.prefix(cap - 1)) + "…" : t
     }
 
     private func action(title: String, _ sel: Selector) -> NSMenuItem {
@@ -469,7 +482,7 @@ final class MenuBarController {
     /// Model-list state for the Models tab (one shared instance).
     private lazy var modelManager = ModelManager(supervisor: supervisor)
 
-    /// The single window the tray's "Open cocore…" opens — Status / Models /
+    /// The single window the tray's "Open co/core…" opens — Status / Models /
     /// Preferences / Help as tabs. Action closures route back to the methods
     /// here (which own the NSAlert flows + supervisor lifecycle).
     private lazy var mainWindow: MainWindowController = MainWindowController(
@@ -514,10 +527,10 @@ final class MenuBarController {
     @objc private func confirmUninstall() {
         let alert = NSAlert()
         alert.alertStyle = .critical
-        alert.messageText = "Uninstall cocore?"
+        alert.messageText = "Uninstall co/core?"
         alert.informativeText = """
         This deregisters this machine (removes its provider record from \
-        your PDS) and removes the cocore agent, its LaunchAgent, the \
+        your PDS) and removes the co/core agent, its LaunchAgent, the \
         ~/.cocore state, the Python runtime, and this app.
 
         Your identity-level records (past receipts, API keys, console \
@@ -579,7 +592,7 @@ final class MenuBarController {
             } else {
                 alert.alertStyle = .warning
                 alert.messageText = "Couldn't create a bug report"
-                alert.informativeText = "The cocore agent binary wasn't found. Try reinstalling."
+                alert.informativeText = "The co/core agent binary wasn't found. Try reinstalling."
             }
             alert.addButton(withTitle: "OK")
             NSApp.activate(ignoringOtherApps: true)
@@ -602,7 +615,7 @@ final class MenuBarController {
         case .updating(let v):
             menu.addItem(disabled("Updating to \(v)…"))
         case .failed(let m):
-            menu.addItem(disabled("⚠ \(m)"))
+            menu.addItem(disabled("⚠ \(Self.clip(m))"))
             menu.addItem(action(title: "Retry update", #selector(installUpdate)))
         case .upToDate:
             // No pending update — offer a routine on-demand check right here
@@ -797,8 +810,8 @@ final class MenuBarController {
             return "Recovery requested — restarting the inference engine."
         default:
             // Already a human-readable sentence (e.g. the recovery-failed
-            // detail). Keep it short for the menu.
-            return reason.count > 120 ? String(reason.prefix(117)) + "…" : reason
+            // detail). Clip to one menu line like the other state rows.
+            return clip(reason)
         }
     }
 }

--- a/provider-shell/Sources/CoCoreShell/ModelsView.swift
+++ b/provider-shell/Sources/CoCoreShell/ModelsView.swift
@@ -27,7 +27,7 @@ final class ModelManager: ObservableObject {
             switch self {
             case .loaded(let m): return "✓ \(m) loaded and serving."
             case .failed(let m):
-                return "✗ \(m) failed to load. cocore runs MLX-format models only "
+                return "✗ \(m) failed to load. co/core runs MLX-format models only "
                     + "(mlx-community/… or another repo with MLX 4-bit weights); a stock "
                     + "PyTorch repo won't load. See this machine on console.cocore.dev for details."
             case .pending(let m):
@@ -338,7 +338,7 @@ final class ModelManager: ObservableObject {
         await withCheckedContinuation { (cont: CheckedContinuation<(Int32, String), Never>) in
             DispatchQueue.global().async {
                 guard let bin = AgentSupervisor.locateBinary() else {
-                    cont.resume(returning: (-1, "cocore binary not found"))
+                    cont.resume(returning: (-1, "co/core binary not found"))
                     return
                 }
                 let p = Process()
@@ -383,7 +383,7 @@ struct ModelsView: View {
             Text("Models this machine loads and advertises. Changes bounce the agent and re-publish your provider record within seconds.")
                 .font(.footnote)
                 .foregroundStyle(.secondary)
-            Text("Any MLX-format model works — not just the suggestions below. cocore runs MLX weights (mlx-community/… or another repo with MLX 4-bit weights); stock PyTorch repos won't load.")
+            Text("Any MLX-format model works — not just the suggestions below. co/core runs MLX weights (mlx-community/… or another repo with MLX 4-bit weights); stock PyTorch repos won't load.")
                 .font(.footnote)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -655,7 +655,7 @@ final class ModelsWindowController {
         if window == nil {
             let hosting = NSHostingController(rootView: ModelsView(manager: manager))
             let w = NSWindow(contentViewController: hosting)
-            w.title = "cocore — Models"
+            w.title = "co/core — Models"
             w.styleMask = [.titled, .closable, .miniaturizable]
             w.isReleasedWhenClosed = false
             w.center()

--- a/provider-shell/Sources/CoCoreShell/PreferencesView.swift
+++ b/provider-shell/Sources/CoCoreShell/PreferencesView.swift
@@ -28,7 +28,7 @@ final class PreferencesWindowController {
             let hosting = NSHostingController(
                 rootView: PreferencesView(supervisor: supervisor).environmentObject(state))
             let w = NSWindow(contentViewController: hosting)
-            w.title = "cocore — Preferences"
+            w.title = "co/core — Settings"
             w.styleMask = [.titled, .closable, .miniaturizable]
             w.isReleasedWhenClosed = false
             w.center()

--- a/provider-shell/Sources/CoCoreShell/Resources/Info.plist
+++ b/provider-shell/Sources/CoCoreShell/Resources/Info.plist
@@ -3,11 +3,11 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDisplayName</key>
-	<string>cocore</string>
+	<string>co/core</string>
 	<key>CFBundleIdentifier</key>
 	<string>dev.cocore.shell</string>
 	<key>CFBundleName</key>
-	<string>cocore</string>
+	<string>co/core</string>
 	<key>CFBundleShortVersionString</key>
 	<string>0.9.16</string>
 	<key>CFBundleURLTypes</key>

--- a/provider-shell/Sources/CoCoreShell/StatusView.swift
+++ b/provider-shell/Sources/CoCoreShell/StatusView.swift
@@ -120,7 +120,7 @@ final class StatusWindowController {
         if window == nil {
             let hosting = NSHostingController(rootView: StatusView().environmentObject(state))
             let w = NSWindow(contentViewController: hosting)
-            w.title = "cocore — Status"
+            w.title = "co/core — Status"
             w.styleMask = [.titled, .closable, .miniaturizable]
             w.isReleasedWhenClosed = false
             w.center()

--- a/provider-shell/Sources/CoCoreShell/WelcomeView.swift
+++ b/provider-shell/Sources/CoCoreShell/WelcomeView.swift
@@ -36,7 +36,7 @@ final class WelcomeWindowController {
                 close: { [weak self] in self?.window?.close() }
             )
             let w = NSWindow(contentViewController: NSHostingController(rootView: view))
-            w.title = "Welcome to cocore"
+            w.title = "Welcome to co/core"
             w.styleMask = [.titled, .closable]
             w.isReleasedWhenClosed = false
             w.center()
@@ -138,7 +138,7 @@ struct WelcomeView: View {
                 .frame(width: 44, height: 44)
                 .foregroundStyle(Brand.mark)
             VStack(alignment: .leading, spacing: 3) {
-                Text("Welcome to cocore")
+                Text("Welcome to co/core")
                     .font(.largeTitle).bold()
                     .foregroundStyle(Brand.accentText)
                 Text("Turn this Mac into a verifiable compute provider — a few quick steps and you're earning credits.")
@@ -352,7 +352,7 @@ struct WelcomeView: View {
     private var footer: some View {
         HStack(spacing: 12) {
             if allDone {
-                Text("🎉 You're all set — this Mac is a live cocore provider.")
+                Text("🎉 You're all set — this Mac is a live co/core provider.")
                     .font(.callout).foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
@@ -432,9 +432,14 @@ struct WelcomeView: View {
                 await state.refreshSession()
                 await state.refreshStatus()
                 await refresh()
+                state.lastError = nil  // clear any prior failed-sign-in line
             } catch {
                 pairError = "Couldn't finish pairing. Click “Sign in with ATProto” to try again."
-                state.setError("Pairing failed: \(error)")
+                // The window shows the actionable `pairError` above; the menu's
+                // catch-all gets a short, directive line (the raw error goes to
+                // the log, not the menu, so it can't balloon a single row).
+                NSLog("cocore: pairing failed: %@", String(describing: error))
+                state.setError("Sign-in didn’t finish — open co/core to retry.")
             }
         }
     }


### PR DESCRIPTION
## Rebrand

The wordmark is **co/core**, not "cocore". Updated every user-facing display string:
- Window + pane titles (`co/core`, `co/core — Status/Models/Settings`), status-item tooltip + accessibility label
- Menu items: **Open co/core…**, **Quit co/core**, the provisioning-failed pointer
- Uninstall + bug-report alerts, the Welcome wizard, the Models copy
- `CFBundleName` / `CFBundleDisplayName`

**Left untouched** (not the wordmark): the `cocore://` OAuth URL scheme, `dev.cocore.shell` bundle id, `~/.cocore` paths, `*.cocore.dev` URLs, the `cocore` CLI binary name, and log prefixes.

## Menu-state hardening

Made the non-happy-path rows as crisp as the normal flow — one tidy, directive line each:
- New `clip(_:)` helper; every variable-length row goes through it — the `lastError` catch-all, the update-`failed` line, and the bad-standing detail — so a raw upstream error can't balloon a non-wrapping NSMenu item.
- **Signed-out**: dropped the "Step 1:" framing (no visible step 2) and made Quit consistent.
- **Sign-in failure**: now sets a short, directive menu line ("Sign-in didn't finish — open co/core to retry.") and logs the raw error instead of dumping it into the menu; cleared on a later success.

## Verification

Built from this branch and drove it on a real Mac: confirmed the window title reads "co/core", the status-bar dropdown shows "Open co/core…" / "Quit co/core" (happy path otherwise unchanged), and About shows "Uninstall co/core…". Swift build clean.

Unreleased — batched with #14/#15/#17 for the next notarized build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)