### PR TITLE
chore(release): bump to 0.9.17

### DIFF
--- a/provider-shell/Sources/CoCoreShell/Resources/Info.plist
+++ b/provider-shell/Sources/CoCoreShell/Resources/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleName</key>
 	<string>co/core</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.16</string>
+	<string>0.9.17</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -22,7 +22,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>916</string>
+	<string>917</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/provider/Cargo.lock
+++ b/provider/Cargo.lock
@@ -277,7 +277,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cocore-provider"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "anyhow",
  "asn1-rs",

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cocore-provider"
-version = "0.9.16"
+version = "0.9.17"
 edition = "2021"
 description = "cocore provider agent: runs hardened compute and publishes signed receipts to AT Protocol."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Bumps the version in all three places (Cargo.toml, Cargo.lock, Info.plist Short+Bundle → 0.9.17/917) and cuts the **0.9.17** release.

Ships the tray UX work batched since 0.9.16 to installed machines via auto-update:
- Models tab scrolls instead of clipping (#15)
- provisioning-failure reason no longer balloons the menu (#14)
- native toolbar tabs + simpler Status / Models / Settings / About flow (#17)
- display name is now **co/core** everywhere; non-happy-path menu rows clipped to one tidy line (#19)

Release cut from `release/0.9.17` (tag `v0.9.17`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)