### PR TITLE
console(auth): scope session cookie to cocore.dev + cutover runbook

### DIFF
--- a/docs/cutover-cocore-dev.md
+++ b/docs/cutover-cocore-dev.md
@@ -1,0 +1,156 @@
+# Cutover runbook: `console.cocore.dev` → `cocore.dev`
+
+Goal: make **`cocore.dev`** the canonical console host, served on Railway, with
+`console.cocore.dev` kept alive as a permanent alias (installed agents + the
+tray app + `curl … | sh` all bake it in, so it can never 301 away on the
+`/agent`, `/api`, `/v1`, `/xrpc`, `/.well-known` paths).
+
+Decisions locked in:
+- **Flip canonical to `cocore.dev`** (accept a one-time re-login for all users —
+  the ATProto OAuth `client_id` is `https://<canonical>/api/auth/atproto/metadata.json`,
+  so changing the host is a new OAuth client).
+- **Move DNS to Cloudflare** for apex CNAME-flattening (DigitalOcean cannot put
+  a CNAME/ALIAS at the zone apex; Railway serves custom domains by CNAME and
+  gives no static apex IP).
+
+## The blocker, in one line
+
+`cocore.dev` (apex) must CNAME to `5srj47wl.up.railway.app`, and only a
+flattening DNS provider (Cloudflare) can do that at the root.
+
+## Current Railway state (already done — no action)
+
+The console service already has all three custom domains attached:
+
+| Domain | Railway-required record | Status |
+|---|---|---|
+| `console.cocore.dev` | CNAME → `lmy3bsgv.up.railway.app` | PROPAGATED (live) |
+| `cocore.dev` | CNAME → `5srj47wl.up.railway.app` | REQUIRES_UPDATE (no DNS yet) |
+| `www.cocore.dev` | CNAME → `ofg1g7be.up.railway.app` | drifted (currently `5srj47wl`) |
+
+Railway IDs (project **co/core**):
+- project `a46692ef-f462-4801-9a64-0af69ea7143d`, env `production` `9584945f-7b2f-4369-87a9-4eea8ffd7eae`
+- console service `e8f485a3-fb10-4d89-8d29-d56a71673bc7`
+
+## Step 0 — Pre-flight (do this first, no user impact)
+
+1. **Export the DigitalOcean zone** for `cocore.dev` (DO panel → Networking →
+   Domains → cocore.dev, or the API). `dig` cannot enumerate the whole zone —
+   the export is the source of truth. Reconcile it against the checklist below.
+2. Known records that MUST exist in Cloudflare (DNS-only / gray cloud — Railway
+   terminates TLS, do **not** proxy):
+
+   | Type | Name | Value | Proxy |
+   |---|---|---|---|
+   | CNAME | `@` (apex `cocore.dev`) | `5srj47wl.up.railway.app` | DNS only |
+   | CNAME | `www` | `ofg1g7be.up.railway.app` | DNS only |
+   | CNAME | `console` | `lmy3bsgv.up.railway.app` | DNS only |
+   | CNAME | `advisor` | `h0aevzi4.up.railway.app` | DNS only |
+   | CNAME | `appview` | `avjh8yxu.up.railway.app` | DNS only |
+   | TXT | `_atproto` | `did=did:plc:5quuhkmwe2q4k3azfsgg7kdz` | n/a |
+   | … | (anything else in the DO export — `_lexicon`, etc.) | (copy verbatim) | |
+
+   ⚠ `_atproto.cocore.dev` is the **@cocore.dev handle verification** (DNS
+   method — the HTTP `/.well-known/atproto-did` returns Not Found). If it's
+   missing after the NS flip, the @cocore.dev account's handle breaks.
+
+3. **Build the full Cloudflare zone now, but do NOT change nameservers yet.**
+   Verify parity by querying Cloudflare's assigned nameservers directly before
+   delegating:
+   ```sh
+   CFNS=<your-cloudflare-ns>   # e.g. xxx.ns.cloudflare.com
+   for n in cocore.dev www.cocore.dev console.cocore.dev advisor.cocore.dev appview.cocore.dev; do
+     echo "$n -> $(dig @$CFNS +short $n)"
+   done
+   dig @$CFNS +short _atproto.cocore.dev TXT   # must be did:plc:5quuhk…
+   ```
+   The apex should return Railway's flattened A records; the subdomains their
+   CNAME targets; `_atproto` the DID. Only proceed once this matches.
+
+## Step 1 — Merge the cookie-domain PR (safe, forward-compatible)
+
+Branch: `console/cookie-domain-cocore-dev` (this PR). It scopes the auth session
+cookie to `cocore.dev` so a login on the apex is also valid on
+`console.cocore.dev`. It's a no-op until `cocore.dev` serves, and harmless on
+`console.cocore.dev` today (a subdomain of `cocore.dev`). Merge → console
+redeploys.
+
+## Step 2 — Flip nameservers (registrar)
+
+Switch the `cocore.dev` NS from DigitalOcean (`ns1/2/3.digitalocean.com`) to the
+two Cloudflare nameservers. `console`/`advisor`/`appview` keep working
+throughout because their records are identical in both zones; `cocore.dev`
+(apex) starts resolving once delegation lands.
+
+## Step 3 — Let Railway issue the apex cert
+
+Poll until `cocore.dev` flips to PROPAGATED and the cert is issued:
+```sh
+cat > /tmp/dq.json <<'JSON'
+{"query":"{ domains(projectId: \"a46692ef-f462-4801-9a64-0af69ea7143d\", environmentId: \"9584945f-7b2f-4369-87a9-4eea8ffd7eae\", serviceId: \"e8f485a3-fb10-4d89-8d29-d56a71673bc7\") { customDomains { domain status { dnsRecords { recordType requiredValue currentValue status } } } } }"}
+JSON
+curl -s -H "Authorization: Bearer $RAILWAY_API_TOKEN" -H "Content-Type: application/json" \
+  --data @/tmp/dq.json https://backboard.railway.app/graphql/v2 | python3 -m json.tool
+```
+Then confirm TLS: `curl -sI https://cocore.dev | head -1` (expect 200/3xx, valid cert).
+
+## Step 4 — Flip the canonical env on Railway (the user-visible moment)
+
+This is what re-points OAuth at `cocore.dev` and logs everyone out once. Do it
+deliberately, after Step 3 succeeds. Set on the **console** service:
+
+| Var | Value | Why |
+|---|---|---|
+| `CONSOLE_PUBLIC_URL` | `https://cocore.dev` | OG/share + OAuth fallback |
+| `PUBLIC_URL` | `https://cocore.dev` | OG/share primary (`getPublicUrl`) |
+| `BETTER_AUTH_URL` | `https://cocore.dev` | OAuth primary (`getBaseUrl`) |
+
+Also check the Railway dashboard for `ATPROTO_BASE_URL` / `VITE_PUBLIC_URL` — if
+either is currently pinned to `console.cocore.dev`, override to `https://cocore.dev`
+(both take precedence over the fallbacks).
+
+Ready-to-run (per var; repeat name/value):
+```sh
+cat > /tmp/vq.json <<'JSON'
+{"query":"mutation { variableUpsert(input: { projectId: \"a46692ef-f462-4801-9a64-0af69ea7143d\", environmentId: \"9584945f-7b2f-4369-87a9-4eea8ffd7eae\", serviceId: \"e8f485a3-fb10-4d89-8d29-d56a71673bc7\", name: \"CONSOLE_PUBLIC_URL\", value: \"https://cocore.dev\" }) }"}
+JSON
+curl -s -H "Authorization: Bearer $RAILWAY_API_TOKEN" -H "Content-Type: application/json" \
+  --data @/tmp/vq.json https://backboard.railway.app/graphql/v2
+```
+The upsert triggers a redeploy.
+
+## Step 5 — Verify
+
+```sh
+# canonical OG/OAuth now cocore.dev
+curl -s https://cocore.dev/api/auth/atproto/metadata.json | python3 -m json.tool | grep client_id
+# expect: "client_id": "https://cocore.dev/api/auth/atproto/metadata.json"
+
+# agents still work on the alias (must NOT have moved)
+curl -s https://console.cocore.dev/agent/version    # v0.9.17
+curl -s https://appview.cocore.dev/xrpc/dev.cocore.appview.getReceipts?limit=1 -o /dev/null -w '%{http_code}\n'
+
+# handle still verifies
+dig +short _atproto.cocore.dev TXT                  # did:plc:5quuhk…
+```
+Then: log in on `https://cocore.dev` end-to-end; confirm the session cookie is
+`Domain=cocore.dev`; load `https://console.cocore.dev` and confirm you're still
+signed in (shared cookie).
+
+## Rollback
+
+- **App canonical bad (cert/OAuth):** revert the three env vars to
+  `https://console.cocore.dev` and redeploy — instant; restores the old OAuth
+  client. (The DNS can stay on Cloudflare.)
+- **Cloudflare misbehaving:** flip NS back to DigitalOcean (slower; propagation
+  lag). The DO zone still exists, unchanged.
+- **Cookie PR bad:** revert the PR.
+
+## Optional follow-ups (not required for the cutover)
+
+- 301 `www.cocore.dev` → `https://cocore.dev`.
+- 301 `console.cocore.dev` **page** routes → `cocore.dev`, **excluding**
+  `/agent*`, `/api/*`, `/v1/*`, `/xrpc/*`, `/.well-known/*`, `/oauth*`.
+- Flip the ~40 hardcoded `console.cocore.dev` defaults in console routes + docs
+  to `cocore.dev`. The tray/provider defaults move on their next release; agents
+  keep working via the `console.cocore.dev` alias meanwhile.

--- a/packages/console/src/integrations/auth/cookie-domain.test.ts
+++ b/packages/console/src/integrations/auth/cookie-domain.test.ts
@@ -1,0 +1,26 @@
+// Pins the cookie-scoping rule for the cocore.dev cutover: the auth session
+// cookie must be shared across the apex and *.cocore.dev (so a login on
+// cocore.dev is also valid on console.cocore.dev), but MUST stay host-only on
+// localhost and Railway preview domains.
+
+import assert from "node:assert/strict";
+import { test } from "vitest";
+
+import { authCookieDomain } from "@/integrations/auth/cookie-domain.ts";
+
+test("cocore.dev apex + subdomains share the registrable domain", () => {
+  assert.equal(authCookieDomain("cocore.dev"), "cocore.dev");
+  assert.equal(authCookieDomain("console.cocore.dev"), "cocore.dev");
+  assert.equal(authCookieDomain("www.cocore.dev"), "cocore.dev");
+  assert.equal(authCookieDomain("cocore.dev:443"), "cocore.dev");
+  assert.equal(authCookieDomain("CONSOLE.COCORE.DEV"), "cocore.dev");
+});
+
+test("dev/preview/other hosts stay host-only (undefined)", () => {
+  assert.equal(authCookieDomain("localhost:3000"), undefined);
+  assert.equal(authCookieDomain("127.0.0.1:5599"), undefined);
+  assert.equal(authCookieDomain("console-production-de0d.up.railway.app"), undefined);
+  assert.equal(authCookieDomain("evilcocore.dev"), undefined);
+  assert.equal(authCookieDomain(null), undefined);
+  assert.equal(authCookieDomain(""), undefined);
+});

--- a/packages/console/src/integrations/auth/cookie-domain.ts
+++ b/packages/console/src/integrations/auth/cookie-domain.ts
@@ -1,0 +1,17 @@
+/** Domain attribute for the auth session cookie.
+ *
+ * Once cocore.dev is the canonical console host, a session set on cocore.dev
+ * should also be valid on console.cocore.dev (and any other *.cocore.dev the
+ * browser visits), so the cookie is scoped to the registrable domain. We only
+ * do this for cocore.dev hosts — localhost, 127.0.0.1, and Railway preview
+ * domains (*.up.railway.app) get a host-only cookie (return undefined), which
+ * is the correct, safe default for dev/preview.
+ *
+ * `host` is the request's Host (may include a :port, which we strip).
+ */
+export function authCookieDomain(host: string | null | undefined): string | undefined {
+  if (!host) return undefined;
+  const h = host.split(":")[0]?.toLowerCase() ?? "";
+  if (h === "cocore.dev" || h.endsWith(".cocore.dev")) return "cocore.dev";
+  return undefined;
+}

--- a/packages/console/src/integrations/auth/oauth-callback.server.ts
+++ b/packages/console/src/integrations/auth/oauth-callback.server.ts
@@ -4,6 +4,7 @@ import { ensureMyProfile } from "@/lib/account-profile.server.ts";
 import { issueAppSession } from "@/integrations/auth/app-session-store.server.ts";
 import { atprotoOAuthCallbackEffect } from "@/integrations/auth/atproto.server.ts";
 import { AUTH_SESSION_TOKEN_COOKIE } from "@/integrations/auth/constants.ts";
+import { authCookieDomain } from "@/integrations/auth/cookie-domain.ts";
 import { fetchBlueskyPublicProfileFieldsEffect } from "@/lib/bluesky-public-profile.server.ts";
 import { sanitizeAuthRedirectTarget } from "@/utils/auth-redirect.ts";
 
@@ -47,11 +48,13 @@ function oauthCallbackResponseEffect(request: Request): Effect.Effect<Response, 
     );
     const sessionToken = issueAppSession(did);
     const isSecure = request.url.startsWith("https://");
+    const cookieDomain = authCookieDomain(new URL(request.url).host);
     const cookieAttributes = [
       `Path=/`,
       `HttpOnly`,
       `SameSite=Lax`,
       ...(isSecure ? ["Secure"] : []),
+      ...(cookieDomain ? [`Domain=${cookieDomain}`] : []),
       `Max-Age=${30 * 24 * 60 * 60}`,
     ].join("; ");
 

--- a/packages/console/src/integrations/auth/session.functions.ts
+++ b/packages/console/src/integrations/auth/session.functions.ts
@@ -6,6 +6,7 @@ import { Effect, Either } from "effect";
 
 import { revokeAppSession } from "@/integrations/auth/app-session-store.server.ts";
 import { AUTH_SESSION_TOKEN_COOKIE } from "@/integrations/auth/constants.ts";
+import { authCookieDomain } from "@/integrations/auth/cookie-domain.ts";
 import { readAuthSessionToken } from "@/integrations/auth/cookie-parse.ts";
 import { ensureMyProfile } from "@/lib/account-profile.server.ts";
 import { deriveChatStorageKey } from "@/lib/chat-storage-key.server.ts";
@@ -78,12 +79,16 @@ const signOutServerFn = createServerFn({ method: "POST" }).handler(() =>
       }
 
       const isHttps = request.url.startsWith("https://");
+      // Must match the Domain used when the cookie was set (oauth-callback),
+      // or the browser won't clear the .cocore.dev-scoped cookie on sign-out.
+      const cookieDomain = authCookieDomain(new URL(request.url).host);
       setCookie(AUTH_SESSION_TOKEN_COOKIE, "", {
         path: "/",
         httpOnly: true,
         sameSite: "lax",
         maxAge: 0,
         ...(isHttps ? { secure: true } : {}),
+        ...(cookieDomain ? { domain: cookieDomain } : {}),
       });
 
       return { success: true } as const;


### PR DESCRIPTION
**Draft / staging — do not merge until the cocore.dev cutover.** No outage risk on its own; the canonical flip is a separate Railway env + DNS move (see the runbook).

## What's here
- **`cookie-domain.ts`** — `authCookieDomain(host)`: returns `cocore.dev` for the apex + `*.cocore.dev`, `undefined` for localhost / `*.up.railway.app` previews / anything else.
- Applied to the **login** cookie (`oauth-callback.server.ts`) and the **sign-out** clear (`session.functions.ts` — must match the set Domain or the browser won't drop it).
- **`cookie-domain.test.ts`** — pins the apex/subdomain sharing + the host-only fallback (incl. the `evilcocore.dev` suffix-trap).
- **`docs/cutover-cocore-dev.md`** — the full ordered runbook: export DO zone → build Cloudflare zone (DNS-only, incl. the critical `_atproto` handle TXT) → flip NS → Railway cert → flip `CONSOLE_PUBLIC_URL`/`PUBLIC_URL`/`BETTER_AUTH_URL` → verify → rollback.

## Why a cookie change at all
Canonical moves to `cocore.dev`, so users log in there; scoping the cookie to `.cocore.dev` keeps the session valid on `console.cocore.dev` too (which stays alive for agents). Forward-compatible — a no-op until `cocore.dev` serves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)