### PR TITLE
moves xrpc endpoints from /api/xrpc to /xrpc 

### DIFF
--- a/docs/api-keys.md
+++ b/docs/api-keys.md
@@ -10,32 +10,69 @@ The server stores only a SHA-256 hash plus a short displayable `prefix`
 (e.g. `cocore-AbCd1234`); the full secret is shown **exactly once**, at
 creation, and is unrecoverable afterward.
 
-These endpoints are served by the console at
-`https://console.cocore.dev/api/xrpc/<nsid>` and are defined by lexicons
-under `dev.cocore.account.*` (published as resolvable
-`com.atproto.lexicon.schema` records, see [`lexicons/README.md`](../lexicons/README.md)).
+The key-management methods are defined by lexicons under `dev.cocore.account.*`
+(published as resolvable `com.atproto.lexicon.schema` records, see
+[`lexicons/README.md`](../lexicons/README.md)) and are reachable two ways:
+
+- **`/xrpc/<nsid>`** — the proper AT Protocol surface, authenticated by
+  **service auth** (recommended; no bootstrapping problem). See below.
+- **`/api/xrpc/<nsid>`** — the legacy alias, authenticated by an existing
+  bearer key or the console session cookie.
 
 ## Authentication
 
-Every key-management endpoint accepts either credential:
+### Service auth (the `/xrpc/*` surface)
 
-- **`Authorization: Bearer cocore-...`** — an existing API key. This is the
-  automation path: mint one key from the console UI, then create, list,
-  revoke, and delete the rest headlessly.
+The `/xrpc/dev.cocore.account.*` endpoints authenticate **only** with an AT
+Protocol service-auth token — a short-lived JWT signed by the signing key in
+*your* DID document. You don't craft it by hand: your client asks its own PDS
+to proxy the call, and the PDS mints and attaches the JWT. With an `atproto`
+agent that's just the `atproto-proxy` header:
+
+```ts
+// agent already authenticated to the requester's PDS
+await agent.call(
+  "dev.cocore.account.listApiKeys",
+  {},
+  { headers: { "atproto-proxy": "did:web:console.cocore.dev#cocore_account" } },
+);
+```
+
+The PDS resolves the console's DID document (served at
+`https://console.cocore.dev/.well-known/did.json`), forwards the request to
+`https://console.cocore.dev/xrpc/<nsid>`, and signs a JWT whose `iss` is your
+DID, `aud` is `did:web:console.cocore.dev`, and `lxm` is the method NSID. The
+console verifies that signature against your DID document — so a valid token is
+proof you control the DID, with no shared secret. This is the recommended path:
+because you authenticate with your own identity, there's nothing to bootstrap.
+
+A missing, malformed, expired, wrong-audience, or wrong-`lxm` token returns
+`401` (`AuthRequired`, `BadJwt`, `JwtExpired`, `BadJwtAudience`,
+`BadJwtLexicon`, `BadJwtIssuer`, or `BadJwtSignature`).
+
+### Bearer key / session (the legacy `/api/xrpc/*` surface)
+
+The `/api/xrpc/dev.cocore.account.*` aliases accept either credential:
+
+- **`Authorization: Bearer cocore-...`** — an existing API key. Mint one key
+  from the console UI, then create, list, revoke, and delete the rest headlessly.
 - **Console session cookie** — what the signed-in web UI sends.
 
 The owning DID is derived from whichever credential you present, and every
 operation is scoped to that DID — you can only ever touch your own keys. A
 missing or invalid credential returns `401` with `{ "error": "AuthRequired" }`.
 
-> **Bootstrapping.** Creating your *first* key needs a credential you didn't
-> mint via the API: sign in to the console and create one key under
-> **Account → API keys**, or let `cocore agent pair` mint one for a machine.
-> After that, that key can create every subsequent key over the API.
+> **Bootstrapping.** Creating your *first* key over the bearer-key path needs a
+> credential you didn't mint via the API: sign in to the console and create one
+> key under **Account → API keys**, or let `cocore agent pair` mint one for a
+> machine. The service-auth `/xrpc/*` path above avoids this entirely.
 
 ## Endpoints
 
-Base URL: `https://console.cocore.dev/api/xrpc`
+The examples below use the legacy bearer-key base URL
+`https://console.cocore.dev/api/xrpc`. The same NSIDs, bodies, and responses
+are served at `https://console.cocore.dev/xrpc/<nsid>` under service auth —
+swap the base URL and the `Authorization` header accordingly.
 
 ### `dev.cocore.account.createApiKey` — mint a key
 

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -17,9 +17,12 @@
     "test:e2e:install": "playwright install --with-deps chromium"
   },
   "dependencies": {
+    "@atcute/crypto": "^2.4.1",
+    "@atcute/identity": "^1.1.5",
     "@atcute/identity-resolver": "^1.2.3",
     "@atcute/identity-resolver-node": "^1.0.4",
     "@atcute/lexicons": "^1.3.1",
+    "@atcute/multibase": "^1.2.0",
     "@atcute/oauth-node-client": "^1.1.1",
     "@cocore/sdk": "workspace:*",
     "@mdx-js/react": "^3.1.1",

--- a/packages/console/src/lib/account-xrpc.server.ts
+++ b/packages/console/src/lib/account-xrpc.server.ts
@@ -1,0 +1,38 @@
+// Body parsing/validation shared by the dev.cocore.account.* key
+// management routes. The service-auth-gated /xrpc/* handlers reuse these
+// so request validation stays identical across the surface.
+
+export interface CreateApiKeyInput {
+  name: string;
+  expiresAt: string | null;
+}
+
+interface CreateRawBody {
+  name?: unknown;
+  expiresAt?: unknown;
+}
+
+/** Validate a createApiKey body. Returns the parsed input, or an error
+ *  message string the caller turns into a 400. */
+export function parseCreateApiKeyBody(raw: CreateRawBody): CreateApiKeyInput | string {
+  if (typeof raw.name !== "string" || raw.name.length < 1 || raw.name.length > 100) {
+    return "name must be a string of 1–100 characters";
+  }
+  if (raw.expiresAt !== undefined && raw.expiresAt !== null && typeof raw.expiresAt !== "string") {
+    return "expiresAt must be an RFC3339 string, null, or omitted";
+  }
+  if (typeof raw.expiresAt === "string" && Number.isNaN(Date.parse(raw.expiresAt))) {
+    return "expiresAt must be a valid RFC3339 datetime";
+  }
+  return {
+    name: raw.name,
+    expiresAt: typeof raw.expiresAt === "string" ? raw.expiresAt : null,
+  };
+}
+
+/** Validate the `id` field shared by revoke/delete. Returns the id or
+ *  null when invalid. */
+export function parseApiKeyId(raw: { id?: unknown }): string | null {
+  if (typeof raw.id !== "string" || raw.id.length < 1 || raw.id.length > 200) return null;
+  return raw.id;
+}

--- a/packages/console/src/lib/cocore-config.ts
+++ b/packages/console/src/lib/cocore-config.ts
@@ -15,6 +15,11 @@ export interface CocoreConfig {
   appviewUrl: string;
   advisorUrl: string;
   exchangeDid: string;
+  /** The console's own service DID. Inbound AT Protocol service-auth
+   *  JWTs (e.g. for the dev.cocore.account.* management endpoints
+   *  reached via PDS service proxying) must carry this as their `aud`.
+   *  Its DID document is served at /.well-known/did.json. */
+  consoleDid: string;
   /** Shared secret for internal-only services endpoints (must match the
    *  services container's COCORE_INTERNAL_API_KEY). Used to countersign
    *  terms acceptances via the exchange. Empty when unset — callers that
@@ -32,5 +37,9 @@ export function cocoreConfig(): CocoreConfig {
     // override with COCORE_EXCHANGE_DID=did:web:exchange.local
     // (or whatever resolves locally).
     exchangeDid: process.env["COCORE_EXCHANGE_DID"] ?? "did:web:console.cocore.dev:exchange",
+    // Defaults to the production console DID. In local dev, override
+    // with COCORE_CONSOLE_DID=did:web:127.0.0.1%3A3000 (or whatever
+    // matches the host a requester's PDS will proxy to).
+    consoleDid: process.env["COCORE_CONSOLE_DID"] ?? "did:web:console.cocore.dev",
   };
 }

--- a/packages/console/src/lib/service-auth.server.ts
+++ b/packages/console/src/lib/service-auth.server.ts
@@ -43,11 +43,7 @@ export type ServiceAuthResult =
   | { ok: true; did: string }
   | { ok: false; status: number; error: string; message: string };
 
-function fail(
-  status: number,
-  error: string,
-  message: string,
-): ServiceAuthResult {
+function fail(status: number, error: string, message: string): ServiceAuthResult {
   return { ok: false, status, error, message };
 }
 
@@ -90,11 +86,7 @@ export async function verifyServiceAuth(
 ): Promise<ServiceAuthResult> {
   const jwt = readBearer(request);
   if (!jwt) {
-    return fail(
-      401,
-      "AuthRequired",
-      "Authorization: Bearer <service-auth jwt> required",
-    );
+    return fail(401, "AuthRequired", "Authorization: Bearer <service-auth jwt> required");
   }
 
   const parts = jwt.split(".");
@@ -111,11 +103,7 @@ export async function verifyServiceAuth(
   }
 
   if (header.alg !== "ES256" && header.alg !== "ES256K") {
-    return fail(
-      401,
-      "BadJwt",
-      "unsupported JWT alg (expected ES256 or ES256K)",
-    );
+    return fail(401, "BadJwt", "unsupported JWT alg (expected ES256 or ES256K)");
   }
 
   const { iss, aud, lxm, exp, nbf } = payload;
@@ -153,11 +141,7 @@ export async function verifyServiceAuth(
     return fail(401, "BadJwtIssuer", "could not resolve issuer DID document");
   }
   if (!material) {
-    return fail(
-      401,
-      "BadJwtIssuer",
-      "issuer DID document has no atproto signing key",
-    );
+    return fail(401, "BadJwtIssuer", "issuer DID document has no atproto signing key");
   }
 
   let verified: boolean;
@@ -171,8 +155,7 @@ export async function verifyServiceAuth(
   } catch {
     return fail(401, "BadJwtSignature", "signature verification failed");
   }
-  if (!verified)
-    return fail(401, "BadJwtSignature", "signature verification failed");
+  if (!verified) return fail(401, "BadJwtSignature", "signature verification failed");
 
   return { ok: true, did: iss };
 }

--- a/packages/console/src/lib/service-auth.server.ts
+++ b/packages/console/src/lib/service-auth.server.ts
@@ -1,0 +1,178 @@
+// AT Protocol service-auth verification for the dev.cocore.account.*
+// management XRPC endpoints served at /xrpc/*.
+//
+// These endpoints authenticate *only* via service auth: a requester's
+// client asks its own PDS to proxy the call
+// (`atproto-proxy: <consoleDid>#cocore_console`); the PDS mints a
+// short-lived JWT signed by the user's repo signing key and forwards it
+// to us as `Authorization: Bearer <jwt>`. The JWT carries:
+//
+//   iss  the requester's DID            (who we authenticate)
+//   aud  the console's service DID       (must equal cocoreConfig().consoleDid)
+//   lxm  the method NSID being called    (must equal the route's NSID)
+//   exp  expiry (unix seconds)
+//
+// We verify the signature against the key published in the issuer's DID
+// document — so a valid token *is* proof the holder controls that DID,
+// with no shared secret and no credential of ours to leak. This is the
+// proper atproto answer to "let an account manage its own API keys":
+// the account proves identity with its own signing key, then uses the
+// minted cocore-* keys for the headless inference/proxy surface.
+
+import { getPublicKeyFromDidController, verifySig } from "@atcute/crypto";
+import { getAtprotoVerificationMaterial } from "@atcute/identity";
+import {
+  CompositeDidDocumentResolver,
+  PlcDidDocumentResolver,
+  WebDidDocumentResolver,
+} from "@atcute/identity-resolver";
+import type { Did } from "@atcute/lexicons";
+import { isDid } from "@atcute/lexicons/syntax";
+import { fromBase64Url } from "@atcute/multibase";
+
+import { cocoreConfig } from "./cocore-config.ts";
+
+/** Tolerance for clock skew between the issuing PDS and us. */
+const CLOCK_SKEW_SECONDS = 30;
+
+/** Success carries the authenticated DID; failure carries everything a
+ *  handler needs to emit a `xrpcError(...)`. Distinct error codes mirror
+ *  the standard atproto auth-failure vocabulary so callers can tell an
+ *  expired token from a wrong audience. */
+export type ServiceAuthResult =
+  | { ok: true; did: string }
+  | { ok: false; status: number; error: string; message: string };
+
+function fail(
+  status: number,
+  error: string,
+  message: string,
+): ServiceAuthResult {
+  return { ok: false, status, error, message };
+}
+
+// did:plc and did:web only — matches the repo-wide DID policy. We accept
+// both DID forms the resolver knows how to fetch a document for.
+const didResolver = new CompositeDidDocumentResolver({
+  methods: {
+    plc: new PlcDidDocumentResolver(),
+    web: new WebDidDocumentResolver(),
+  },
+});
+
+function readBearer(request: Request): string | null {
+  const h = request.headers.get("authorization");
+  if (!h) return null;
+  const m = /^Bearer\s+(.+)$/i.exec(h);
+  return m ? m[1]!.trim() : null;
+}
+
+interface JwtPayload {
+  iss?: unknown;
+  aud?: unknown;
+  lxm?: unknown;
+  exp?: unknown;
+  nbf?: unknown;
+}
+
+function decodeJson(segment: string): unknown {
+  return JSON.parse(new TextDecoder().decode(fromBase64Url(segment)));
+}
+
+/** Verify the service-auth JWT on `request` and confirm it was minted
+ *  for `expectedLxm`. Returns the authenticated DID on success. Every
+ *  failure mode collapses to a 401-shaped result (success vs. each
+ *  failure isn't meaningfully distinguishable to an attacker, but the
+ *  error code aids legitimate debugging). */
+export async function verifyServiceAuth(
+  request: Request,
+  expectedLxm: string,
+): Promise<ServiceAuthResult> {
+  const jwt = readBearer(request);
+  if (!jwt) {
+    return fail(
+      401,
+      "AuthRequired",
+      "Authorization: Bearer <service-auth jwt> required",
+    );
+  }
+
+  const parts = jwt.split(".");
+  if (parts.length !== 3) return fail(401, "BadJwt", "malformed JWT");
+  const [headerB64, payloadB64, sigB64] = parts as [string, string, string];
+
+  let header: { alg?: unknown };
+  let payload: JwtPayload;
+  try {
+    header = decodeJson(headerB64) as { alg?: unknown };
+    payload = decodeJson(payloadB64) as JwtPayload;
+  } catch {
+    return fail(401, "BadJwt", "JWT header/payload not valid base64url JSON");
+  }
+
+  if (header.alg !== "ES256" && header.alg !== "ES256K") {
+    return fail(
+      401,
+      "BadJwt",
+      "unsupported JWT alg (expected ES256 or ES256K)",
+    );
+  }
+
+  const { iss, aud, lxm, exp, nbf } = payload;
+
+  if (typeof iss !== "string" || !isDid(iss)) {
+    return fail(401, "BadJwtIssuer", "iss must be a DID");
+  }
+  if (!iss.startsWith("did:plc:") && !iss.startsWith("did:web:")) {
+    return fail(401, "BadJwtIssuer", "iss must be a did:plc or did:web");
+  }
+  if (aud !== cocoreConfig().consoleDid) {
+    console.log(aud, cocoreConfig().consoleDid);
+    return fail(401, "BadJwtAudience", "aud does not match this service");
+  }
+  if (lxm !== expectedLxm) {
+    return fail(401, "BadJwtLexicon", `lxm does not match ${expectedLxm}`);
+  }
+  if (typeof exp !== "number") {
+    return fail(401, "BadJwt", "exp missing");
+  }
+  const now = Date.now() / 1000;
+  if (exp <= now - CLOCK_SKEW_SECONDS) {
+    return fail(401, "JwtExpired", "token expired");
+  }
+  if (typeof nbf === "number" && nbf > now + CLOCK_SKEW_SECONDS) {
+    return fail(401, "BadJwt", "token not yet valid");
+  }
+
+  // Resolve the issuer's DID document and pull the atproto signing key.
+  let material: { type: string; publicKeyMultibase: string } | undefined;
+  try {
+    const doc = await didResolver.resolve(iss as Did<"plc" | "web">);
+    material = getAtprotoVerificationMaterial(doc);
+  } catch {
+    return fail(401, "BadJwtIssuer", "could not resolve issuer DID document");
+  }
+  if (!material) {
+    return fail(
+      401,
+      "BadJwtIssuer",
+      "issuer DID document has no atproto signing key",
+    );
+  }
+
+  let verified: boolean;
+  try {
+    const key = getPublicKeyFromDidController(material);
+    if (key.jwtAlg !== header.alg) {
+      return fail(401, "BadJwtSignature", "JWT alg does not match issuer key");
+    }
+    const data = new TextEncoder().encode(`${headerB64}.${payloadB64}`);
+    verified = await verifySig(key, fromBase64Url(sigB64), data);
+  } catch {
+    return fail(401, "BadJwtSignature", "signature verification failed");
+  }
+  if (!verified)
+    return fail(401, "BadJwtSignature", "signature verification failed");
+
+  return { ok: true, did: iss };
+}

--- a/packages/console/src/lib/service-auth.test.ts
+++ b/packages/console/src/lib/service-auth.test.ts
@@ -1,0 +1,135 @@
+// Verifies verifyServiceAuth end-to-end against a real signature: we
+// generate a P-256 keypair (the curve a did:plc signing key commonly
+// uses), mint a JWT the way a PDS would for service proxying, and stub
+// only the DID-document resolution so the test doesn't hit the network.
+// The signature check itself runs for real via @atcute/crypto.
+
+import { P256PrivateKeyExportable } from "@atcute/crypto";
+import { toBase64Url } from "@atcute/multibase";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+// Mutable state the module mocks read. vi.hoisted keeps it valid inside
+// the hoisted vi.mock factories.
+const state = vi.hoisted(() => ({
+  material: undefined as { type: string; publicKeyMultibase: string } | undefined,
+  throwOnResolve: false,
+}));
+
+vi.mock("@atcute/identity-resolver", () => ({
+  CompositeDidDocumentResolver: class {
+    async resolve() {
+      if (state.throwOnResolve) throw new Error("resolve failed");
+      return {}; // shape irrelevant; getAtprotoVerificationMaterial is mocked
+    }
+  },
+  PlcDidDocumentResolver: class {},
+  WebDidDocumentResolver: class {},
+}));
+
+vi.mock("@atcute/identity", () => ({
+  getAtprotoVerificationMaterial: () => state.material,
+}));
+
+import { verifyServiceAuth } from "./service-auth.server.ts";
+
+const CONSOLE_DID = "did:web:console.test";
+const ISS = "did:plc:ewvi7nxzyoun6zhxrhs64oiz";
+
+function b64urlJson(obj: unknown): string {
+  return toBase64Url(new TextEncoder().encode(JSON.stringify(obj)));
+}
+
+async function mintJwt(
+  signer: P256PrivateKeyExportable,
+  payload: Record<string, unknown>,
+  alg = "ES256",
+): Promise<string> {
+  const signingInput = `${b64urlJson({ alg, typ: "JWT" })}.${b64urlJson(payload)}`;
+  const sig = await signer.sign(new TextEncoder().encode(signingInput));
+  return `${signingInput}.${toBase64Url(sig)}`;
+}
+
+function reqWith(jwt?: string): Request {
+  return new Request("https://console.test/xrpc/dev.cocore.account.listApiKeys", {
+    headers: jwt ? { authorization: `Bearer ${jwt}` } : {},
+  });
+}
+
+function freshPayload(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    iss: ISS,
+    aud: CONSOLE_DID,
+    lxm: "dev.cocore.account.listApiKeys",
+    exp: Math.floor(Date.now() / 1000) + 60,
+    ...over,
+  };
+}
+
+let keypair: P256PrivateKeyExportable;
+
+beforeEach(async () => {
+  process.env["COCORE_CONSOLE_DID"] = CONSOLE_DID;
+  keypair = await P256PrivateKeyExportable.createKeypair();
+  state.material = {
+    type: "Multikey",
+    publicKeyMultibase: await keypair.exportPublicKey("multikey"),
+  };
+  state.throwOnResolve = false;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("verifyServiceAuth", () => {
+  test("valid token resolves to the issuer DID", async () => {
+    const jwt = await mintJwt(keypair, freshPayload());
+    const res = await verifyServiceAuth(reqWith(jwt), "dev.cocore.account.listApiKeys");
+    expect(res).toEqual({ ok: true, did: ISS });
+  });
+
+  test("missing Authorization header is AuthRequired", async () => {
+    const res = await verifyServiceAuth(reqWith(), "dev.cocore.account.listApiKeys");
+    expect(res).toMatchObject({ ok: false, status: 401, error: "AuthRequired" });
+  });
+
+  test("wrong audience is rejected", async () => {
+    const jwt = await mintJwt(keypair, freshPayload({ aud: "did:web:someone-else" }));
+    const res = await verifyServiceAuth(reqWith(jwt), "dev.cocore.account.listApiKeys");
+    expect(res).toMatchObject({ ok: false, error: "BadJwtAudience" });
+  });
+
+  test("wrong lexicon method is rejected", async () => {
+    const jwt = await mintJwt(keypair, freshPayload({ lxm: "dev.cocore.account.createApiKey" }));
+    const res = await verifyServiceAuth(reqWith(jwt), "dev.cocore.account.listApiKeys");
+    expect(res).toMatchObject({ ok: false, error: "BadJwtLexicon" });
+  });
+
+  test("expired token is rejected", async () => {
+    const jwt = await mintJwt(keypair, freshPayload({ exp: Math.floor(Date.now() / 1000) - 120 }));
+    const res = await verifyServiceAuth(reqWith(jwt), "dev.cocore.account.listApiKeys");
+    expect(res).toMatchObject({ ok: false, error: "JwtExpired" });
+  });
+
+  test("signature from a different key is rejected", async () => {
+    // Sign with an attacker key but advertise the legitimate key as the
+    // resolved material — the signature must not verify.
+    const attacker = await P256PrivateKeyExportable.createKeypair();
+    const jwt = await mintJwt(attacker, freshPayload());
+    const res = await verifyServiceAuth(reqWith(jwt), "dev.cocore.account.listApiKeys");
+    expect(res).toMatchObject({ ok: false, error: "BadJwtSignature" });
+  });
+
+  test("non-plc/web issuer is rejected", async () => {
+    const jwt = await mintJwt(keypair, freshPayload({ iss: "did:example:nope" }));
+    const res = await verifyServiceAuth(reqWith(jwt), "dev.cocore.account.listApiKeys");
+    expect(res).toMatchObject({ ok: false, error: "BadJwtIssuer" });
+  });
+
+  test("unresolvable issuer DID is rejected", async () => {
+    state.throwOnResolve = true;
+    const jwt = await mintJwt(keypair, freshPayload());
+    const res = await verifyServiceAuth(reqWith(jwt), "dev.cocore.account.listApiKeys");
+    expect(res).toMatchObject({ ok: false, error: "BadJwtIssuer" });
+  });
+});

--- a/packages/console/src/routeTree.gen.ts
+++ b/packages/console/src/routeTree.gen.ts
@@ -16,6 +16,10 @@ import { Route as HeaderLayoutRouteImport } from './routes/_header-layout'
 import { Route as DocsHeaderLayoutRouteImport } from './routes/_docs-header-layout'
 import { Route as LexiconsIndexRouteImport } from './routes/lexicons.index'
 import { Route as HeaderLayoutIndexRouteImport } from './routes/_header-layout.index'
+import { Route as XrpcDevDotcocoreDotaccountDotrevokeApiKeyRouteImport } from './routes/xrpc.dev[.]cocore[.]account[.]revokeApiKey'
+import { Route as XrpcDevDotcocoreDotaccountDotlistApiKeysRouteImport } from './routes/xrpc.dev[.]cocore[.]account[.]listApiKeys'
+import { Route as XrpcDevDotcocoreDotaccountDotdeleteApiKeyRouteImport } from './routes/xrpc.dev[.]cocore[.]account[.]deleteApiKey'
+import { Route as XrpcDevDotcocoreDotaccountDotcreateApiKeyRouteImport } from './routes/xrpc.dev[.]cocore[.]account[.]createApiKey'
 import { Route as V1ModelsRouteImport } from './routes/v1.models'
 import { Route as LexiconsNsidRouteImport } from './routes/lexicons.$nsid'
 import { Route as ExchangeDidDotjsonRouteImport } from './routes/exchange.did[.]json'
@@ -38,6 +42,7 @@ import { Route as HeaderLayoutChatPreviewRouteImport } from './routes/_header-la
 import { Route as HeaderLayoutChatRouteImport } from './routes/_header-layout.chat'
 import { Route as HeaderLayoutAccountRouteImport } from './routes/_header-layout.account'
 import { Route as HeaderLayoutAcceptTermsRouteImport } from './routes/_header-layout.accept-terms'
+import { Route as DotwellKnownDidDotjsonRouteImport } from './routes/[.]well-known.did[.]json'
 import { Route as HeaderLayoutMachinesIndexRouteImport } from './routes/_header-layout.machines.index'
 import { Route as HeaderLayoutBlogIndexRouteImport } from './routes/_header-layout.blog.index'
 import { Route as DocsHeaderLayoutDocsIndexRouteImport } from './routes/_docs-header-layout.docs.index'
@@ -116,6 +121,30 @@ const HeaderLayoutIndexRoute = HeaderLayoutIndexRouteImport.update({
   path: '/',
   getParentRoute: () => HeaderLayoutRoute,
 } as any)
+const XrpcDevDotcocoreDotaccountDotrevokeApiKeyRoute =
+  XrpcDevDotcocoreDotaccountDotrevokeApiKeyRouteImport.update({
+    id: '/xrpc/dev.cocore.account.revokeApiKey',
+    path: '/xrpc/dev.cocore.account.revokeApiKey',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const XrpcDevDotcocoreDotaccountDotlistApiKeysRoute =
+  XrpcDevDotcocoreDotaccountDotlistApiKeysRouteImport.update({
+    id: '/xrpc/dev.cocore.account.listApiKeys',
+    path: '/xrpc/dev.cocore.account.listApiKeys',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const XrpcDevDotcocoreDotaccountDotdeleteApiKeyRoute =
+  XrpcDevDotcocoreDotaccountDotdeleteApiKeyRouteImport.update({
+    id: '/xrpc/dev.cocore.account.deleteApiKey',
+    path: '/xrpc/dev.cocore.account.deleteApiKey',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const XrpcDevDotcocoreDotaccountDotcreateApiKeyRoute =
+  XrpcDevDotcocoreDotaccountDotcreateApiKeyRouteImport.update({
+    id: '/xrpc/dev.cocore.account.createApiKey',
+    path: '/xrpc/dev.cocore.account.createApiKey',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const V1ModelsRoute = V1ModelsRouteImport.update({
   id: '/v1/models',
   path: '/v1/models',
@@ -225,6 +254,11 @@ const HeaderLayoutAcceptTermsRoute = HeaderLayoutAcceptTermsRouteImport.update({
   id: '/accept-terms',
   path: '/accept-terms',
   getParentRoute: () => HeaderLayoutRoute,
+} as any)
+const DotwellKnownDidDotjsonRoute = DotwellKnownDidDotjsonRouteImport.update({
+  id: '/.well-known/did.json',
+  path: '/.well-known/did.json',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const HeaderLayoutMachinesIndexRoute =
   HeaderLayoutMachinesIndexRouteImport.update({
@@ -480,6 +514,7 @@ export interface FileRoutesByFullPath {
   '/agent': typeof AgentRouteWithChildren
   '/login': typeof LoginRoute
   '/og.png': typeof OgDotpngRoute
+  '/.well-known/did.json': typeof DotwellKnownDidDotjsonRoute
   '/accept-terms': typeof HeaderLayoutAcceptTermsRoute
   '/account': typeof HeaderLayoutAccountRoute
   '/chat': typeof HeaderLayoutChatRoute
@@ -502,6 +537,10 @@ export interface FileRoutesByFullPath {
   '/exchange/did.json': typeof ExchangeDidDotjsonRoute
   '/lexicons/$nsid': typeof LexiconsNsidRoute
   '/v1/models': typeof V1ModelsRoute
+  '/xrpc/dev.cocore.account.createApiKey': typeof XrpcDevDotcocoreDotaccountDotcreateApiKeyRoute
+  '/xrpc/dev.cocore.account.deleteApiKey': typeof XrpcDevDotcocoreDotaccountDotdeleteApiKeyRoute
+  '/xrpc/dev.cocore.account.listApiKeys': typeof XrpcDevDotcocoreDotaccountDotlistApiKeysRoute
+  '/xrpc/dev.cocore.account.revokeApiKey': typeof XrpcDevDotcocoreDotaccountDotrevokeApiKeyRoute
   '/lexicons/': typeof LexiconsIndexRoute
   '/docs/api': typeof DocsHeaderLayoutDocsApiRoute
   '/docs/inference': typeof DocsHeaderLayoutDocsInferenceRouteWithChildren
@@ -553,6 +592,7 @@ export interface FileRoutesByTo {
   '/agent': typeof AgentRouteWithChildren
   '/login': typeof LoginRoute
   '/og.png': typeof OgDotpngRoute
+  '/.well-known/did.json': typeof DotwellKnownDidDotjsonRoute
   '/accept-terms': typeof HeaderLayoutAcceptTermsRoute
   '/account': typeof HeaderLayoutAccountRoute
   '/chat': typeof HeaderLayoutChatRoute
@@ -575,6 +615,10 @@ export interface FileRoutesByTo {
   '/exchange/did.json': typeof ExchangeDidDotjsonRoute
   '/lexicons/$nsid': typeof LexiconsNsidRoute
   '/v1/models': typeof V1ModelsRoute
+  '/xrpc/dev.cocore.account.createApiKey': typeof XrpcDevDotcocoreDotaccountDotcreateApiKeyRoute
+  '/xrpc/dev.cocore.account.deleteApiKey': typeof XrpcDevDotcocoreDotaccountDotdeleteApiKeyRoute
+  '/xrpc/dev.cocore.account.listApiKeys': typeof XrpcDevDotcocoreDotaccountDotlistApiKeysRoute
+  '/xrpc/dev.cocore.account.revokeApiKey': typeof XrpcDevDotcocoreDotaccountDotrevokeApiKeyRoute
   '/lexicons': typeof LexiconsIndexRoute
   '/docs/api': typeof DocsHeaderLayoutDocsApiRoute
   '/docs/lexicons': typeof DocsHeaderLayoutDocsLexiconsRoute
@@ -627,6 +671,7 @@ export interface FileRoutesById {
   '/agent': typeof AgentRouteWithChildren
   '/login': typeof LoginRoute
   '/og.png': typeof OgDotpngRoute
+  '/.well-known/did.json': typeof DotwellKnownDidDotjsonRoute
   '/_header-layout/accept-terms': typeof HeaderLayoutAcceptTermsRoute
   '/_header-layout/account': typeof HeaderLayoutAccountRoute
   '/_header-layout/chat': typeof HeaderLayoutChatRoute
@@ -649,6 +694,10 @@ export interface FileRoutesById {
   '/exchange/did.json': typeof ExchangeDidDotjsonRoute
   '/lexicons/$nsid': typeof LexiconsNsidRoute
   '/v1/models': typeof V1ModelsRoute
+  '/xrpc/dev.cocore.account.createApiKey': typeof XrpcDevDotcocoreDotaccountDotcreateApiKeyRoute
+  '/xrpc/dev.cocore.account.deleteApiKey': typeof XrpcDevDotcocoreDotaccountDotdeleteApiKeyRoute
+  '/xrpc/dev.cocore.account.listApiKeys': typeof XrpcDevDotcocoreDotaccountDotlistApiKeysRoute
+  '/xrpc/dev.cocore.account.revokeApiKey': typeof XrpcDevDotcocoreDotaccountDotrevokeApiKeyRoute
   '/_header-layout/': typeof HeaderLayoutIndexRoute
   '/lexicons/': typeof LexiconsIndexRoute
   '/_docs-header-layout/docs/api': typeof DocsHeaderLayoutDocsApiRoute
@@ -703,6 +752,7 @@ export interface FileRouteTypes {
     | '/agent'
     | '/login'
     | '/og.png'
+    | '/.well-known/did.json'
     | '/accept-terms'
     | '/account'
     | '/chat'
@@ -725,6 +775,10 @@ export interface FileRouteTypes {
     | '/exchange/did.json'
     | '/lexicons/$nsid'
     | '/v1/models'
+    | '/xrpc/dev.cocore.account.createApiKey'
+    | '/xrpc/dev.cocore.account.deleteApiKey'
+    | '/xrpc/dev.cocore.account.listApiKeys'
+    | '/xrpc/dev.cocore.account.revokeApiKey'
     | '/lexicons/'
     | '/docs/api'
     | '/docs/inference'
@@ -776,6 +830,7 @@ export interface FileRouteTypes {
     | '/agent'
     | '/login'
     | '/og.png'
+    | '/.well-known/did.json'
     | '/accept-terms'
     | '/account'
     | '/chat'
@@ -798,6 +853,10 @@ export interface FileRouteTypes {
     | '/exchange/did.json'
     | '/lexicons/$nsid'
     | '/v1/models'
+    | '/xrpc/dev.cocore.account.createApiKey'
+    | '/xrpc/dev.cocore.account.deleteApiKey'
+    | '/xrpc/dev.cocore.account.listApiKeys'
+    | '/xrpc/dev.cocore.account.revokeApiKey'
     | '/lexicons'
     | '/docs/api'
     | '/docs/lexicons'
@@ -849,6 +908,7 @@ export interface FileRouteTypes {
     | '/agent'
     | '/login'
     | '/og.png'
+    | '/.well-known/did.json'
     | '/_header-layout/accept-terms'
     | '/_header-layout/account'
     | '/_header-layout/chat'
@@ -871,6 +931,10 @@ export interface FileRouteTypes {
     | '/exchange/did.json'
     | '/lexicons/$nsid'
     | '/v1/models'
+    | '/xrpc/dev.cocore.account.createApiKey'
+    | '/xrpc/dev.cocore.account.deleteApiKey'
+    | '/xrpc/dev.cocore.account.listApiKeys'
+    | '/xrpc/dev.cocore.account.revokeApiKey'
     | '/_header-layout/'
     | '/lexicons/'
     | '/_docs-header-layout/docs/api'
@@ -925,9 +989,14 @@ export interface RootRouteChildren {
   AgentRoute: typeof AgentRouteWithChildren
   LoginRoute: typeof LoginRoute
   OgDotpngRoute: typeof OgDotpngRoute
+  DotwellKnownDidDotjsonRoute: typeof DotwellKnownDidDotjsonRoute
   ExchangeDidDotjsonRoute: typeof ExchangeDidDotjsonRoute
   LexiconsNsidRoute: typeof LexiconsNsidRoute
   V1ModelsRoute: typeof V1ModelsRoute
+  XrpcDevDotcocoreDotaccountDotcreateApiKeyRoute: typeof XrpcDevDotcocoreDotaccountDotcreateApiKeyRoute
+  XrpcDevDotcocoreDotaccountDotdeleteApiKeyRoute: typeof XrpcDevDotcocoreDotaccountDotdeleteApiKeyRoute
+  XrpcDevDotcocoreDotaccountDotlistApiKeysRoute: typeof XrpcDevDotcocoreDotaccountDotlistApiKeysRoute
+  XrpcDevDotcocoreDotaccountDotrevokeApiKeyRoute: typeof XrpcDevDotcocoreDotaccountDotrevokeApiKeyRoute
   LexiconsIndexRoute: typeof LexiconsIndexRoute
   ApiAgentBugReportRoute: typeof ApiAgentBugReportRoute
   ApiAgentHealthRoute: typeof ApiAgentHealthRoute
@@ -1011,6 +1080,34 @@ declare module '@tanstack/react-router' {
       fullPath: '/'
       preLoaderRoute: typeof HeaderLayoutIndexRouteImport
       parentRoute: typeof HeaderLayoutRoute
+    }
+    '/xrpc/dev.cocore.account.revokeApiKey': {
+      id: '/xrpc/dev.cocore.account.revokeApiKey'
+      path: '/xrpc/dev.cocore.account.revokeApiKey'
+      fullPath: '/xrpc/dev.cocore.account.revokeApiKey'
+      preLoaderRoute: typeof XrpcDevDotcocoreDotaccountDotrevokeApiKeyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/xrpc/dev.cocore.account.listApiKeys': {
+      id: '/xrpc/dev.cocore.account.listApiKeys'
+      path: '/xrpc/dev.cocore.account.listApiKeys'
+      fullPath: '/xrpc/dev.cocore.account.listApiKeys'
+      preLoaderRoute: typeof XrpcDevDotcocoreDotaccountDotlistApiKeysRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/xrpc/dev.cocore.account.deleteApiKey': {
+      id: '/xrpc/dev.cocore.account.deleteApiKey'
+      path: '/xrpc/dev.cocore.account.deleteApiKey'
+      fullPath: '/xrpc/dev.cocore.account.deleteApiKey'
+      preLoaderRoute: typeof XrpcDevDotcocoreDotaccountDotdeleteApiKeyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/xrpc/dev.cocore.account.createApiKey': {
+      id: '/xrpc/dev.cocore.account.createApiKey'
+      path: '/xrpc/dev.cocore.account.createApiKey'
+      fullPath: '/xrpc/dev.cocore.account.createApiKey'
+      preLoaderRoute: typeof XrpcDevDotcocoreDotaccountDotcreateApiKeyRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/v1/models': {
       id: '/v1/models'
@@ -1165,6 +1262,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/accept-terms'
       preLoaderRoute: typeof HeaderLayoutAcceptTermsRouteImport
       parentRoute: typeof HeaderLayoutRoute
+    }
+    '/.well-known/did.json': {
+      id: '/.well-known/did.json'
+      path: '/.well-known/did.json'
+      fullPath: '/.well-known/did.json'
+      preLoaderRoute: typeof DotwellKnownDidDotjsonRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/_header-layout/machines/': {
       id: '/_header-layout/machines/'
@@ -1594,9 +1698,18 @@ const rootRouteChildren: RootRouteChildren = {
   AgentRoute: AgentRouteWithChildren,
   LoginRoute: LoginRoute,
   OgDotpngRoute: OgDotpngRoute,
+  DotwellKnownDidDotjsonRoute: DotwellKnownDidDotjsonRoute,
   ExchangeDidDotjsonRoute: ExchangeDidDotjsonRoute,
   LexiconsNsidRoute: LexiconsNsidRoute,
   V1ModelsRoute: V1ModelsRoute,
+  XrpcDevDotcocoreDotaccountDotcreateApiKeyRoute:
+    XrpcDevDotcocoreDotaccountDotcreateApiKeyRoute,
+  XrpcDevDotcocoreDotaccountDotdeleteApiKeyRoute:
+    XrpcDevDotcocoreDotaccountDotdeleteApiKeyRoute,
+  XrpcDevDotcocoreDotaccountDotlistApiKeysRoute:
+    XrpcDevDotcocoreDotaccountDotlistApiKeysRoute,
+  XrpcDevDotcocoreDotaccountDotrevokeApiKeyRoute:
+    XrpcDevDotcocoreDotaccountDotrevokeApiKeyRoute,
   LexiconsIndexRoute: LexiconsIndexRoute,
   ApiAgentBugReportRoute: ApiAgentBugReportRoute,
   ApiAgentHealthRoute: ApiAgentHealthRoute,

--- a/packages/console/src/routes/[.]well-known.did[.]json.ts
+++ b/packages/console/src/routes/[.]well-known.did[.]json.ts
@@ -1,0 +1,63 @@
+// GET /.well-known/did.json
+//
+// did:web DID document for the cocore console itself. Publishing it is
+// what lets a requester's PDS reach our XRPC surface via service
+// proxying: the client sends `atproto-proxy: <consoleDid>#cocore_console`
+// to its own PDS, the PDS resolves this document, finds the matching
+// service entry, mints a JWT signed by the user's repo key, and POSTs
+// to `<serviceEndpoint>/xrpc/<nsid>`. We verify that JWT in
+// service-auth.server.ts (the `aud` must equal this document's `id`).
+//
+// did:web:<host> (no path) resolves to https://<host>/.well-known/did.json,
+// so the `id` is derived from CONSOLE_PUBLIC_URL and MUST match the host
+// the resolver hit. The exchange's document (see exchange.did[.]json.ts)
+// is the path-form sibling (did:web:<host>:exchange).
+//
+// No verificationMethod block: the console doesn't sign anything with
+// this DID, it only *verifies* inbound JWTs (whose signing keys live in
+// the requester's DID document, not ours).
+
+import { createFileRoute } from "@tanstack/react-router";
+
+function consoleDidFor(request: Request): string {
+  const explicit = process.env["CONSOLE_PUBLIC_URL"];
+  const url = explicit ?? request.url;
+  const host = new URL(url).host;
+  // host with `:port` becomes `%3Aport` per did:web spec.
+  const encoded = host.replace(":", "%3A");
+  return `did:web:${encoded}`;
+}
+
+export const Route = createFileRoute("/.well-known/did.json")({
+  server: {
+    handlers: {
+      GET: ({ request }) => {
+        const did = consoleDidFor(request);
+        const baseUrl =
+          process.env["CONSOLE_PUBLIC_URL"]?.replace(/\/$/, "") ??
+          new URL(request.url).origin;
+
+        const doc = {
+          id: did,
+          // The fragment a client names in `atproto-proxy`. The PDS
+          // appends `/xrpc/<nsid>` to serviceEndpoint, so our account
+          // endpoints live at <baseUrl>/xrpc/dev.cocore.account.*.
+          service: [
+            {
+              id: "#cocore_console",
+              type: "CocoreConsole",
+              serviceEndpoint: baseUrl,
+            },
+          ],
+        };
+        return new Response(JSON.stringify(doc), {
+          status: 200,
+          headers: {
+            "content-type": "application/did+json",
+            "cache-control": "public, max-age=300",
+          },
+        });
+      },
+    },
+  },
+});

--- a/packages/console/src/routes/[.]well-known.did[.]json.ts
+++ b/packages/console/src/routes/[.]well-known.did[.]json.ts
@@ -34,8 +34,7 @@ export const Route = createFileRoute("/.well-known/did.json")({
       GET: ({ request }) => {
         const did = consoleDidFor(request);
         const baseUrl =
-          process.env["CONSOLE_PUBLIC_URL"]?.replace(/\/$/, "") ??
-          new URL(request.url).origin;
+          process.env["CONSOLE_PUBLIC_URL"]?.replace(/\/$/, "") ?? new URL(request.url).origin;
 
         const doc = {
           id: did,

--- a/packages/console/src/routes/xrpc.dev[.]cocore[.]account[.]createApiKey.ts
+++ b/packages/console/src/routes/xrpc.dev[.]cocore[.]account[.]createApiKey.ts
@@ -37,18 +37,14 @@ export const Route = createFileRoute("/xrpc/dev.cocore.account.createApiKey")({
           return xrpcError(400, "InvalidRequest", "body must be JSON");
         }
         const parsed = parseCreateApiKeyBody(raw as Record<string, unknown>);
-        if (typeof parsed === "string")
-          return xrpcError(400, "InvalidRequest", parsed);
+        if (typeof parsed === "string") return xrpcError(400, "InvalidRequest", parsed);
 
         const created = createKey({
           did: auth.did,
           name: parsed.name,
           expiresAt: parsed.expiresAt,
         });
-        return xrpcJson(
-          { key: apiKeyView(created.key), secret: created.secret },
-          200,
-        );
+        return xrpcJson({ key: apiKeyView(created.key), secret: created.secret }, 200);
       },
     },
   },

--- a/packages/console/src/routes/xrpc.dev[.]cocore[.]account[.]createApiKey.ts
+++ b/packages/console/src/routes/xrpc.dev[.]cocore[.]account[.]createApiKey.ts
@@ -1,0 +1,55 @@
+// POST /xrpc/dev.cocore.account.createApiKey
+//
+// Mint a new cocore API key for the authenticated account and return the
+// full secret exactly once. Authenticated via AT Protocol service auth:
+// the caller proxies the request through its own PDS
+// (`atproto-proxy: <consoleDid>#cocore_console`), which signs a JWT with
+// the account's repo key. See service-auth.server.ts.
+//
+// The /api/xrpc/dev.cocore.account.createApiKey route is the legacy
+// alias (session cookie / bearer key); this is the proper atproto path.
+//
+// Body:    { name: string, expiresAt?: string | null }
+// Returns: 200 { key: apiKeyView, secret } | 400 | 401
+//
+// Lexicon: dev.cocore.account.createApiKey
+
+import { createFileRoute } from "@tanstack/react-router";
+
+import { parseCreateApiKeyBody } from "@/lib/account-xrpc.server.ts";
+import { createKey } from "@/lib/api-keys.server.ts";
+import { verifyServiceAuth } from "@/lib/service-auth.server.ts";
+import { apiKeyView, xrpcError, xrpcJson } from "@/lib/xrpc-key-auth.server.ts";
+
+const LXM = "dev.cocore.account.createApiKey";
+
+export const Route = createFileRoute("/xrpc/dev.cocore.account.createApiKey")({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        const auth = await verifyServiceAuth(request, LXM);
+        if (!auth.ok) return xrpcError(auth.status, auth.error, auth.message);
+
+        let raw: unknown;
+        try {
+          raw = await request.json();
+        } catch {
+          return xrpcError(400, "InvalidRequest", "body must be JSON");
+        }
+        const parsed = parseCreateApiKeyBody(raw as Record<string, unknown>);
+        if (typeof parsed === "string")
+          return xrpcError(400, "InvalidRequest", parsed);
+
+        const created = createKey({
+          did: auth.did,
+          name: parsed.name,
+          expiresAt: parsed.expiresAt,
+        });
+        return xrpcJson(
+          { key: apiKeyView(created.key), secret: created.secret },
+          200,
+        );
+      },
+    },
+  },
+});

--- a/packages/console/src/routes/xrpc.dev[.]cocore[.]account[.]deleteApiKey.ts
+++ b/packages/console/src/routes/xrpc.dev[.]cocore[.]account[.]deleteApiKey.ts
@@ -1,0 +1,46 @@
+// POST /xrpc/dev.cocore.account.deleteApiKey
+//
+// Hard-delete one of the authenticated account's API keys, removing the
+// row entirely (no audit-trail recovery). Prefer revokeApiKey for most
+// flows; use this to clean up revoked or expired keys. Scoped to the
+// caller's DID, which comes from a verified AT Protocol service-auth JWT
+// (see service-auth.server.ts).
+//
+// The /api/xrpc/dev.cocore.account.deleteApiKey route is the legacy alias.
+//
+// Body:    { id: string }
+// Returns: 200 { deleted: boolean } | 400 | 401
+//
+// Lexicon: dev.cocore.account.deleteApiKey
+
+import { createFileRoute } from "@tanstack/react-router";
+
+import { parseApiKeyId } from "@/lib/account-xrpc.server.ts";
+import { deleteKey } from "@/lib/api-keys.server.ts";
+import { verifyServiceAuth } from "@/lib/service-auth.server.ts";
+import { xrpcError, xrpcJson } from "@/lib/xrpc-key-auth.server.ts";
+
+const LXM = "dev.cocore.account.deleteApiKey";
+
+export const Route = createFileRoute("/xrpc/dev.cocore.account.deleteApiKey")({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        const auth = await verifyServiceAuth(request, LXM);
+        if (!auth.ok) return xrpcError(auth.status, auth.error, auth.message);
+
+        let raw: unknown;
+        try {
+          raw = await request.json();
+        } catch {
+          return xrpcError(400, "InvalidRequest", "body must be JSON");
+        }
+        const id = parseApiKeyId(raw as Record<string, unknown>);
+        if (id === null) return xrpcError(400, "InvalidRequest", "id must be a 1–200 char string");
+
+        const deleted = deleteKey({ id, did: auth.did });
+        return xrpcJson({ deleted }, 200);
+      },
+    },
+  },
+});

--- a/packages/console/src/routes/xrpc.dev[.]cocore[.]account[.]listApiKeys.ts
+++ b/packages/console/src/routes/xrpc.dev[.]cocore[.]account[.]listApiKeys.ts
@@ -1,0 +1,34 @@
+// GET /xrpc/dev.cocore.account.listApiKeys
+//
+// List every API key owned by the authenticated account, newest first.
+// The owning DID comes from a verified AT Protocol service-auth JWT (see
+// service-auth.server.ts); there is no parameter to list another
+// account's keys. Secrets are never returned.
+//
+// The /api/xrpc/dev.cocore.account.listApiKeys route is the legacy alias.
+//
+// Returns: 200 { keys: apiKeyView[] } | 401
+//
+// Lexicon: dev.cocore.account.listApiKeys
+
+import { createFileRoute } from "@tanstack/react-router";
+
+import { listKeysForDid } from "@/lib/api-keys.server.ts";
+import { verifyServiceAuth } from "@/lib/service-auth.server.ts";
+import { apiKeyView, xrpcError, xrpcJson } from "@/lib/xrpc-key-auth.server.ts";
+
+const LXM = "dev.cocore.account.listApiKeys";
+
+export const Route = createFileRoute("/xrpc/dev.cocore.account.listApiKeys")({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const auth = await verifyServiceAuth(request, LXM);
+        if (!auth.ok) return xrpcError(auth.status, auth.error, auth.message);
+
+        const keys = listKeysForDid(auth.did).map(apiKeyView);
+        return xrpcJson({ keys }, 200);
+      },
+    },
+  },
+});

--- a/packages/console/src/routes/xrpc.dev[.]cocore[.]account[.]revokeApiKey.ts
+++ b/packages/console/src/routes/xrpc.dev[.]cocore[.]account[.]revokeApiKey.ts
@@ -1,0 +1,46 @@
+// POST /xrpc/dev.cocore.account.revokeApiKey
+//
+// Revoke one of the authenticated account's API keys. The key stops
+// authenticating immediately; the row survives with `revokedAt` set so
+// it stays visible in listApiKeys for audit. Scoped to the caller's DID,
+// which comes from a verified AT Protocol service-auth JWT (see
+// service-auth.server.ts).
+//
+// The /api/xrpc/dev.cocore.account.revokeApiKey route is the legacy alias.
+//
+// Body:    { id: string }
+// Returns: 200 { revoked: boolean } | 400 | 401
+//
+// Lexicon: dev.cocore.account.revokeApiKey
+
+import { createFileRoute } from "@tanstack/react-router";
+
+import { parseApiKeyId } from "@/lib/account-xrpc.server.ts";
+import { revokeKey } from "@/lib/api-keys.server.ts";
+import { verifyServiceAuth } from "@/lib/service-auth.server.ts";
+import { xrpcError, xrpcJson } from "@/lib/xrpc-key-auth.server.ts";
+
+const LXM = "dev.cocore.account.revokeApiKey";
+
+export const Route = createFileRoute("/xrpc/dev.cocore.account.revokeApiKey")({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        const auth = await verifyServiceAuth(request, LXM);
+        if (!auth.ok) return xrpcError(auth.status, auth.error, auth.message);
+
+        let raw: unknown;
+        try {
+          raw = await request.json();
+        } catch {
+          return xrpcError(400, "InvalidRequest", "body must be JSON");
+        }
+        const id = parseApiKeyId(raw as Record<string, unknown>);
+        if (id === null) return xrpcError(400, "InvalidRequest", "id must be a 1–200 char string");
+
+        const revoked = revokeKey({ id, did: auth.did });
+        return xrpcJson({ revoked }, 200);
+      },
+    },
+  },
+});

--- a/packages/console/vite.config.ts
+++ b/packages/console/vite.config.ts
@@ -32,6 +32,7 @@ export default mergeConfig(
       allowedHosts: [
         ".cocore.dev",
         ".railway.app",
+        "app.modelo.social",
         ...(process.env["CONSOLE_ALLOWED_HOSTS"]
           ?.split(",")
           .map((s) => s.trim())

--- a/packages/console/vite.config.ts
+++ b/packages/console/vite.config.ts
@@ -32,7 +32,6 @@ export default mergeConfig(
       allowedHosts: [
         ".cocore.dev",
         ".railway.app",
-        "app.modelo.social",
         ...(process.env["CONSOLE_ALLOWED_HOSTS"]
           ?.split(",")
           .map((s) => s.trim())

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,28 +5,24 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  vite: 8.0.11
+  better-sqlite3: ^11.10.0
 
 importers:
 
   .:
-    dependencies:
-      eslint:
-        specifier: ^8.57.0 || ^9.0.0 || ^10.0.0
-        version: 10.3.0(jiti@2.7.0)
     devDependencies:
       '@cocore/sdk':
         specifier: workspace:*
-        version: 0.1.0
+        version: link:packages/sdk
       '@tanstack/eslint-plugin-router':
         specifier: ^1.161.6
-        version: 1.161.6(eslint@10.3.0(jiti@2.7.0))
+        version: 1.161.6(eslint@10.3.0(jiti@2.7.0))(typescript@5.9.3)
       hip-ui:
         specifier: ^0.3.0
-        version: 0.3.0
+        version: 0.3.0(@types/react@19.2.14)(react@19.2.6)(typescript@5.9.3)
       knip:
         specifier: ^6.12.2
-        version: 6.12.2
+        version: 6.12.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.1)
       oxfmt:
         specifier: ^0.48.0
         version: 0.48.0
@@ -38,10 +34,7 @@ importers:
     dependencies:
       '@cocore/sdk':
         specifier: workspace:*
-        version: 0.1.0
-      '@types/debug':
-        specifier: ^4.1.12
-        version: 4.1.13
+        version: link:../../packages/sdk
       ws:
         specifier: ^8.18.0
         version: 8.20.0
@@ -57,13 +50,13 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.18)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.18)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
 
   infra/mock-provider:
     dependencies:
       '@cocore/sdk':
         specifier: workspace:*
-        version: 0.1.0
+        version: link:../../packages/sdk
     devDependencies:
       '@types/node':
         specifier: ^22.5.0
@@ -76,18 +69,15 @@ importers:
     dependencies:
       '@cocore/appview':
         specifier: workspace:*
-        version: 0.1.0
+        version: link:../../packages/appview
       '@cocore/exchange':
         specifier: workspace:*
-        version: 0.1.0
+        version: link:../../packages/exchange
       '@cocore/sdk':
         specifier: workspace:*
-        version: 0.1.0
-      '@types/debug':
-        specifier: ^4.1.12
-        version: 4.1.13
+        version: link:../../packages/sdk
       better-sqlite3:
-        specifier: ^11.5.0
+        specifier: ^11.10.0
         version: 11.10.0
     devDependencies:
       '@types/better-sqlite3':
@@ -101,7 +91,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.18)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.18)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
 
   packages/appview:
     dependencies:
@@ -113,12 +103,9 @@ importers:
         version: 0.2.2
       '@cocore/sdk':
         specifier: workspace:*
-        version: 0.1.0
-      '@types/debug':
-        specifier: ^4.1.12
-        version: 4.1.13
+        version: link:../sdk
       better-sqlite3:
-        specifier: ^11.5.0
+        specifier: ^11.10.0
         version: 11.10.0
     devDependencies:
       '@atproto/api':
@@ -138,28 +125,34 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.18)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.18)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
 
   packages/console:
     dependencies:
+      '@atcute/crypto':
+        specifier: ^2.4.1
+        version: 2.4.1
       '@atcute/identity':
-        specifier: ^1.0.0
+        specifier: ^1.1.5
         version: 1.1.5(@atcute/lexicons@1.3.1)
       '@atcute/identity-resolver':
         specifier: ^1.2.3
         version: 1.2.3(@atcute/identity@1.1.5(@atcute/lexicons@1.3.1))(@atcute/lexicons@1.3.1)
       '@atcute/identity-resolver-node':
         specifier: ^1.0.4
-        version: 1.0.4(@atcute/identity@1.1.5(@atcute/lexicons@1.3.1))(@atcute/identity-resolver@1.2.3(@atcute/identity@1.1.5(@atcute/lexicons@1.3.1))(@atcute/lexicons@1.3.1))(@atcute/lexicons@1.3.1)
+        version: 1.0.4(@atcute/identity-resolver@1.2.3(@atcute/identity@1.1.5(@atcute/lexicons@1.3.1))(@atcute/lexicons@1.3.1))(@atcute/identity@1.1.5(@atcute/lexicons@1.3.1))(@atcute/lexicons@1.3.1)
       '@atcute/lexicons':
         specifier: ^1.3.1
         version: 1.3.1
+      '@atcute/multibase':
+        specifier: ^1.2.0
+        version: 1.2.0
       '@atcute/oauth-node-client':
         specifier: ^1.1.1
-        version: 1.1.1(@atcute/identity-resolver@1.2.3(@atcute/identity@1.1.5(@atcute/lexicons@1.3.1))(@atcute/lexicons@1.3.1))(@atcute/lexicons@1.3.1)
+        version: 1.1.1(@atcute/identity-resolver@1.2.3(@atcute/identity@1.1.5(@atcute/lexicons@1.3.1))(@atcute/lexicons@1.3.1))(@atcute/lexicons@1.3.1)(typescript@5.9.3)
       '@cocore/sdk':
         specifier: workspace:*
-        version: 0.1.0
+        version: link:../sdk
       '@mdx-js/react':
         specifier: ^3.1.1
         version: 3.1.1(@types/react@19.2.14)(react@19.2.6)
@@ -168,51 +161,42 @@ importers:
         version: 3.1.1(rollup@4.60.3)
       '@origin-space/image-cropper':
         specifier: ^0.1.9
-        version: 0.1.9(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+        version: 0.1.9(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/overlays':
         specifier: ^3.32.0
-        version: 3.32.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+        version: 3.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/utils':
         specifier: ^3.34.0
-        version: 3.34.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
-      '@react-spectrum/provider':
-        specifier: ^3.0.0
-        version: 3.11.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+        version: 3.34.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-stately/utils':
         specifier: ^3.12.0
-        version: 3.12.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+        version: 3.12.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-types/overlays':
         specifier: ^3.10.0
-        version: 3.10.0(@react-spectrum/provider@3.11.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6)))(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+        version: 3.10.0(@react-spectrum/provider@3.11.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@resvg/resvg-js':
         specifier: ^2.6.2
         version: 2.6.2
       '@stylexjs/stylex':
         specifier: ^0.18.3
         version: 0.18.3
-      '@tanstack/query-core':
-        specifier: '>=5.90.0'
-        version: 5.100.9
       '@tanstack/react-query':
         specifier: ^5.100.9
         version: 5.100.9(react@19.2.6)
       '@tanstack/react-router':
         specifier: ^1.169.2
-        version: 1.169.2(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+        version: 1.169.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/react-router-ssr-query':
         specifier: ^1.166.12
-        version: 1.166.12(@tanstack/query-core@5.100.9)(@tanstack/react-query@5.100.9(react@19.2.6))(@tanstack/react-router@1.169.2(react@19.2.6)(react-dom@19.2.6(react@19.2.6)))(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+        version: 1.166.12(@tanstack/query-core@5.100.9)(@tanstack/react-query@5.100.9(react@19.2.6))(@tanstack/react-router@1.169.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@tanstack/router-core@1.169.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/react-start':
         specifier: ^1.167.65
-        version: 1.167.65(react@19.2.6)(react-dom@19.2.6(react@19.2.6))(vite@8.0.11(@types/node@22.19.18)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.4))
-      '@types/debug':
-        specifier: ^4.1.12
-        version: 4.1.13
+        version: 1.167.65(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@22.19.18)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.4))
       '@window-splitter/react':
         specifier: ^1.1.3
-        version: 1.1.3(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+        version: 1.1.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       better-sqlite3:
-        specifier: ^11.5.0
+        specifier: ^11.10.0
         version: 11.10.0
       dedent:
         specifier: ^1.7.2
@@ -220,30 +204,24 @@ importers:
       effect:
         specifier: ^3.21.2
         version: 3.21.2
-      esbuild:
-        specifier: ^0.27.0 || ^0.28.0
-        version: 0.27.7
       hip-ui:
         specifier: ^0.3.0
-        version: 0.3.0
-      jiti:
-        specifier: '>=1.21.0'
-        version: 2.7.0
+        version: 0.3.0(@types/react@19.2.14)(react@19.2.6)(typescript@5.9.3)
       lucide-react:
         specifier: ^0.548.0
         version: 0.548.0(react@19.2.6)
       media-chrome:
         specifier: ^4.19.0
-        version: 4.19.0
+        version: 4.19.0(react@19.2.6)
       react:
         specifier: ^19.0.0
         version: 19.2.6
       react-aria:
         specifier: ^3.48.0
-        version: 3.48.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+        version: 3.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-aria-components:
         specifier: ^1.17.0
-        version: 1.17.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+        version: 1.17.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom:
         specifier: ^19.0.0
         version: 19.2.6(react@19.2.6)
@@ -268,9 +246,6 @@ importers:
       remark-mdx-frontmatter:
         specifier: ^5.2.0
         version: 5.2.0
-      rollup:
-        specifier: '>=2'
-        version: 4.60.3
       satori:
         specifier: ^0.26.0
         version: 0.26.0
@@ -280,15 +255,9 @@ importers:
       tweetnacl:
         specifier: ^1.0.3
         version: 1.0.3
-      unplugin:
-        specifier: ^2.3.11
-        version: 3.0.0
       web-haptics:
         specifier: ^0.0.6
-        version: 0.0.6(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
-      yaml:
-        specifier: ^2.4.2
-        version: 2.8.4
+        version: 0.0.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -334,18 +303,15 @@ importers:
         version: 8.0.11(@types/node@22.19.18)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.4)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.18)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.18)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
 
   packages/exchange:
     dependencies:
       '@cocore/sdk':
         specifier: workspace:*
-        version: 0.1.0
-      '@types/debug':
-        specifier: ^4.1.12
-        version: 4.1.13
+        version: link:../sdk
       better-sqlite3:
-        specifier: ^11.5.0
+        specifier: ^11.10.0
         version: 11.10.0
     devDependencies:
       '@types/better-sqlite3':
@@ -359,16 +325,13 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.18)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.18)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
 
   packages/sdk:
     dependencies:
       '@atproto/lexicon':
         specifier: ^0.5.2
         version: 0.5.2
-      '@types/debug':
-        specifier: ^4.1.12
-        version: 4.1.13
     devDependencies:
       '@types/node':
         specifier: ^22.5.0
@@ -378,7 +341,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.18)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.18)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
 
 packages:
 
@@ -408,6 +371,9 @@ packages:
     resolution: {integrity: sha512-z16BaGgdO6WIkDCxqeI+zhnh2KmW9jsjd312PJ6YYsoDBpPPqL+WkBmxQ7eO9C6CMFxXsZpYcM81RzZEETA4PQ==}
     peerDependencies:
       '@atcute/lexicons': ^1.0.0
+
+  '@atcute/crypto@2.4.1':
+    resolution: {integrity: sha512-tJ3Pi/XYcAsABKtqSlSOTKfO5YiQ4XdqlTuPS8HiRZSezOPcXBFFzAFWpSIJPURbVPFQL3LLrrK0Ea24wl5qeQ==}
 
   '@atcute/identity-resolver-node@1.0.4':
     resolution: {integrity: sha512-bXc3/X2xE5A9fMD1QrjQJkmBrxESTqwwezvfzu518Fyf050jejC7a6E+ld7k3hsWJBiVWBqc+GkIjCNBeU3Wag==}
@@ -936,45 +902,173 @@ packages:
   '@dual-bundle/import-meta-resolve@4.2.1':
     resolution: {integrity: sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==}
 
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/darwin-arm64@0.27.7':
     resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
-    os:
-    - darwin
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
 
   '@esbuild/linux-arm64@0.27.7':
     resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
-    os:
-    - linux
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
 
   '@esbuild/linux-x64@0.27.7':
     resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
     engines: {node: '>=18'}
-    os:
-    - linux
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
-    os:
-    - win32
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
 
   '@esbuild/win32-x64@0.27.7':
     resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
     engines: {node: '>=18'}
-    os:
-    - win32
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -1070,85 +1164,119 @@ packages:
   '@img/sharp-darwin-arm64@0.33.5':
     resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    os:
-    - darwin
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.33.5':
+    resolution: {integrity: sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
 
   '@img/sharp-libvips-darwin-arm64@1.0.4':
     resolution: {integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==}
-    os:
-    - darwin
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.0.4':
+    resolution: {integrity: sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==}
+    cpu: [x64]
+    os: [darwin]
 
   '@img/sharp-libvips-linux-arm64@1.0.4':
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
-    os:
-    - linux
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.0.5':
+    resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.0.4':
+    resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
-    os:
-    - linux
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
-    os:
-    - linux
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
-    os:
-    - linux
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    os:
-    - linux
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.33.5':
+    resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.33.5':
+    resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    os:
-    - linux
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    os:
-    - linux
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    os:
-    - linux
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.33.5':
+    resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-ia32@0.33.5':
+    resolution: {integrity: sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
 
   '@img/sharp-win32-x64@0.33.5':
     resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    os:
-    - win32
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [win32]
 
   '@inkjs/ui@2.0.0':
     resolution: {integrity: sha512-5+8fJmwtF9UvikzLfph9sA+LS+l37Ij/szQltkuXLOAXwNkBX9innfzh4pLGXIB59vKEQUtc6D4qGvhD7h3pAg==}
@@ -1208,6 +1336,12 @@ packages:
     peerDependencies:
       rollup: '>=2'
 
+  '@napi-rs/wasm-runtime@1.1.5':
+    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@noble/curves@1.9.7':
     resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
     engines: {node: ^14.21.3 || >=16}
@@ -1218,6 +1352,9 @@ packages:
 
   '@noble/secp256k1@1.7.2':
     resolution: {integrity: sha512-/qzwYl5eFLH8OWIecQWM31qld2g1NfjgylK+TNhqtaUKP37Nm+Y+z30Fjhw0Ct8p9yCQEm2N3W/AckdIb3SMcQ==}
+
+  '@noble/secp256k1@3.1.0':
+    resolution: {integrity: sha512-+F7iS7tUMaNGXcc9X3PjmjvuQnXEuSjCRNzVVA2xAcKXgCaP0dHYz4SFyt4FKNHef7sOP//xihowcySSS7PK9g==}
 
   '@nodable/entities@2.1.0':
     resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
@@ -1244,225 +1381,487 @@ packages:
       react: ^19.1.0
       react-dom: ^19.1.0
 
+  '@oxc-parser/binding-android-arm-eabi@0.128.0':
+    resolution: {integrity: sha512-aca6ZvzmCBUGOANQRiRQRZuRKYI3ENhcit6GisnknOOmcezfQc7xJ4dxlPU7MV7mOvrC7RNR1u3LAD7xyaiCxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.128.0':
+    resolution: {integrity: sha512-BbeDmuohoJ7Rz/it5wnkj69i/OsCPS3Z51nLEzwO/Y6YshtC4JU+15oNwhY8v4LRKRYclRc7ggOikwrsJ/eOEQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
   '@oxc-parser/binding-darwin-arm64@0.128.0':
     resolution: {integrity: sha512-tRUHPt80417QmvNpoSslJT1VY8NUbWdrWR+L14Zn+RbOTcaqB8E6PYE/ZGN8jjWBzqporiA/H4MfO50ew/NCNA==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    os:
-    - darwin
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.128.0':
+    resolution: {integrity: sha512-rWI2Hb1Nt3U/vKsjyNvZzDC8i/l144U20DKjhzaTmwIhIiSRGeroPWWiImwypmKLqrw8GuIixbWJkpGWLbkzrQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-freebsd-x64@0.128.0':
+    resolution: {integrity: sha512-hhpdVMaNCLgQxjgNPeeFzSeJMmZPc5lKfv0NGSI3egZq9EdnEGqeC8JsYsQjK7PoQgbvZ17xlj0SO5ziH5Obkg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.128.0':
+    resolution: {integrity: sha512-093zNw0zZ/e/obML+rhlSdmnzR0mVZluPcAkxunEc5E3F0yBVsFn24Y1ILfsEte11Ud041qn/gp2OJ1jxNqUng==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.128.0':
+    resolution: {integrity: sha512-fq7DmKmfC+dvD97IXrgbph6Jzwe0EDu+PYMofmzZ6fv5X1k9vtaqLpDGMuICO9MmUnyKAQmVl+wIv2RNy4Dz8g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
 
   '@oxc-parser/binding-linux-arm64-gnu@0.128.0':
     resolution: {integrity: sha512-Xvm48jJah8TlIrURIjNOP/gNiGe6aKvCB+r06VliflFo8Kq7VOLE8PxtgShJzZIqubrgdMdYfvuPPozn7F6MbQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    os:
-    - linux
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.128.0':
     resolution: {integrity: sha512-M7iwBGmYJTx+pKOYFjI0buop4gJvlmcVzFGaXPt21DKpQkbQZG1f63Yg7LloIYT/t9yLxCw0Lhfx/RFlAlMSjA==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    os:
-    - linux
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.128.0':
+    resolution: {integrity: sha512-21LGNIZb1Pcfk5/EGsqabrxv4yqQOWis1407JJrClS7XpFCrbvr74YAB1V+m54cYbwvO6UWwQqS4WecxiyfCRg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.128.0':
+    resolution: {integrity: sha512-gyHjOTFpg9bTTYjxPmQirvufb89+VdZwVfcMtAUyPr6F5H8ZswvCQshK4qOW+Q+2Xyb33hduRgY/eFHJQjU/vQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.128.0':
+    resolution: {integrity: sha512-X6Q2oKUrP5GyDd2xniuEBLk6aFQCZ97W2+aVXGgJXdjx5t4/oFuA9ri0wLOUrBIX+qdSuK581snMBio4z910eA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.128.0':
+    resolution: {integrity: sha512-BdzTmqxfxoYkpgokoLaSnOX6T+R3/goL42klre2tnG+kHbG2TXS0VN+P5BPofH1axdKOHy5ei4ENZrjmCOt2lA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.128.0':
     resolution: {integrity: sha512-OO1nW2Q7sSYYvJZpDHdvyFSdRaVcQqRijZSSmWVMqFxPYy8cEF45zJ9fcdIYuzIT3jYq6YRhEFm/VMWNWhE22Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    os:
-    - linux
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.128.0':
     resolution: {integrity: sha512-4NehAe404MRdoZVS9DW8C5XbJwbXIc/KfVlYdpi5vE4081zc9Y0YzKVqyOYj/Puye7/Do+ohaONBFWlEHYl9hw==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    os:
-    - linux
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-openharmony-arm64@0.128.0':
+    resolution: {integrity: sha512-kVbqgW9xLL8bh8oc7aYOJilRKXE5G33+tE0jan+duo/9OriaFRpijcCwT2waWs2oqYROYq0GlE7/p3ywoshVeg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-wasm32-wasi@0.128.0':
+    resolution: {integrity: sha512-L38ojghJYHmgiz6fJd7jwLB/ESDBpB02NdFxh+smqVM6P2anCEvHn0jhaSrt5eVNR1Ak8+moOeftUlofeyvniA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
 
   '@oxc-parser/binding-win32-arm64-msvc@0.128.0':
     resolution: {integrity: sha512-xgvO35GyHBtjlQ5AEpaYr7Rll1rvY7zqIhT6ty8E3ezBW2J1SFLjIDEvI/tcgDg6oaseDAqVcM+jU1HuCekgZw==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    os:
-    - win32
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.128.0':
+    resolution: {integrity: sha512-OY+3eM2SN72prHKRB22mPz8o5A/7dJ+f5DFLBVvggyZhEaNDAH9IB+ElMjmOkOIwf5MDCUAowCK7pAncNxzpBA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
 
   '@oxc-parser/binding-win32-x64-msvc@0.128.0':
     resolution: {integrity: sha512-NE9ny+cPUCCObXa0IKLfj0tCdPd7pe/dz9ZpkxpUOymB3miNeMPybdlYYTBSGJUalMWeBM85/4JcCErCNTqOXw==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    os:
-    - win32
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [win32]
 
   '@oxc-project/types@0.128.0':
     resolution: {integrity: sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==}
 
+  '@oxc-resolver/binding-android-arm-eabi@11.19.1':
+    resolution: {integrity: sha512-aUs47y+xyXHUKlbhqHUjBABjvycq6YSD7bpxSW7vplUmdzAlJ93yXY6ZR0c1o1x5A/QKbENCvs3+NlY8IpIVzg==}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-resolver/binding-android-arm64@11.19.1':
+    resolution: {integrity: sha512-oolbkRX+m7Pq2LNjr/kKgYeC7bRDMVTWPgxBGMjSpZi/+UskVo4jsMU3MLheZV55jL6c3rNelPl4oD60ggYmqA==}
+    cpu: [arm64]
+    os: [android]
+
   '@oxc-resolver/binding-darwin-arm64@11.19.1':
     resolution: {integrity: sha512-nUC6d2i3R5B12sUW4O646qD5cnMXf2oBGPLIIeaRfU9doJRORAbE2SGv4eW6rMqhD+G7nf2Y8TTJTLiiO3Q/dQ==}
-    os:
-    - darwin
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-darwin-x64@11.19.1':
+    resolution: {integrity: sha512-cV50vE5+uAgNcFa3QY1JOeKDSkM/9ReIcc/9wn4TavhW/itkDGrXhw9jaKnkQnGbjJ198Yh5nbX/Gr2mr4Z5jQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-freebsd-x64@11.19.1':
+    resolution: {integrity: sha512-xZOQiYGFxtk48PBKff+Zwoym7ScPAIVp4c14lfLxizO2LTTTJe5sx9vQNGrBymrf/vatSPNMD4FgsaaRigPkqw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.19.1':
+    resolution: {integrity: sha512-lXZYWAC6kaGe/ky2su94e9jN9t6M0/6c+GrSlCqL//XO1cxi5lpAhnJYdyrKfm0ZEr/c7RNyAx3P7FSBcBd5+A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.19.1':
+    resolution: {integrity: sha512-veG1kKsuK5+t2IsO9q0DErYVSw2azvCVvWHnfTOS73WE0STdLLB7Q1bB9WR+yHPQM76ASkFyRbogWo1GR1+WbQ==}
+    cpu: [arm]
+    os: [linux]
 
   '@oxc-resolver/binding-linux-arm64-gnu@11.19.1':
     resolution: {integrity: sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==}
-    os:
-    - linux
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.19.1':
     resolution: {integrity: sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==}
-    os:
-    - linux
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.19.1':
+    resolution: {integrity: sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.19.1':
+    resolution: {integrity: sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-riscv64-musl@11.19.1':
+    resolution: {integrity: sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-linux-s390x-gnu@11.19.1':
+    resolution: {integrity: sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.19.1':
     resolution: {integrity: sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==}
-    os:
-    - linux
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.19.1':
     resolution: {integrity: sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==}
-    os:
-    - linux
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-openharmony-arm64@11.19.1':
+    resolution: {integrity: sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-resolver/binding-wasm32-wasi@11.19.1':
+    resolution: {integrity: sha512-w8UCKhX826cP/ZLokXDS6+milN8y4X7zidsAttEdWlVoamTNf6lhBJldaWr3ukTDiye7s4HRcuPEPOXNC432Vg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
 
   '@oxc-resolver/binding-win32-arm64-msvc@11.19.1':
     resolution: {integrity: sha512-nJ4AsUVZrVKwnU/QRdzPCCrO0TrabBqgJ8pJhXITdZGYOV28TIYystV1VFLbQ7DtAcaBHpocT5/ZJnF78YJPtQ==}
-    os:
-    - win32
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-resolver/binding-win32-ia32-msvc@11.19.1':
+    resolution: {integrity: sha512-EW+ND5q2Tl+a3pH81l1QbfgbF3HmqgwLfDfVithRFheac8OTcnbXt/JxqD2GbDkb7xYEqy1zNaVFRr3oeG8npA==}
+    cpu: [ia32]
+    os: [win32]
 
   '@oxc-resolver/binding-win32-x64-msvc@11.19.1':
     resolution: {integrity: sha512-6hIU3RQu45B+VNTY4Ru8ppFwjVS/S5qwYyGhBotmjxfEKk41I2DlGtRfGJndZ5+6lneE2pwloqunlOyZuX/XAw==}
-    os:
-    - win32
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [win32]
+
+  '@oxfmt/binding-android-arm-eabi@0.48.0':
+    resolution: {integrity: sha512-uwqk+/KhQvBIpULD8SMM/zAafMRC/+DV/xsEQjkkIsJ/kLmEI/2bxonVowcYTiXqqZ/a0FEW8DPkZY3VvwELDA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxfmt/binding-android-arm64@0.48.0':
+    resolution: {integrity: sha512-VUCiKuXK5+McVssgHEJdrcGK7hRJzrRb36zm9/jwzMholyYt4BgXhw5Nm1V1DX6Ce717Zi/1jk432b/tgmQgtQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
 
   '@oxfmt/binding-darwin-arm64@0.48.0':
     resolution: {integrity: sha512-IkKp8rnIyQLW6Jt+6jragCbUVYSayk55lapiprLjIVvt4NczLyO/nwX2GgefLQ5iaBdfS8UEAFgCs/pLO6Cl0w==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    os:
-    - darwin
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxfmt/binding-darwin-x64@0.48.0':
+    resolution: {integrity: sha512-+aFuhsGIuvnoOjXyKVHMhPKJZR1kQkAl8QyrKoMlA7yJsSTC3N0Asl53La8TChSHhW8epToQ/Q0nvLmEmfNmLg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxfmt/binding-freebsd-x64@0.48.0':
+    resolution: {integrity: sha512-fbqzQL8FjI9gGnktI7RIo0dksDziTAYBy7xlI7jU7eID5fxLF/25fS4Xj6GydD8Y5oWHL83U4NK160QaOAxtyg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.48.0':
+    resolution: {integrity: sha512-hn4i0zhAyTiB3ZHjQfYUZkDvrbVkohw1S7pySWxWUoZ87HnkDoTFThj7QTxk40hNPOTUP0vHbPRNamFIv1HBJQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.48.0':
+    resolution: {integrity: sha512-R4WBD9qF3QM9hqgdAa+fBGXmquTvDUujrPQ36t2Sjk8RPOSKGHDeN7l/khr10hqbQaOq9KCgPHG9ubNET/X/RQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
 
   '@oxfmt/binding-linux-arm64-gnu@0.48.0':
     resolution: {integrity: sha512-5bVdwSwlm1M8wbYCorLOxWxUBw/8tBvHYyQNIfwWVPwOJaj5vg1APSGJQVpwJfV5VNE9PSrR91UKEpoNwHhqUA==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    os:
-    - linux
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-arm64-musl@0.48.0':
     resolution: {integrity: sha512-vCS3Fk7gFslTqE1lUE2IlroyVV7u/9SmMA/uBqDoshuck2psGWcjW0ePyPZI3rM3+qtf2pDaMVIKMHozraifuw==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    os:
-    - linux
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.48.0':
+    resolution: {integrity: sha512-gKtfFfueUClXDumyoHUbymqRf7prHejOOyzJK0eIJn93GF9JBdFHdo60TM1ZBHxkEwZvjuOgHmKtneKbEOc/Eg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.48.0':
+    resolution: {integrity: sha512-SYt0UhOvZD/UwZz9sXq6J2uAw8o24f5VZpLB2DH01f6MevshmlgakQlZe2lwek2sZJkd07eLu7mZa0g7yeiw7Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-musl@0.48.0':
+    resolution: {integrity: sha512-JLbrwck2AopG4ud/XklZO5N+qxGC7cS7ROvXZVNfx0MCLDDL2kGOLvzuWORkVjnjAM0CMAfIMU2zNBtQbM+4dw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-s390x-gnu@0.48.0':
+    resolution: {integrity: sha512-mdxt5L8OQLxkQH+JVpdC/lknZNe0lX4hlO3d8+xvw2wToo+iDrid9tiGOd5bmHfUVd5wVhrUry0qlu5vq66NkQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-gnu@0.48.0':
     resolution: {integrity: sha512-oEz1BQwMrV7OMEFx/3VPDU3n9TM0AnxpktDYXjEg5i6nTX87wo18wSfBvkl4tzAICdKtoAQAdBIl7Y7hsPlx5w==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    os:
-    - linux
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-musl@0.48.0':
     resolution: {integrity: sha512-g2SKTTurP5mWjd8Ecait0erYqmltL4IqW1EwttM25BxM6NiTt4ubobJYMR1uox1V2QgG4UfHH10CGRvWlUixjw==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    os:
-    - linux
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-openharmony-arm64@0.48.0':
+    resolution: {integrity: sha512-CIg24VgheEpvolHL2gQuax5qcQ602bRMHrJ9g8XsQr3iVj9aSPgopigBKuMqrXsupwkrU+RQCn5cG8PgFntR6w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
 
   '@oxfmt/binding-win32-arm64-msvc@0.48.0':
     resolution: {integrity: sha512-zeaWkcxcEULwkGF3I/HgEvcDPN8buYDrxibBUa/IFh5Vmwyge+KpLO+hEwSovW349H0O/C0Z2kaFmEzEDm00/Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    os:
-    - win32
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxfmt/binding-win32-ia32-msvc@0.48.0':
+    resolution: {integrity: sha512-yiEKnIAGvx5CyZQOlMaNlZkAbwT7/Quk0j3WLt+PR5hK+qYjPTRRJYDfD77wCBPLvEYAG41v4KG3iL0H+uxoxg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
 
   '@oxfmt/binding-win32-x64-msvc@0.48.0':
     resolution: {integrity: sha512-GSD2+7t2UoVMV2NgxXypa4bKewflPMAjYnF0Xw9/ht82ZfafAHhb8STwrEd7wlH2PFogt5zw3WVCxYJaHUdbeQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    os:
-    - win32
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [win32]
+
+  '@oxlint/binding-android-arm-eabi@1.63.0':
+    resolution: {integrity: sha512-A9xLtQt7i0OA1PoB/meog6kikXI9CdwEp7ZwQqmgnpKn3G3b1orvTDy8CQ6T7w1HvDrgWGB78PkFKcWgibcTCg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.63.0':
+    resolution: {integrity: sha512-SQo+ZMvdR9l3CxZp5W5gFNxSiDxclY6lOzzNpKYLF8asESpm3Pwumx0gER5T7aHLF1/2BAAtLD3DiDkdgy4V1A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
 
   '@oxlint/binding-darwin-arm64@1.63.0':
     resolution: {integrity: sha512-6W82XjJDTmMnjg30427l0dufpnyLoq7wEukKdM6/g2VIybRVuQiBVh43EA4b+UxZ3+tLcKm+Or/pXGNgLCEU8g==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    os:
-    - darwin
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/binding-darwin-x64@1.63.0':
+    resolution: {integrity: sha512-CnWd/YCuVG5W1BYkjJEVbJG11o526O9qAwBEQM+nh8K19CRFUkFdROXCyYkGmroHEYQe4vgQ6+lh3550Lp35Xw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/binding-freebsd-x64@1.63.0':
+    resolution: {integrity: sha512-a4eZAqrmtajqcxfdAzC+l7g3PaE3V8hpAYqqeD3fTxLXOMFdK3eNTZrU80n4dDEVm0JXy1aL5PqvqWldBl6zYA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.63.0':
+    resolution: {integrity: sha512-tYUtU9TdbU3uXF5D62g5zXJ13iniFGhXQx5vp9cyEjGdbSAY3VdFBSaldYvyoDmgMZ0ZYuwQP1Y4t2Fhejwa0w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-musleabihf@1.63.0':
+    resolution: {integrity: sha512-I5r3twFf776UZg9dmRo2xbrKt00tTkORXEVe0ctg4vdTkQvJAjiCHxnbAU2HL1AiJ9cqADA76MAliuilsAWnvg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
 
   '@oxlint/binding-linux-arm64-gnu@1.63.0':
     resolution: {integrity: sha512-t7ltUkg6FFh4b564QyGir8xIj/QZbXu8FlcRkcyW9+ztr/mfRHlvUOFd95pJCXi9s/L5DrUeWWgpXRS+V+6igQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    os:
-    - linux
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.63.0':
     resolution: {integrity: sha512-Q5mmZy/XWjuYFUuQyYjOvZ5U/JkKEwnpir6hGxhh6HcdP0V/BKxLo8dqkfF/t7r7AguB17dfS/8+go5AQDRR6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    os:
-    - linux
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-ppc64-gnu@1.63.0':
+    resolution: {integrity: sha512-uBGtuZ0TzLB4x5wVa82HGNvYqY8buwDhyCnCP0R0gkk9szqVsP0MeTtD5HX7EsEuFIt+aYmYxuxeVxs3nTSwtQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-gnu@1.63.0':
+    resolution: {integrity: sha512-h4s6FwxE+9MeA181o0dnDwHP32Y/bG8EiB/vrD6Ib+AMt6haigDc/0bUtI/sLmQDBMJnUfaCmtSSrEAqjtEVrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-musl@1.63.0':
+    resolution: {integrity: sha512-2EaNcCBR8Mcjl5ARtuN3BdEpVkX7KpjSjMGZ/mJMIeaXgTtdz5ytg2VwygMSStA/k0ixfvZFoZOfjDEcouV5vQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-s390x-gnu@1.63.0':
+    resolution: {integrity: sha512-p4hlf/fd7TrYYl3QrWWD0GocqJefwMu3cHQhmi2FvEB/YOvFb5DZN3SMBaPi7B1TM5DeypkEtrVib674q1KKPg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.63.0':
     resolution: {integrity: sha512-Vgq9rkRVcPcjbcH+ihYTfpeR7vCXfqpd+z5ItTGc0yYUV59L5ceHYN1iV4H9bKGV7Rn5hkVc7x3mSvHegduENA==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    os:
-    - linux
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.63.0':
     resolution: {integrity: sha512-3/Lkq/ncooA61rorrC+ZQed1Bc4VpGj+WnGsp58zmxKgvZ2vhreu+dcVyr3mX8NUpq7mfZ4gDDTou/yrF1Pd7A==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    os:
-    - linux
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-openharmony-arm64@1.63.0':
+    resolution: {integrity: sha512-0/EdD/6hDkx5Mfd769PTjvEM8mZ/6Dfukp1dBCL/2PjlIVGEtYdNZyok6ChqYPsT9JcFnlQnUeQzO0/1L/oC9w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
 
   '@oxlint/binding-win32-arm64-msvc@1.63.0':
     resolution: {integrity: sha512-wb0CUkN8ngwPiRQBjD1Cj0LsHeNvm+Xt6YBHDMtj2DVQVD6Oj8Ri7g6BD+KICf6LaBqZlmzOvy6nF9E/8yyGOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    os:
-    - win32
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint/binding-win32-ia32-msvc@1.63.0':
+    resolution: {integrity: sha512-BX5iq+ovdNlVYhSn5qPMUIT0uwAwt2lmEnCnzK+Gkhw4DovIvhGb96OFhV8yzQNUnQxn/xGkOR+X+BLrLDNm8w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
 
   '@oxlint/binding-win32-x64-msvc@1.63.0':
     resolution: {integrity: sha512-QeN/WELOfsXMeYwxvfgQrl6CbVftYUCZsGXHjXQd5Trccm8+i4gmtxaOui4xbJQaiDlviF8F3yLSBloQUeFsfA==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    os:
-    - win32
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [win32]
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1551,121 +1950,180 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
+  '@resvg/resvg-js-android-arm-eabi@2.6.2':
+    resolution: {integrity: sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+
+  '@resvg/resvg-js-android-arm64@2.6.2':
+    resolution: {integrity: sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
   '@resvg/resvg-js-darwin-arm64@2.6.2':
     resolution: {integrity: sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==}
     engines: {node: '>= 10'}
-    os:
-    - darwin
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [darwin]
+
+  '@resvg/resvg-js-darwin-x64@2.6.2':
+    resolution: {integrity: sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@resvg/resvg-js-linux-arm-gnueabihf@2.6.2':
+    resolution: {integrity: sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
 
   '@resvg/resvg-js-linux-arm64-gnu@2.6.2':
     resolution: {integrity: sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==}
     engines: {node: '>= 10'}
-    os:
-    - linux
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
 
   '@resvg/resvg-js-linux-arm64-musl@2.6.2':
     resolution: {integrity: sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==}
     engines: {node: '>= 10'}
-    os:
-    - linux
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
 
   '@resvg/resvg-js-linux-x64-gnu@2.6.2':
     resolution: {integrity: sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==}
     engines: {node: '>= 10'}
-    os:
-    - linux
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
   '@resvg/resvg-js-linux-x64-musl@2.6.2':
     resolution: {integrity: sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==}
     engines: {node: '>= 10'}
-    os:
-    - linux
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
 
   '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
     resolution: {integrity: sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==}
     engines: {node: '>= 10'}
-    os:
-    - win32
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [win32]
+
+  '@resvg/resvg-js-win32-ia32-msvc@2.6.2':
+    resolution: {integrity: sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
 
   '@resvg/resvg-js-win32-x64-msvc@2.6.2':
     resolution: {integrity: sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==}
     engines: {node: '>= 10'}
-    os:
-    - win32
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [win32]
 
   '@resvg/resvg-js@2.6.2':
     resolution: {integrity: sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==}
     engines: {node: '>= 10'}
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.18':
+    resolution: {integrity: sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
   '@rolldown/binding-darwin-arm64@1.0.0-rc.18':
     resolution: {integrity: sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    os:
-    - darwin
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.18':
+    resolution: {integrity: sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.18':
+    resolution: {integrity: sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.18':
+    resolution: {integrity: sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.18':
     resolution: {integrity: sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    os:
-    - linux
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.18':
     resolution: {integrity: sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    os:
-    - linux
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18':
+    resolution: {integrity: sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18':
+    resolution: {integrity: sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.18':
     resolution: {integrity: sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    os:
-    - linux
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.18':
     resolution: {integrity: sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    os:
-    - linux
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.18':
+    resolution: {integrity: sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.18':
+    resolution: {integrity: sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.18':
     resolution: {integrity: sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    os:
-    - win32
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [win32]
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.18':
     resolution: {integrity: sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    os:
-    - win32
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [win32]
 
   '@rolldown/pluginutils@1.0.0-beta.40':
     resolution: {integrity: sha512-s3GeJKSQOwBlzdUrj4ISjJj5SfSh+aqn0wjOar4Bx95iV1ETI7F6S/5hLcfAxZ9kXDcyrAkxPlqmd1ZITttf+w==}
@@ -1685,61 +2143,143 @@ packages:
       rollup:
         optional: true
 
+  '@rollup/rollup-android-arm-eabi@4.60.3':
+    resolution: {integrity: sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.3':
+    resolution: {integrity: sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==}
+    cpu: [arm64]
+    os: [android]
+
   '@rollup/rollup-darwin-arm64@4.60.3':
     resolution: {integrity: sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==}
-    os:
-    - darwin
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.3':
+    resolution: {integrity: sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.3':
+    resolution: {integrity: sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.3':
+    resolution: {integrity: sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.3':
+    resolution: {integrity: sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.3':
+    resolution: {integrity: sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.3':
     resolution: {integrity: sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==}
-    os:
-    - linux
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.3':
     resolution: {integrity: sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==}
-    os:
-    - linux
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.3':
+    resolution: {integrity: sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.3':
+    resolution: {integrity: sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.3':
+    resolution: {integrity: sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.3':
+    resolution: {integrity: sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.3':
+    resolution: {integrity: sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.3':
+    resolution: {integrity: sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.3':
+    resolution: {integrity: sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.3':
     resolution: {integrity: sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==}
-    os:
-    - linux
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.3':
     resolution: {integrity: sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==}
-    os:
-    - linux
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.3':
+    resolution: {integrity: sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.3':
+    resolution: {integrity: sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==}
+    cpu: [arm64]
+    os: [openharmony]
 
   '@rollup/rollup-win32-arm64-msvc@4.60.3':
     resolution: {integrity: sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==}
-    os:
-    - win32
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.3':
+    resolution: {integrity: sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==}
+    cpu: [ia32]
+    os: [win32]
 
   '@rollup/rollup-win32-x64-gnu@4.60.3':
     resolution: {integrity: sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==}
-    os:
-    - win32
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [win32]
 
   '@rollup/rollup-win32-x64-msvc@4.60.3':
     resolution: {integrity: sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==}
-    os:
-    - win32
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [win32]
 
   '@shikijs/core@4.0.2':
     resolution: {integrity: sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==}
@@ -2213,6 +2753,9 @@ packages:
   '@ts-morph/common@0.28.1':
     resolution: {integrity: sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==}
 
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
@@ -2512,9 +3055,6 @@ packages:
     resolution: {integrity: sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-
-  better-sqlite3@10.1.0:
-    resolution: {integrity: sha512-hqpHJaCfKEZFaAWdMh6crdzRWyzQzfP6Ih8TYI0vFn01a6ZTDSbJIMXN+6AMBaBOh99DzUy8l3PsV9R3qnJDng==}
 
   better-sqlite3@11.10.0:
     resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
@@ -3290,14 +3830,12 @@ packages:
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os:
-    - darwin
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os:
-    - darwin
+    os: [darwin]
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -3640,61 +4178,75 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
   lightningcss-darwin-arm64@1.32.0:
     resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
     engines: {node: '>= 12.0.0'}
-    os:
-    - darwin
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
 
   lightningcss-linux-arm64-gnu@1.32.0:
     resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
-    os:
-    - linux
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
-    os:
-    - linux
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
-    os:
-    - linux
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
-    os:
-    - linux
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
     engines: {node: '>= 12.0.0'}
-    os:
-    - win32
-    cpu:
-    - arm64
+    cpu: [arm64]
+    os: [win32]
 
   lightningcss-win32-x64-msvc@1.32.0:
     resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
     engines: {node: '>= 12.0.0'}
-    os:
-    - win32
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [win32]
 
   lightningcss@1.32.0:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
@@ -4282,6 +4834,7 @@ packages:
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   prelude-ls@1.2.1:
@@ -5004,6 +5557,46 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
+  vite@7.3.5:
+    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   vite@8.0.11:
     resolution: {integrity: sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -5220,31 +5813,31 @@ packages:
 
 snapshots:
 
-  '@adobe/react-spectrum-ui@1.2.1(react@19.2.6)(react-dom@19.2.6(react@19.2.6))':
+  '@adobe/react-spectrum-ui@1.2.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  '@adobe/react-spectrum-workflow@2.3.5(react@19.2.6)(react-dom@19.2.6(react@19.2.6))':
+  '@adobe/react-spectrum-workflow@2.3.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  '@adobe/react-spectrum@3.47.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6))':
+  '@adobe/react-spectrum@3.47.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@internationalized/date': 3.12.1
       '@react-types/shared': 3.34.0(react@19.2.6)
-      '@spectrum-icons/ui': 3.7.0(@adobe/react-spectrum@3.47.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6)))(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
-      '@spectrum-icons/workflow': 4.3.0(@adobe/react-spectrum@3.47.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6)))(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+      '@spectrum-icons/ui': 3.7.0(@adobe/react-spectrum@3.47.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@spectrum-icons/workflow': 4.3.0(@adobe/react-spectrum@3.47.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@swc/helpers': 0.5.21
       client-only: 0.0.1
       clsx: 2.1.1
       react: 19.2.6
-      react-aria: 3.48.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
-      react-aria-components: 1.17.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+      react-aria: 3.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react-aria-components: 1.17.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom: 19.2.6(react@19.2.6)
       react-stately: 3.46.0(react@19.2.6)
-      react-transition-group: 4.4.5(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+      react-transition-group: 4.4.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       use-sync-external-store: 1.6.0(react@19.2.6)
 
   '@alcalzone/ansi-tokenize@0.2.5':
@@ -5256,9 +5849,15 @@ snapshots:
     dependencies:
       '@atcute/identity': 1.1.5(@atcute/lexicons@1.3.1)
       '@atcute/lexicons': 1.3.1
-  ? '@atcute/identity-resolver-node@1.0.4(@atcute/identity@1.1.5(@atcute/lexicons@1.3.1))(@atcute/identity-resolver@1.2.3(@atcute/identity@1.1.5(@atcute/lexicons@1.3.1))(@atcute/lexicons@1.3.1))(@atcute/lexicons@1.3.1)'
 
-  : dependencies:
+  '@atcute/crypto@2.4.1':
+    dependencies:
+      '@atcute/multibase': 1.2.0
+      '@atcute/uint8array': 1.1.1
+      '@noble/secp256k1': 3.1.0
+
+  '@atcute/identity-resolver-node@1.0.4(@atcute/identity-resolver@1.2.3(@atcute/identity@1.1.5(@atcute/lexicons@1.3.1))(@atcute/lexicons@1.3.1))(@atcute/identity@1.1.5(@atcute/lexicons@1.3.1))(@atcute/lexicons@1.3.1)':
+    dependencies:
       '@atcute/identity': 1.1.5(@atcute/lexicons@1.3.1)
       '@atcute/identity-resolver': 1.2.3(@atcute/identity@1.1.5(@atcute/lexicons@1.3.1))(@atcute/lexicons@1.3.1)
       '@atcute/lexicons': 1.3.1
@@ -5293,44 +5892,44 @@ snapshots:
       '@badrap/valita': 0.4.6
       nanoid: 5.1.11
 
-  '@atcute/oauth-crypto@1.0.0':
+  '@atcute/oauth-crypto@1.0.0(typescript@5.9.3)':
     dependencies:
       '@atcute/multibase': 1.2.0
       '@atcute/uint8array': 1.1.1
       nanoid: 5.1.11
       valibot: 1.4.0(typescript@5.9.3)
     transitivePeerDependencies:
-    - typescript
+      - typescript
 
-  '@atcute/oauth-keyset@0.1.1':
+  '@atcute/oauth-keyset@0.1.1(typescript@5.9.3)':
     dependencies:
-      '@atcute/oauth-crypto': 1.0.0
+      '@atcute/oauth-crypto': 1.0.0(typescript@5.9.3)
     transitivePeerDependencies:
-    - typescript
-  ? '@atcute/oauth-node-client@1.1.1(@atcute/identity-resolver@1.2.3(@atcute/identity@1.1.5(@atcute/lexicons@1.3.1))(@atcute/lexicons@1.3.1))(@atcute/lexicons@1.3.1)'
+      - typescript
 
-  : dependencies:
+  '@atcute/oauth-node-client@1.1.1(@atcute/identity-resolver@1.2.3(@atcute/identity@1.1.5(@atcute/lexicons@1.3.1))(@atcute/lexicons@1.3.1))(@atcute/lexicons@1.3.1)(typescript@5.9.3)':
+    dependencies:
       '@atcute/client': 4.2.2(@atcute/lexicons@1.3.1)
       '@atcute/identity': 1.1.5(@atcute/lexicons@1.3.1)
       '@atcute/identity-resolver': 1.2.3(@atcute/identity@1.1.5(@atcute/lexicons@1.3.1))(@atcute/lexicons@1.3.1)
       '@atcute/lexicons': 1.3.1
       '@atcute/oauth-crypto': 0.1.0
-      '@atcute/oauth-keyset': 0.1.1
-      '@atcute/oauth-types': 0.1.1
+      '@atcute/oauth-keyset': 0.1.1(typescript@5.9.3)
+      '@atcute/oauth-types': 0.1.1(typescript@5.9.3)
       '@atcute/util-fetch': 1.0.5
       '@badrap/valita': 0.4.6
       nanoid: 5.1.11
     transitivePeerDependencies:
-    - typescript
+      - typescript
 
-  '@atcute/oauth-types@0.1.1':
+  '@atcute/oauth-types@0.1.1(typescript@5.9.3)':
     dependencies:
       '@atcute/identity': 1.1.5(@atcute/lexicons@1.3.1)
       '@atcute/lexicons': 1.3.1
-      '@atcute/oauth-keyset': 0.1.1
+      '@atcute/oauth-keyset': 0.1.1(typescript@5.9.3)
       '@badrap/valita': 0.4.6
     transitivePeerDependencies:
-    - typescript
+      - typescript
 
   '@atcute/uint8array@1.1.1': {}
 
@@ -5381,9 +5980,9 @@ snapshots:
       '@atproto/xrpc': 0.7.7
       '@atproto/xrpc-server': 0.10.20
     transitivePeerDependencies:
-    - bufferutil
-    - supports-color
-    - utf-8-validate
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   '@atproto/api@0.19.16':
     dependencies:
@@ -5411,7 +6010,7 @@ snapshots:
       multiformats: 9.9.0
       uint8arrays: 3.0.0
     transitivePeerDependencies:
-    - aws-crt
+      - aws-crt
 
   '@atproto/bsky@0.0.228':
     dependencies:
@@ -5429,7 +6028,7 @@ snapshots:
       '@atproto/xrpc-server': 0.10.20
       '@bufbuild/protobuf': 1.10.1
       '@connectrpc/connect': 1.7.0(@bufbuild/protobuf@1.10.1)
-      '@connectrpc/connect-express': 1.7.0(@bufbuild/protobuf@1.10.1)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.1))(@connectrpc/connect-node@1.7.0(@bufbuild/protobuf@1.10.1)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.1)))
+      '@connectrpc/connect-express': 1.7.0(@bufbuild/protobuf@1.10.1)(@connectrpc/connect-node@1.7.0(@bufbuild/protobuf@1.10.1)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.1)))(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.1))
       '@connectrpc/connect-node': 1.7.0(@bufbuild/protobuf@1.10.1)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.1))
       '@did-plc/lib': 0.0.1
       '@growthbook/growthbook': 1.6.5
@@ -5459,11 +6058,11 @@ snapshots:
       undici: 6.25.0
       zod: 3.23.8
     transitivePeerDependencies:
-    - bufferutil
-    - debug
-    - pg-native
-    - supports-color
-    - utf-8-validate
+      - bufferutil
+      - debug
+      - pg-native
+      - supports-color
+      - utf-8-validate
 
   '@atproto/bsync@0.0.25':
     dependencies:
@@ -5478,7 +6077,7 @@ snapshots:
       pino-http: 8.6.1
       typed-emitter: 2.1.0
     transitivePeerDependencies:
-    - pg-native
+      - pg-native
 
   '@atproto/common-web@0.4.21':
     dependencies:
@@ -5547,12 +6146,12 @@ snapshots:
       uint8arrays: 3.0.0
       undici: 6.25.0
     transitivePeerDependencies:
-    - aws-crt
-    - bufferutil
-    - debug
-    - pg-native
-    - supports-color
-    - utf-8-validate
+      - aws-crt
+      - bufferutil
+      - debug
+      - pg-native
+      - supports-color
+      - utf-8-validate
 
   '@atproto/did@0.3.0':
     dependencies:
@@ -5708,7 +6307,7 @@ snapshots:
       jose: 5.10.0
       zod: 3.25.76
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   '@atproto/oauth-scopes@0.3.2':
     dependencies:
@@ -5749,11 +6348,11 @@ snapshots:
       undici: 6.25.0
       ws: 8.20.0
     transitivePeerDependencies:
-    - bufferutil
-    - debug
-    - pg-native
-    - supports-color
-    - utf-8-validate
+      - bufferutil
+      - debug
+      - pg-native
+      - supports-color
+      - utf-8-validate
 
   '@atproto/pds@0.4.221':
     dependencies:
@@ -5778,7 +6377,7 @@ snapshots:
       '@atproto/xrpc-server': 0.10.20
       '@did-plc/lib': 0.0.4
       '@hapi/address': 5.1.1
-      better-sqlite3: 10.1.0
+      better-sqlite3: 11.10.0
       compression: 1.8.1
       cors: 2.8.6
       disposable-email-domains-js: 1.25.0
@@ -5802,11 +6401,11 @@ snapshots:
       undici: 6.25.0
       zod: 3.25.76
     transitivePeerDependencies:
-    - aws-crt
-    - bufferutil
-    - debug
-    - supports-color
-    - utf-8-validate
+      - aws-crt
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
 
   '@atproto/repo@0.9.1':
     dependencies:
@@ -5830,9 +6429,9 @@ snapshots:
       p-queue: 6.6.2
       ws: 8.20.0
     transitivePeerDependencies:
-    - bufferutil
-    - supports-color
-    - utf-8-validate
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   '@atproto/syntax@0.4.3':
     dependencies:
@@ -5847,8 +6446,8 @@ snapshots:
       '@atproto/common': 0.5.16
       ws: 8.20.0
     transitivePeerDependencies:
-    - bufferutil
-    - utf-8-validate
+      - bufferutil
+      - utf-8-validate
 
   '@atproto/xrpc-server@0.10.20':
     dependencies:
@@ -5868,9 +6467,9 @@ snapshots:
       rate-limiter-flexible: 2.4.2
       ws: 8.20.0
     transitivePeerDependencies:
-    - bufferutil
-    - supports-color
-    - utf-8-validate
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   '@atproto/xrpc@0.7.7':
     dependencies:
@@ -5968,7 +6567,7 @@ snapshots:
       '@smithy/util-waiter': 4.3.0
       tslib: 2.8.1
     transitivePeerDependencies:
-    - aws-crt
+      - aws-crt
 
   '@aws-sdk/client-kms@3.1045.0':
     dependencies:
@@ -6012,7 +6611,7 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
     transitivePeerDependencies:
-    - aws-crt
+      - aws-crt
 
   '@aws-sdk/client-s3@3.1045.0':
     dependencies:
@@ -6072,7 +6671,7 @@ snapshots:
       '@smithy/util-waiter': 4.3.0
       tslib: 2.8.1
     transitivePeerDependencies:
-    - aws-crt
+      - aws-crt
 
   '@aws-sdk/core@3.974.8':
     dependencies:
@@ -6134,7 +6733,7 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
-    - aws-crt
+      - aws-crt
 
   '@aws-sdk/credential-provider-login@3.972.38':
     dependencies:
@@ -6147,7 +6746,7 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
-    - aws-crt
+      - aws-crt
 
   '@aws-sdk/credential-provider-node@3.972.39':
     dependencies:
@@ -6164,7 +6763,7 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
-    - aws-crt
+      - aws-crt
 
   '@aws-sdk/credential-provider-process@3.972.34':
     dependencies:
@@ -6186,7 +6785,7 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
-    - aws-crt
+      - aws-crt
 
   '@aws-sdk/credential-provider-web-identity@3.972.38':
     dependencies:
@@ -6198,7 +6797,7 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
-    - aws-crt
+      - aws-crt
 
   '@aws-sdk/lib-storage@3.879.0(@aws-sdk/client-s3@3.1045.0)':
     dependencies:
@@ -6348,7 +6947,7 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
     transitivePeerDependencies:
-    - aws-crt
+      - aws-crt
 
   '@aws-sdk/region-config-resolver@3.972.13':
     dependencies:
@@ -6377,7 +6976,7 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
-    - aws-crt
+      - aws-crt
 
   '@aws-sdk/types@3.973.8':
     dependencies:
@@ -6452,12 +7051,12 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   '@babel/generator@7.29.1':
     dependencies:
@@ -6482,7 +7081,7 @@ snapshots:
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -6491,7 +7090,7 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   '@babel/helper-plugin-utils@7.28.6': {}
 
@@ -6541,9 +7140,9 @@ snapshots:
       '@babel/parser': 7.29.3
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   '@babel/types@7.29.0':
     dependencies:
@@ -6553,9 +7152,9 @@ snapshots:
   '@badrap/valita@0.4.6': {}
 
   '@bufbuild/protobuf@1.10.1': {}
-  ? '@connectrpc/connect-express@1.7.0(@bufbuild/protobuf@1.10.1)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.1))(@connectrpc/connect-node@1.7.0(@bufbuild/protobuf@1.10.1)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.1)))'
 
-  : dependencies:
+  '@connectrpc/connect-express@1.7.0(@bufbuild/protobuf@1.10.1)(@connectrpc/connect-node@1.7.0(@bufbuild/protobuf@1.10.1)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.1)))(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.1))':
+    dependencies:
       '@bufbuild/protobuf': 1.10.1
       '@connectrpc/connect': 1.7.0(@bufbuild/protobuf@1.10.1)
       '@connectrpc/connect-node': 1.7.0(@bufbuild/protobuf@1.10.1)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.1))
@@ -6580,7 +7179,7 @@ snapshots:
       uint8arrays: 3.0.0
       zod: 3.25.76
     transitivePeerDependencies:
-    - debug
+      - debug
 
   '@did-plc/lib@0.0.4':
     dependencies:
@@ -6592,7 +7191,7 @@ snapshots:
       uint8arrays: 3.0.0
       zod: 3.25.76
     transitivePeerDependencies:
-    - debug
+      - debug
 
   '@did-plc/server@0.0.1':
     dependencies:
@@ -6610,22 +7209,106 @@ snapshots:
       pino: 8.21.0
       pino-http: 8.6.1
     transitivePeerDependencies:
-    - debug
-    - pg-native
-    - supports-color
+      - debug
+      - pg-native
+      - supports-color
 
   '@dual-bundle/import-meta-resolve@4.2.1': {}
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
   '@esbuild/linux-arm64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
   '@esbuild/linux-x64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
   '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
@@ -6641,10 +7324,10 @@ snapshots:
   '@eslint/config-array@0.23.5':
     dependencies:
       '@eslint/object-schema': 3.0.5
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       minimatch: 10.2.5
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   '@eslint/config-helpers@0.5.5':
     dependencies:
@@ -6728,10 +7411,24 @@ snapshots:
       '@img/sharp-libvips-darwin-arm64': 1.0.4
     optional: true
 
+  '@img/sharp-darwin-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.0.4
+    optional: true
+
   '@img/sharp-libvips-darwin-arm64@1.0.4':
     optional: true
 
+  '@img/sharp-libvips-darwin-x64@1.0.4':
+    optional: true
+
   '@img/sharp-libvips-linux-arm64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.0.5':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.0.4':
     optional: true
 
   '@img/sharp-libvips-linux-x64@1.0.4':
@@ -6748,6 +7445,16 @@ snapshots:
       '@img/sharp-libvips-linux-arm64': 1.0.4
     optional: true
 
+  '@img/sharp-linux-arm@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.0.5
+    optional: true
+
+  '@img/sharp-linux-s390x@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.0.4
+    optional: true
+
   '@img/sharp-linux-x64@0.33.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-x64': 1.0.4
@@ -6761,6 +7468,14 @@ snapshots:
   '@img/sharp-linuxmusl-x64@0.33.5':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+    optional: true
+
+  '@img/sharp-wasm32@0.33.5':
+    dependencies:
+      '@emnapi/runtime': 1.11.1
+    optional: true
+
+  '@img/sharp-win32-ia32@0.33.5':
     optional: true
 
   '@img/sharp-win32-x64@0.33.5':
@@ -6851,7 +7566,7 @@ snapshots:
       unist-util-visit: 5.1.0
       vfile: 6.0.3
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   '@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
@@ -6867,7 +7582,21 @@ snapshots:
       source-map: 0.7.6
       vfile: 6.0.3
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
+
+  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.2
+    optional: true
 
   '@noble/curves@1.9.7':
     dependencies:
@@ -6876,6 +7605,8 @@ snapshots:
   '@noble/hashes@1.8.0': {}
 
   '@noble/secp256k1@1.7.2': {}
+
+  '@noble/secp256k1@3.1.0': {}
 
   '@nodable/entities@2.1.0': {}
 
@@ -6896,12 +7627,30 @@ snapshots:
 
   '@oozcitak/util@10.0.0': {}
 
-  '@origin-space/image-cropper@0.1.9(react@19.2.6)(react-dom@19.2.6(react@19.2.6))':
+  '@origin-space/image-cropper@0.1.9(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
+  '@oxc-parser/binding-android-arm-eabi@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.128.0':
+    optional: true
+
   '@oxc-parser/binding-darwin-arm64@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-freebsd-x64@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.128.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm64-gnu@0.128.0':
@@ -6910,13 +7659,38 @@ snapshots:
   '@oxc-parser/binding-linux-arm64-musl@0.128.0':
     optional: true
 
+  '@oxc-parser/binding-linux-ppc64-gnu@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.128.0':
+    optional: true
+
   '@oxc-parser/binding-linux-x64-gnu@0.128.0':
     optional: true
 
   '@oxc-parser/binding-linux-x64-musl@0.128.0':
     optional: true
 
+  '@oxc-parser/binding-openharmony-arm64@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-wasm32-wasi@0.128.0':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
   '@oxc-parser/binding-win32-arm64-msvc@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.128.0':
     optional: true
 
   '@oxc-parser/binding-win32-x64-msvc@0.128.0':
@@ -6924,7 +7698,25 @@ snapshots:
 
   '@oxc-project/types@0.128.0': {}
 
+  '@oxc-resolver/binding-android-arm-eabi@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-android-arm64@11.19.1':
+    optional: true
+
   '@oxc-resolver/binding-darwin-arm64@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-darwin-x64@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-freebsd-x64@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.19.1':
     optional: true
 
   '@oxc-resolver/binding-linux-arm64-gnu@11.19.1':
@@ -6933,19 +7725,63 @@ snapshots:
   '@oxc-resolver/binding-linux-arm64-musl@11.19.1':
     optional: true
 
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-riscv64-musl@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-s390x-gnu@11.19.1':
+    optional: true
+
   '@oxc-resolver/binding-linux-x64-gnu@11.19.1':
     optional: true
 
   '@oxc-resolver/binding-linux-x64-musl@11.19.1':
     optional: true
 
+  '@oxc-resolver/binding-openharmony-arm64@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.1)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
   '@oxc-resolver/binding-win32-arm64-msvc@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-win32-ia32-msvc@11.19.1':
     optional: true
 
   '@oxc-resolver/binding-win32-x64-msvc@11.19.1':
     optional: true
 
+  '@oxfmt/binding-android-arm-eabi@0.48.0':
+    optional: true
+
+  '@oxfmt/binding-android-arm64@0.48.0':
+    optional: true
+
   '@oxfmt/binding-darwin-arm64@0.48.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-x64@0.48.0':
+    optional: true
+
+  '@oxfmt/binding-freebsd-x64@0.48.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.48.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.48.0':
     optional: true
 
   '@oxfmt/binding-linux-arm64-gnu@0.48.0':
@@ -6954,19 +7790,55 @@ snapshots:
   '@oxfmt/binding-linux-arm64-musl@0.48.0':
     optional: true
 
+  '@oxfmt/binding-linux-ppc64-gnu@0.48.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.48.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-musl@0.48.0':
+    optional: true
+
+  '@oxfmt/binding-linux-s390x-gnu@0.48.0':
+    optional: true
+
   '@oxfmt/binding-linux-x64-gnu@0.48.0':
     optional: true
 
   '@oxfmt/binding-linux-x64-musl@0.48.0':
     optional: true
 
+  '@oxfmt/binding-openharmony-arm64@0.48.0':
+    optional: true
+
   '@oxfmt/binding-win32-arm64-msvc@0.48.0':
+    optional: true
+
+  '@oxfmt/binding-win32-ia32-msvc@0.48.0':
     optional: true
 
   '@oxfmt/binding-win32-x64-msvc@0.48.0':
     optional: true
 
+  '@oxlint/binding-android-arm-eabi@1.63.0':
+    optional: true
+
+  '@oxlint/binding-android-arm64@1.63.0':
+    optional: true
+
   '@oxlint/binding-darwin-arm64@1.63.0':
+    optional: true
+
+  '@oxlint/binding-darwin-x64@1.63.0':
+    optional: true
+
+  '@oxlint/binding-freebsd-x64@1.63.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.63.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-musleabihf@1.63.0':
     optional: true
 
   '@oxlint/binding-linux-arm64-gnu@1.63.0':
@@ -6975,13 +7847,31 @@ snapshots:
   '@oxlint/binding-linux-arm64-musl@1.63.0':
     optional: true
 
+  '@oxlint/binding-linux-ppc64-gnu@1.63.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-gnu@1.63.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-musl@1.63.0':
+    optional: true
+
+  '@oxlint/binding-linux-s390x-gnu@1.63.0':
+    optional: true
+
   '@oxlint/binding-linux-x64-gnu@1.63.0':
     optional: true
 
   '@oxlint/binding-linux-x64-musl@1.63.0':
     optional: true
 
+  '@oxlint/binding-openharmony-arm64@1.63.0':
+    optional: true
+
   '@oxlint/binding-win32-arm64-msvc@1.63.0':
+    optional: true
+
+  '@oxlint/binding-win32-ia32-msvc@1.63.0':
     optional: true
 
   '@oxlint/binding-win32-x64-msvc@1.63.0':
@@ -7017,55 +7907,55 @@ snapshots:
 
   '@protobufjs/utf8@1.1.1': {}
 
-  '@react-aria/overlays@3.32.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6))':
+  '@react-aria/overlays@3.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@swc/helpers': 0.5.21
       react: 19.2.6
-      react-aria: 3.48.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+      react-aria: 3.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom: 19.2.6(react@19.2.6)
 
-  '@react-aria/utils@3.34.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6))':
+  '@react-aria/utils@3.34.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@swc/helpers': 0.5.21
       react: 19.2.6
-      react-aria: 3.48.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
-      react-dom: 19.2.6(react@19.2.6)
-      react-stately: 3.46.0(react@19.2.6)
-
-  '@react-spectrum/overlays@5.10.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6))':
-    dependencies:
-      '@adobe/react-spectrum': 3.47.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
-      '@swc/helpers': 0.5.21
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  '@react-spectrum/provider@3.11.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6))':
-    dependencies:
-      '@adobe/react-spectrum': 3.47.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
-      '@swc/helpers': 0.5.21
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  '@react-stately/overlays@3.7.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6))':
-    dependencies:
-      '@swc/helpers': 0.5.21
-      react: 19.2.6
+      react-aria: 3.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom: 19.2.6(react@19.2.6)
       react-stately: 3.46.0(react@19.2.6)
 
-  '@react-stately/utils@3.12.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6))':
+  '@react-spectrum/overlays@5.10.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@adobe/react-spectrum': 3.47.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@swc/helpers': 0.5.21
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
+  '@react-spectrum/provider@3.11.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@adobe/react-spectrum': 3.47.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@swc/helpers': 0.5.21
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
+  '@react-stately/overlays@3.7.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       react-stately: 3.46.0(react@19.2.6)
-  ? '@react-types/overlays@3.10.0(@react-spectrum/provider@3.11.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6)))(react@19.2.6)(react-dom@19.2.6(react@19.2.6))'
 
-  : dependencies:
-      '@react-aria/overlays': 3.32.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
-      '@react-spectrum/overlays': 5.10.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
-      '@react-spectrum/provider': 3.11.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
-      '@react-stately/overlays': 3.7.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+  '@react-stately/utils@3.12.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@swc/helpers': 0.5.21
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-stately: 3.46.0(react@19.2.6)
+
+  '@react-types/overlays@3.10.0(@react-spectrum/provider@3.11.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@react-aria/overlays': 3.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@react-spectrum/overlays': 5.10.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@react-spectrum/provider': 3.11.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@react-stately/overlays': 3.7.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-types/shared': 3.34.0(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -7074,7 +7964,19 @@ snapshots:
     dependencies:
       react: 19.2.6
 
+  '@resvg/resvg-js-android-arm-eabi@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-android-arm64@2.6.2':
+    optional: true
+
   '@resvg/resvg-js-darwin-arm64@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-darwin-x64@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm-gnueabihf@2.6.2':
     optional: true
 
   '@resvg/resvg-js-linux-arm64-gnu@2.6.2':
@@ -7092,20 +7994,40 @@ snapshots:
   '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
     optional: true
 
+  '@resvg/resvg-js-win32-ia32-msvc@2.6.2':
+    optional: true
+
   '@resvg/resvg-js-win32-x64-msvc@2.6.2':
     optional: true
 
   '@resvg/resvg-js@2.6.2':
     optionalDependencies:
+      '@resvg/resvg-js-android-arm-eabi': 2.6.2
+      '@resvg/resvg-js-android-arm64': 2.6.2
       '@resvg/resvg-js-darwin-arm64': 2.6.2
+      '@resvg/resvg-js-darwin-x64': 2.6.2
+      '@resvg/resvg-js-linux-arm-gnueabihf': 2.6.2
       '@resvg/resvg-js-linux-arm64-gnu': 2.6.2
       '@resvg/resvg-js-linux-arm64-musl': 2.6.2
       '@resvg/resvg-js-linux-x64-gnu': 2.6.2
       '@resvg/resvg-js-linux-x64-musl': 2.6.2
       '@resvg/resvg-js-win32-arm64-msvc': 2.6.2
+      '@resvg/resvg-js-win32-ia32-msvc': 2.6.2
       '@resvg/resvg-js-win32-x64-msvc': 2.6.2
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.18':
+    optional: true
+
   '@rolldown/binding-darwin-arm64@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.18':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.18':
@@ -7114,10 +8036,26 @@ snapshots:
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.18':
     optional: true
 
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18':
+    optional: true
+
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.18':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.18':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.18':
@@ -7140,7 +8078,28 @@ snapshots:
     optionalDependencies:
       rollup: 4.60.3
 
+  '@rollup/rollup-android-arm-eabi@4.60.3':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.3':
+    optional: true
+
   '@rollup/rollup-darwin-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.3':
     optional: true
 
   '@rollup/rollup-linux-arm64-gnu@4.60.3':
@@ -7149,13 +8108,43 @@ snapshots:
   '@rollup/rollup-linux-arm64-musl@4.60.3':
     optional: true
 
+  '@rollup/rollup-linux-loong64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.3':
+    optional: true
+
   '@rollup/rollup-linux-x64-gnu@4.60.3':
     optional: true
 
   '@rollup/rollup-linux-x64-musl@4.60.3':
     optional: true
 
+  '@rollup/rollup-openbsd-x64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.3':
+    optional: true
+
   '@rollup/rollup-win32-arm64-msvc@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.3':
     optional: true
 
   '@rollup/rollup-win32-x64-gnu@4.60.3':
@@ -7546,20 +8535,20 @@ snapshots:
   '@smithy/uuid@1.1.2':
     dependencies:
       tslib: 2.8.1
-  ? '@spectrum-icons/ui@3.7.0(@adobe/react-spectrum@3.47.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6)))(react@19.2.6)(react-dom@19.2.6(react@19.2.6))'
 
-  : dependencies:
-      '@adobe/react-spectrum': 3.47.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
-      '@adobe/react-spectrum-ui': 1.2.1(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+  '@spectrum-icons/ui@3.7.0(@adobe/react-spectrum@3.47.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@adobe/react-spectrum': 3.47.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@adobe/react-spectrum-ui': 1.2.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@babel/runtime': 7.29.2
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-  ? '@spectrum-icons/workflow@4.3.0(@adobe/react-spectrum@3.47.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6)))(react@19.2.6)(react-dom@19.2.6(react@19.2.6))'
 
-  : dependencies:
-      '@adobe/react-spectrum': 3.47.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
-      '@adobe/react-spectrum-workflow': 2.3.5(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+  '@spectrum-icons/workflow@4.3.0(@adobe/react-spectrum@3.47.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@adobe/react-spectrum': 3.47.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@adobe/react-spectrum-workflow': 2.3.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -7577,7 +8566,7 @@ snapshots:
       '@stylexjs/stylex': 0.18.3
       postcss-value-parser: 4.2.0
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   '@stylexjs/shared@0.18.3': {}
 
@@ -7598,19 +8587,19 @@ snapshots:
       lightningcss: 1.32.0
       unplugin: 3.0.0
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   '@swc/helpers@0.5.21':
     dependencies:
       tslib: 2.8.1
 
-  '@tanstack/eslint-plugin-router@1.161.6(eslint@10.3.0(jiti@2.7.0))':
+  '@tanstack/eslint-plugin-router@1.161.6(eslint@10.3.0(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/utils': 8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@5.9.3)
       eslint: 10.3.0(jiti@2.7.0)
     transitivePeerDependencies:
-    - supports-color
-    - typescript
+      - supports-color
+      - typescript
 
   '@tanstack/history@1.161.6': {}
 
@@ -7620,78 +8609,78 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.100.9
       react: 19.2.6
-  ? '@tanstack/react-router-ssr-query@1.166.12(@tanstack/query-core@5.100.9)(@tanstack/react-query@5.100.9(react@19.2.6))(@tanstack/react-router@1.169.2(react@19.2.6)(react-dom@19.2.6(react@19.2.6)))(react@19.2.6)(react-dom@19.2.6(react@19.2.6))'
 
-  : dependencies:
+  '@tanstack/react-router-ssr-query@1.166.12(@tanstack/query-core@5.100.9)(@tanstack/react-query@5.100.9(react@19.2.6))(@tanstack/react-router@1.169.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@tanstack/router-core@1.169.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
       '@tanstack/query-core': 5.100.9
       '@tanstack/react-query': 5.100.9(react@19.2.6)
-      '@tanstack/react-router': 1.169.2(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+      '@tanstack/react-router': 1.169.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/router-ssr-query-core': 1.168.0(@tanstack/query-core@5.100.9)(@tanstack/router-core@1.169.2)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:
-    - '@tanstack/router-core'
+      - '@tanstack/router-core'
 
-  '@tanstack/react-router@1.169.2(react@19.2.6)(react-dom@19.2.6(react@19.2.6))':
+  '@tanstack/react-router@1.169.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@tanstack/history': 1.161.6
-      '@tanstack/react-store': 0.9.3(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+      '@tanstack/react-store': 0.9.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/router-core': 1.169.2
       isbot: 5.1.40
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  '@tanstack/react-start-client@1.166.48(react@19.2.6)(react-dom@19.2.6(react@19.2.6))':
+  '@tanstack/react-start-client@1.166.48(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@tanstack/react-router': 1.169.2(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+      '@tanstack/react-router': 1.169.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/router-core': 1.169.2
       '@tanstack/start-client-core': 1.168.2
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  '@tanstack/react-start-rsc@0.0.44(react@19.2.6)(react-dom@19.2.6(react@19.2.6))':
+  '@tanstack/react-start-rsc@0.0.44(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@22.19.18)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.4))':
     dependencies:
-      '@tanstack/react-router': 1.169.2(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
-      '@tanstack/react-start-server': 1.166.52(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+      '@tanstack/react-router': 1.169.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@tanstack/react-start-server': 1.166.52(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/router-core': 1.169.2
       '@tanstack/router-utils': 1.161.8
       '@tanstack/start-client-core': 1.168.2
       '@tanstack/start-fn-stubs': 1.161.6
-      '@tanstack/start-plugin-core': 1.169.20(vite@8.0.11(@types/node@22.19.18)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.4))
+      '@tanstack/start-plugin-core': 1.169.20(@tanstack/react-router@1.169.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.11(@types/node@22.19.18)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.4))
       '@tanstack/start-server-core': 1.167.30
       '@tanstack/start-storage-context': 1.166.35
       pathe: 2.0.3
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:
-    - '@rsbuild/core'
-    - crossws
-    - supports-color
-    - vite
-    - vite-plugin-solid
-    - webpack
+      - '@rsbuild/core'
+      - crossws
+      - supports-color
+      - vite
+      - vite-plugin-solid
+      - webpack
 
-  '@tanstack/react-start-server@1.166.52(react@19.2.6)(react-dom@19.2.6(react@19.2.6))':
+  '@tanstack/react-start-server@1.166.52(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@tanstack/history': 1.161.6
-      '@tanstack/react-router': 1.169.2(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+      '@tanstack/react-router': 1.169.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/router-core': 1.169.2
       '@tanstack/start-client-core': 1.168.2
       '@tanstack/start-server-core': 1.167.30
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:
-    - crossws
-  ? '@tanstack/react-start@1.167.65(react@19.2.6)(react-dom@19.2.6(react@19.2.6))(vite@8.0.11(@types/node@22.19.18)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.4))'
+      - crossws
 
-  : dependencies:
-      '@tanstack/react-router': 1.169.2(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
-      '@tanstack/react-start-client': 1.166.48(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
-      '@tanstack/react-start-rsc': 0.0.44(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
-      '@tanstack/react-start-server': 1.166.52(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+  '@tanstack/react-start@1.167.65(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@22.19.18)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.4))':
+    dependencies:
+      '@tanstack/react-router': 1.169.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@tanstack/react-start-client': 1.166.48(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@tanstack/react-start-rsc': 0.0.44(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@22.19.18)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.4))
+      '@tanstack/react-start-server': 1.166.52(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/router-utils': 1.161.8
       '@tanstack/start-client-core': 1.168.2
-      '@tanstack/start-plugin-core': 1.169.20(vite@8.0.11(@types/node@22.19.18)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.4))
+      '@tanstack/start-plugin-core': 1.169.20(@tanstack/react-router@1.169.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.11(@types/node@22.19.18)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.4))
       '@tanstack/start-server-core': 1.167.30
       pathe: 2.0.3
       react: 19.2.6
@@ -7699,14 +8688,14 @@ snapshots:
     optionalDependencies:
       vite: 8.0.11(@types/node@22.19.18)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.4)
     transitivePeerDependencies:
-    - '@rspack/core'
-    - crossws
-    - react-server-dom-rspack
-    - supports-color
-    - vite-plugin-solid
-    - webpack
+      - '@rspack/core'
+      - crossws
+      - react-server-dom-rspack
+      - supports-color
+      - vite-plugin-solid
+      - webpack
 
-  '@tanstack/react-store@0.9.3(react@19.2.6)(react-dom@19.2.6(react@19.2.6))':
+  '@tanstack/react-store@0.9.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@tanstack/store': 0.9.3
       react: 19.2.6
@@ -7719,7 +8708,7 @@ snapshots:
       chokidar: 3.6.0
       yargs: 17.7.2
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   '@tanstack/router-core@1.169.2':
     dependencies:
@@ -7739,10 +8728,10 @@ snapshots:
       prettier: 3.8.3
       zod: 3.25.76
     transitivePeerDependencies:
-    - supports-color
-  ? '@tanstack/router-plugin@1.167.35(@tanstack/react-router@1.169.2(react@19.2.6)(react-dom@19.2.6(react@19.2.6)))(vite@8.0.11(@types/node@22.19.18)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.4))'
+      - supports-color
 
-  : dependencies:
+  '@tanstack/router-plugin@1.167.35(@tanstack/react-router@1.169.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.11(@types/node@22.19.18)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.4))':
+    dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
@@ -7757,10 +8746,10 @@ snapshots:
       unplugin: 3.0.0
       zod: 3.25.76
     optionalDependencies:
-      '@tanstack/react-router': 1.169.2(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+      '@tanstack/react-router': 1.169.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       vite: 8.0.11(@types/node@22.19.18)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.4)
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   '@tanstack/router-ssr-query-core@1.168.0(@tanstack/query-core@5.100.9)(@tanstack/router-core@1.169.2)':
     dependencies:
@@ -7779,7 +8768,7 @@ snapshots:
       pathe: 2.0.3
       tinyglobby: 0.2.16
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   '@tanstack/start-client-core@1.168.2':
     dependencies:
@@ -7790,7 +8779,7 @@ snapshots:
 
   '@tanstack/start-fn-stubs@1.161.6': {}
 
-  '@tanstack/start-plugin-core@1.169.20(vite@8.0.11(@types/node@22.19.18)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.4))':
+  '@tanstack/start-plugin-core@1.169.20(@tanstack/react-router@1.169.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.11(@types/node@22.19.18)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.4))':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.29.0
@@ -7798,7 +8787,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.40
       '@tanstack/router-core': 1.169.2
       '@tanstack/router-generator': 1.166.42
-      '@tanstack/router-plugin': 1.167.35(@tanstack/react-router@1.169.2(react@19.2.6)(react-dom@19.2.6(react@19.2.6)))(vite@8.0.11(@types/node@22.19.18)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.4))
+      '@tanstack/router-plugin': 1.167.35(@tanstack/react-router@1.169.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.11(@types/node@22.19.18)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.4))
       '@tanstack/router-utils': 1.161.8
       '@tanstack/start-client-core': 1.168.2
       '@tanstack/start-server-core': 1.167.30
@@ -7818,11 +8807,11 @@ snapshots:
     optionalDependencies:
       vite: 8.0.11(@types/node@22.19.18)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.4)
     transitivePeerDependencies:
-    - '@tanstack/react-router'
-    - crossws
-    - supports-color
-    - vite-plugin-solid
-    - webpack
+      - '@tanstack/react-router'
+      - crossws
+      - supports-color
+      - vite-plugin-solid
+      - webpack
 
   '@tanstack/start-server-core@1.167.30':
     dependencies:
@@ -7834,7 +8823,7 @@ snapshots:
       h3-v2: h3@2.0.1-rc.20
       seroval: 1.5.4
     transitivePeerDependencies:
-    - crossws
+      - crossws
 
   '@tanstack/start-storage-context@1.166.35':
     dependencies:
@@ -7844,16 +8833,16 @@ snapshots:
 
   '@tanstack/virtual-file-routes@1.161.7': {}
 
-  '@tmcp/adapter-valibot@0.1.5(tmcp@1.19.4)(valibot@1.4.0(typescript@5.9.3))':
+  '@tmcp/adapter-valibot@0.1.5(tmcp@1.19.4(typescript@5.9.3))(valibot@1.4.0(typescript@5.9.3))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@valibot/to-json-schema': 1.7.0(valibot@1.4.0(typescript@5.9.3))
-      tmcp: 1.19.4
+      tmcp: 1.19.4(typescript@5.9.3)
       valibot: 1.4.0(typescript@5.9.3)
 
-  '@tmcp/transport-stdio@0.4.3(tmcp@1.19.4)':
+  '@tmcp/transport-stdio@0.4.3(tmcp@1.19.4(typescript@5.9.3))':
     dependencies:
-      tmcp: 1.19.4
+      tmcp: 1.19.4(typescript@5.9.3)
 
   '@tokenizer/token@0.3.0': {}
 
@@ -7862,6 +8851,11 @@ snapshots:
       minimatch: 10.2.5
       path-browserify: 1.0.1
       tinyglobby: 0.2.16
+
+  '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@types/better-sqlite3@7.6.13':
     dependencies:
@@ -7940,10 +8934,10 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.59.2(typescript@5.9.3)
       '@typescript-eslint/types': 8.59.2
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   '@typescript-eslint/scope-manager@8.59.2':
     dependencies:
@@ -7962,14 +8956,14 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.59.2(typescript@5.9.3)
       '@typescript-eslint/types': 8.59.2
       '@typescript-eslint/visitor-keys': 8.59.2
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.8.0
       tinyglobby: 0.2.16
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   '@typescript-eslint/utils@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
@@ -7980,7 +8974,7 @@ snapshots:
       eslint: 10.3.0(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   '@typescript-eslint/visitor-keys@8.59.2':
     dependencies:
@@ -8006,13 +9000,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@8.0.11(@types/node@22.19.18)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.4))':
+  '@vitest/mocker@3.2.4(vite@7.3.5(@types/node@22.19.18)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.11(@types/node@22.19.18)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.4)
+      vite: 7.3.5(@types/node@22.19.18)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -8044,9 +9038,9 @@ snapshots:
     dependencies:
       '@window-splitter/state': 1.1.3
 
-  '@window-splitter/react@1.1.3(react@19.2.6)(react-dom@19.2.6(react@19.2.6))':
+  '@window-splitter/react@1.1.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@react-aria/utils': 3.34.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+      '@react-aria/utils': 3.34.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@window-splitter/interface': 1.1.3
       '@window-splitter/state': 1.1.3
       react: 19.2.6
@@ -8136,11 +9130,11 @@ snapshots:
 
   axios@1.16.0:
     dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3(supports-color@5.5.0))
+      follow-redirects: 1.16.0
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
-    - debug
+      - debug
 
   babel-dead-code-elimination@1.0.12:
     dependencies:
@@ -8149,7 +9143,7 @@ snapshots:
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   bail@2.0.2: {}
 
@@ -8162,11 +9156,6 @@ snapshots:
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.29: {}
-
-  better-sqlite3@10.1.0:
-    dependencies:
-      bindings: 1.5.0
-      prebuild-install: 7.1.3
 
   better-sqlite3@11.10.0:
     dependencies:
@@ -8197,7 +9186,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 2.6.9(supports-color@5.5.0)
+      debug: 2.6.9
       depd: 2.0.0
       destroy: 1.2.0
       http-errors: 2.0.1
@@ -8208,7 +9197,7 @@ snapshots:
       type-is: 1.6.18
       unpipe: 1.0.0
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   boolbase@1.0.0: {}
 
@@ -8431,13 +9420,13 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       compressible: 2.0.18
-      debug: 2.6.9(supports-color@5.5.0)
+      debug: 2.6.9
       negotiator: 0.6.4
       on-headers: 1.1.0
       safe-buffer: 5.2.1
       vary: 1.1.2
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   content-disposition@0.5.4:
     dependencies:
@@ -8496,15 +9485,13 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  debug@2.6.9(supports-color@5.5.0):
+  debug@2.6.9:
     dependencies:
       ms: 2.0.0
-      supports-color: 5.5.0
 
-  debug@4.4.3(supports-color@5.5.0):
+  debug@4.4.3:
     dependencies:
       ms: 2.1.3
-      supports-color: 5.5.0
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -8680,10 +9667,31 @@ snapshots:
 
   esbuild@0.27.7:
     optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
       '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
       '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
       '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
       '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
 
   escalade@3.2.0: {}
@@ -8723,7 +9731,7 @@ snapshots:
       '@types/estree': 1.0.9
       ajv: 6.15.0
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       escape-string-regexp: 4.0.0
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
@@ -8744,7 +9752,7 @@ snapshots:
     optionalDependencies:
       jiti: 2.7.0
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   esm-env@1.2.2: {}
 
@@ -8837,7 +9845,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.0.7
-      debug: 2.6.9(supports-color@5.5.0)
+      debug: 2.6.9
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -8862,7 +9870,7 @@ snapshots:
       utils-merge: 1.0.1
       vary: 1.1.2
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   exsolve@1.0.8: {}
 
@@ -8932,7 +9940,7 @@ snapshots:
 
   finalhandler@1.3.2:
     dependencies:
-      debug: 2.6.9(supports-color@5.5.0)
+      debug: 2.6.9
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -8940,7 +9948,7 @@ snapshots:
       statuses: 2.0.2
       unpipe: 1.0.0
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   find-replace@3.0.0:
     dependencies:
@@ -8958,9 +9966,7 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.16.0(debug@4.4.3(supports-color@5.5.0)):
-    dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+  follow-redirects@1.16.0: {}
 
   foreground-child@3.3.1:
     dependencies:
@@ -9111,7 +10117,7 @@ snapshots:
       unist-util-position: 5.0.0
       zwitch: 2.0.4
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   hast-util-to-html@9.0.5:
     dependencies:
@@ -9145,7 +10151,7 @@ snapshots:
       unist-util-position: 5.0.0
       vfile-message: 4.0.3
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   hast-util-to-string@3.0.1:
     dependencies:
@@ -9159,24 +10165,24 @@ snapshots:
 
   hex-rgb@4.3.0: {}
 
-  hip-ui@0.3.0:
+  hip-ui@0.3.0(@types/react@19.2.14)(react@19.2.6)(typescript@5.9.3):
     dependencies:
       '@inkjs/ui': 2.0.0(ink@6.8.0(@types/react@19.2.14)(react@19.2.6))
-      '@tmcp/adapter-valibot': 0.1.5(tmcp@1.19.4)(valibot@1.4.0(typescript@5.9.3))
-      '@tmcp/transport-stdio': 0.4.3(tmcp@1.19.4)
+      '@tmcp/adapter-valibot': 0.1.5(tmcp@1.19.4(typescript@5.9.3))(valibot@1.4.0(typescript@5.9.3))
+      '@tmcp/transport-stdio': 0.4.3(tmcp@1.19.4(typescript@5.9.3))
       command-line-application: 0.10.1
       ink: 6.8.0(@types/react@19.2.14)(react@19.2.6)
       lilconfig: 3.1.3
-      media-chrome: 4.19.0
-      tmcp: 1.19.4
+      media-chrome: 4.19.0(react@19.2.6)
+      tmcp: 1.19.4(typescript@5.9.3)
       valibot: 1.4.0(typescript@5.9.3)
     transitivePeerDependencies:
-    - '@types/react'
-    - bufferutil
-    - react
-    - react-devtools-core
-    - typescript
-    - utf-8-validate
+      - '@types/react'
+      - bufferutil
+      - react
+      - react-devtools-core
+      - typescript
+      - utf-8-validate
 
   hmac-drbg@1.0.1:
     dependencies:
@@ -9275,8 +10281,8 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
     transitivePeerDependencies:
-    - bufferutil
-    - utf-8-validate
+      - bufferutil
+      - utf-8-validate
 
   inline-style-parser@0.2.7: {}
 
@@ -9288,7 +10294,7 @@ snapshots:
     dependencies:
       '@ioredis/commands': 1.5.1
       cluster-key-slot: 1.1.2
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       denque: 2.1.0
       lodash.defaults: 4.2.0
       lodash.isarguments: 3.1.0
@@ -9296,7 +10302,7 @@ snapshots:
       redis-parser: 3.0.0
       standard-as-callback: 2.1.0
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   ipaddr.js@1.9.1: {}
 
@@ -9386,7 +10392,7 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  knip@6.12.2:
+  knip@6.12.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.1):
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       formatly: 0.3.0
@@ -9394,7 +10400,7 @@ snapshots:
       jiti: 2.7.0
       minimist: 1.2.8
       oxc-parser: 0.128.0
-      oxc-resolver: 11.19.1
+      oxc-resolver: 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.1)
       picomatch: 4.0.4
       smol-toml: 1.6.1
       strip-json-comments: 5.0.3
@@ -9403,8 +10409,8 @@ snapshots:
       yaml: 2.8.4
       zod: 4.4.3
     transitivePeerDependencies:
-    - '@emnapi/core'
-    - '@emnapi/runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
   kysely@0.22.0: {}
 
@@ -9424,7 +10430,19 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
   lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
     optional: true
 
   lightningcss-linux-arm64-gnu@1.32.0:
@@ -9449,7 +10467,11 @@ snapshots:
     dependencies:
       detect-libc: 2.1.2
     optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
       lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
       lightningcss-linux-arm64-gnu: 1.32.0
       lightningcss-linux-arm64-musl: 1.32.0
       lightningcss-linux-x64-gnu: 1.32.0
@@ -9526,7 +10548,7 @@ snapshots:
       micromark-util-types: 2.0.2
       unist-util-stringify-position: 4.0.0
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   mdast-util-frontmatter@2.0.1:
     dependencies:
@@ -9537,7 +10559,7 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       micromark-extension-frontmatter: 2.0.0
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   mdast-util-gfm-autolink-literal@2.0.1:
     dependencies:
@@ -9555,7 +10577,7 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   mdast-util-gfm-strikethrough@2.0.0:
     dependencies:
@@ -9563,7 +10585,7 @@ snapshots:
       mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   mdast-util-gfm-table@2.0.0:
     dependencies:
@@ -9573,7 +10595,7 @@ snapshots:
       mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   mdast-util-gfm-task-list-item@2.0.0:
     dependencies:
@@ -9582,7 +10604,7 @@ snapshots:
       mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   mdast-util-gfm@3.1.0:
     dependencies:
@@ -9594,7 +10616,7 @@ snapshots:
       mdast-util-gfm-task-list-item: 2.0.0
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   mdast-util-mdx-expression@2.0.1:
     dependencies:
@@ -9605,7 +10627,7 @@ snapshots:
       mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   mdast-util-mdx-jsx@3.2.0:
     dependencies:
@@ -9622,7 +10644,7 @@ snapshots:
       unist-util-stringify-position: 4.0.0
       vfile-message: 4.0.3
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   mdast-util-mdx@3.0.0:
     dependencies:
@@ -9632,7 +10654,7 @@ snapshots:
       mdast-util-mdxjs-esm: 2.0.1
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   mdast-util-mdxjs-esm@2.0.1:
     dependencies:
@@ -9643,7 +10665,7 @@ snapshots:
       mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   mdast-util-phrasing@4.1.0:
     dependencies:
@@ -9680,11 +10702,11 @@ snapshots:
 
   meant@1.0.3: {}
 
-  media-chrome@4.19.0:
+  media-chrome@4.19.0(react@19.2.6):
     dependencies:
       ce-la-react: 0.3.2(react@19.2.6)
     transitivePeerDependencies:
-    - react
+      - react
 
   media-typer@0.3.0: {}
 
@@ -9944,7 +10966,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.13
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -9961,7 +10983,7 @@ snapshots:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   mime-db@1.52.0: {}
 
@@ -10076,47 +11098,97 @@ snapshots:
     dependencies:
       '@oxc-project/types': 0.128.0
     optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.128.0
+      '@oxc-parser/binding-android-arm64': 0.128.0
       '@oxc-parser/binding-darwin-arm64': 0.128.0
+      '@oxc-parser/binding-darwin-x64': 0.128.0
+      '@oxc-parser/binding-freebsd-x64': 0.128.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.128.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.128.0
       '@oxc-parser/binding-linux-arm64-gnu': 0.128.0
       '@oxc-parser/binding-linux-arm64-musl': 0.128.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.128.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.128.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.128.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.128.0
       '@oxc-parser/binding-linux-x64-gnu': 0.128.0
       '@oxc-parser/binding-linux-x64-musl': 0.128.0
+      '@oxc-parser/binding-openharmony-arm64': 0.128.0
+      '@oxc-parser/binding-wasm32-wasi': 0.128.0
       '@oxc-parser/binding-win32-arm64-msvc': 0.128.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.128.0
       '@oxc-parser/binding-win32-x64-msvc': 0.128.0
 
-  oxc-resolver@11.19.1:
+  oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.1):
     optionalDependencies:
+      '@oxc-resolver/binding-android-arm-eabi': 11.19.1
+      '@oxc-resolver/binding-android-arm64': 11.19.1
       '@oxc-resolver/binding-darwin-arm64': 11.19.1
+      '@oxc-resolver/binding-darwin-x64': 11.19.1
+      '@oxc-resolver/binding-freebsd-x64': 11.19.1
+      '@oxc-resolver/binding-linux-arm-gnueabihf': 11.19.1
+      '@oxc-resolver/binding-linux-arm-musleabihf': 11.19.1
       '@oxc-resolver/binding-linux-arm64-gnu': 11.19.1
       '@oxc-resolver/binding-linux-arm64-musl': 11.19.1
+      '@oxc-resolver/binding-linux-ppc64-gnu': 11.19.1
+      '@oxc-resolver/binding-linux-riscv64-gnu': 11.19.1
+      '@oxc-resolver/binding-linux-riscv64-musl': 11.19.1
+      '@oxc-resolver/binding-linux-s390x-gnu': 11.19.1
       '@oxc-resolver/binding-linux-x64-gnu': 11.19.1
       '@oxc-resolver/binding-linux-x64-musl': 11.19.1
+      '@oxc-resolver/binding-openharmony-arm64': 11.19.1
+      '@oxc-resolver/binding-wasm32-wasi': 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.1)
       '@oxc-resolver/binding-win32-arm64-msvc': 11.19.1
+      '@oxc-resolver/binding-win32-ia32-msvc': 11.19.1
       '@oxc-resolver/binding-win32-x64-msvc': 11.19.1
     transitivePeerDependencies:
-    - '@emnapi/core'
-    - '@emnapi/runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
   oxfmt@0.48.0:
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
+      '@oxfmt/binding-android-arm-eabi': 0.48.0
+      '@oxfmt/binding-android-arm64': 0.48.0
       '@oxfmt/binding-darwin-arm64': 0.48.0
+      '@oxfmt/binding-darwin-x64': 0.48.0
+      '@oxfmt/binding-freebsd-x64': 0.48.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.48.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.48.0
       '@oxfmt/binding-linux-arm64-gnu': 0.48.0
       '@oxfmt/binding-linux-arm64-musl': 0.48.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.48.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.48.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.48.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.48.0
       '@oxfmt/binding-linux-x64-gnu': 0.48.0
       '@oxfmt/binding-linux-x64-musl': 0.48.0
+      '@oxfmt/binding-openharmony-arm64': 0.48.0
       '@oxfmt/binding-win32-arm64-msvc': 0.48.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.48.0
       '@oxfmt/binding-win32-x64-msvc': 0.48.0
 
   oxlint@1.63.0:
     optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.63.0
+      '@oxlint/binding-android-arm64': 1.63.0
       '@oxlint/binding-darwin-arm64': 1.63.0
+      '@oxlint/binding-darwin-x64': 1.63.0
+      '@oxlint/binding-freebsd-x64': 1.63.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.63.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.63.0
       '@oxlint/binding-linux-arm64-gnu': 1.63.0
       '@oxlint/binding-linux-arm64-musl': 1.63.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.63.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.63.0
+      '@oxlint/binding-linux-riscv64-musl': 1.63.0
+      '@oxlint/binding-linux-s390x-gnu': 1.63.0
       '@oxlint/binding-linux-x64-gnu': 1.63.0
       '@oxlint/binding-linux-x64-musl': 1.63.0
+      '@oxlint/binding-openharmony-arm64': 1.63.0
       '@oxlint/binding-win32-arm64-msvc': 1.63.0
+      '@oxlint/binding-win32-ia32-msvc': 1.63.0
       '@oxlint/binding-win32-x64-msvc': 1.63.0
 
   p-finally@1.0.0: {}
@@ -10384,18 +11456,18 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-aria-components@1.17.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6)):
+  react-aria-components@1.17.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@internationalized/date': 3.12.1
       '@react-types/shared': 3.34.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       client-only: 0.0.1
       react: 19.2.6
-      react-aria: 3.48.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+      react-aria: 3.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom: 19.2.6(react@19.2.6)
       react-stately: 3.46.0(react@19.2.6)
 
-  react-aria@3.48.0(react@19.2.6)(react-dom@19.2.6(react@19.2.6)):
+  react-aria@3.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@internationalized/date': 3.12.1
       '@internationalized/number': 3.6.6
@@ -10432,7 +11504,7 @@ snapshots:
       unist-util-visit: 5.1.0
       vfile: 6.0.3
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   react-reconciler@0.33.0(react@19.2.6):
     dependencies:
@@ -10449,7 +11521,7 @@ snapshots:
       react: 19.2.6
       use-sync-external-store: 1.6.0(react@19.2.6)
 
-  react-transition-group@4.4.5(react@19.2.6)(react-dom@19.2.6(react@19.2.6)):
+  react-transition-group@4.4.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@babel/runtime': 7.29.2
       dom-helpers: 5.2.1
@@ -10537,7 +11609,7 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-to-estree: 3.1.3
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   rehype-sanitize@6.0.0:
     dependencies:
@@ -10559,7 +11631,7 @@ snapshots:
       micromark-extension-frontmatter: 2.0.0
       unified: 11.0.5
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   remark-gfm@4.0.1:
     dependencies:
@@ -10570,7 +11642,7 @@ snapshots:
       remark-stringify: 11.0.0
       unified: 11.0.5
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   remark-mdx-frontmatter@5.2.0:
     dependencies:
@@ -10586,7 +11658,7 @@ snapshots:
       mdast-util-mdx: 3.0.0
       micromark-extension-mdxjs: 3.0.0
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   remark-parse@11.0.0:
     dependencies:
@@ -10595,7 +11667,7 @@ snapshots:
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   remark-rehype@11.1.2:
     dependencies:
@@ -10633,11 +11705,19 @@ snapshots:
       '@oxc-project/types': 0.128.0
       '@rolldown/pluginutils': 1.0.0-rc.18
     optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.18
       '@rolldown/binding-darwin-arm64': 1.0.0-rc.18
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.18
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.18
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.18
       '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.18
       '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.18
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.18
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.18
       '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.18
       '@rolldown/binding-linux-x64-musl': 1.0.0-rc.18
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.18
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.18
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.18
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.18
 
@@ -10645,12 +11725,29 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.3
+      '@rollup/rollup-android-arm64': 4.60.3
       '@rollup/rollup-darwin-arm64': 4.60.3
+      '@rollup/rollup-darwin-x64': 4.60.3
+      '@rollup/rollup-freebsd-arm64': 4.60.3
+      '@rollup/rollup-freebsd-x64': 4.60.3
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.3
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.3
       '@rollup/rollup-linux-arm64-gnu': 4.60.3
       '@rollup/rollup-linux-arm64-musl': 4.60.3
+      '@rollup/rollup-linux-loong64-gnu': 4.60.3
+      '@rollup/rollup-linux-loong64-musl': 4.60.3
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.3
+      '@rollup/rollup-linux-ppc64-musl': 4.60.3
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.3
+      '@rollup/rollup-linux-riscv64-musl': 4.60.3
+      '@rollup/rollup-linux-s390x-gnu': 4.60.3
       '@rollup/rollup-linux-x64-gnu': 4.60.3
       '@rollup/rollup-linux-x64-musl': 4.60.3
+      '@rollup/rollup-openbsd-x64': 4.60.3
+      '@rollup/rollup-openharmony-arm64': 4.60.3
       '@rollup/rollup-win32-arm64-msvc': 4.60.3
+      '@rollup/rollup-win32-ia32-msvc': 4.60.3
       '@rollup/rollup-win32-x64-gnu': 4.60.3
       '@rollup/rollup-win32-x64-msvc': 4.60.3
       fsevents: 2.3.3
@@ -10695,7 +11792,7 @@ snapshots:
 
   send@0.19.2:
     dependencies:
-      debug: 2.6.9(supports-color@5.5.0)
+      debug: 2.6.9
       depd: 2.0.0
       destroy: 1.2.0
       encodeurl: 2.0.0
@@ -10709,7 +11806,7 @@ snapshots:
       range-parser: 1.2.1
       statuses: 2.0.2
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   seroval-plugins@1.5.4(seroval@1.5.4):
     dependencies:
@@ -10724,7 +11821,7 @@ snapshots:
       parseurl: 1.3.3
       send: 0.19.2
     transitivePeerDependencies:
-    - supports-color
+      - supports-color
 
   setprototypeof@1.2.0: {}
 
@@ -10735,15 +11832,23 @@ snapshots:
       semver: 7.8.0
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
+      '@img/sharp-darwin-x64': 0.33.5
       '@img/sharp-libvips-darwin-arm64': 1.0.4
+      '@img/sharp-libvips-darwin-x64': 1.0.4
+      '@img/sharp-libvips-linux-arm': 1.0.5
       '@img/sharp-libvips-linux-arm64': 1.0.4
+      '@img/sharp-libvips-linux-s390x': 1.0.4
       '@img/sharp-libvips-linux-x64': 1.0.4
       '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
       '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+      '@img/sharp-linux-arm': 0.33.5
       '@img/sharp-linux-arm64': 0.33.5
+      '@img/sharp-linux-s390x': 0.33.5
       '@img/sharp-linux-x64': 0.33.5
       '@img/sharp-linuxmusl-arm64': 0.33.5
       '@img/sharp-linuxmusl-x64': 0.33.5
+      '@img/sharp-wasm32': 0.33.5
+      '@img/sharp-win32-ia32': 0.33.5
       '@img/sharp-win32-x64': 0.33.5
 
   shebang-command@2.0.0:
@@ -10975,7 +12080,7 @@ snapshots:
 
   tlds@1.261.0: {}
 
-  tmcp@1.19.4:
+  tmcp@1.19.4(typescript@5.9.3):
     dependencies:
       '@standard-schema/spec': 1.1.0
       json-rpc-2.0: 1.7.1
@@ -10983,7 +12088,7 @@ snapshots:
       uri-template-matcher: 1.1.2
       valibot: 1.4.0(typescript@5.9.3)
     transitivePeerDependencies:
-    - typescript
+      - typescript
 
   to-regex-range@5.0.1:
     dependencies:
@@ -11169,26 +12274,41 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@3.2.4:
+  vite-node@3.2.4(@types/node@22.19.18)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 8.0.11(@types/node@22.19.18)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.4)
+      vite: 7.3.5(@types/node@22.19.18)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
     transitivePeerDependencies:
-    - '@types/node'
-    - jiti
-    - less
-    - lightningcss
-    - sass
-    - sass-embedded
-    - stylus
-    - sugarss
-    - supports-color
-    - terser
-    - tsx
-    - yaml
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.5(@types/node@22.19.18)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4):
+    dependencies:
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rollup: 4.60.3
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 22.19.18
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      yaml: 2.8.4
 
   vite@8.0.11(@types/node@22.19.18)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.4):
     dependencies:
@@ -11208,18 +12328,18 @@ snapshots:
     optionalDependencies:
       vite: 8.0.11(@types/node@22.19.18)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.4)
 
-  vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.18):
+  vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.18)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@8.0.11(@types/node@22.19.18)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.4))
+      '@vitest/mocker': 3.2.4(vite@7.3.5(@types/node@22.19.18)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
       chai: 5.3.3
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       expect-type: 1.3.0
       magic-string: 0.30.21
       pathe: 2.0.3
@@ -11230,29 +12350,29 @@ snapshots:
       tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 8.0.11(@types/node@22.19.18)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.4)
-      vite-node: 3.2.4
+      vite: 7.3.5(@types/node@22.19.18)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
+      vite-node: 3.2.4(@types/node@22.19.18)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.13
       '@types/node': 22.19.18
     transitivePeerDependencies:
-    - jiti
-    - less
-    - lightningcss
-    - msw
-    - sass
-    - sass-embedded
-    - stylus
-    - sugarss
-    - supports-color
-    - terser
-    - tsx
-    - yaml
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   walk-up-path@4.0.0: {}
 
-  web-haptics@0.0.6(react@19.2.6)(react-dom@19.2.6(react@19.2.6)):
+  web-haptics@0.0.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     optionalDependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,13 @@ packages:
   - "packages/*"
   - "infra/*"
 
+overrides:
+  # @atproto/pds pins better-sqlite3@10.x, whose native source predates
+  # Node 24's C++20-only V8 headers and won't compile (no Node 24 prebuilt
+  # exists either). Force the 11.x our own packages already use, which
+  # builds cleanly from source on Node 24.
+  better-sqlite3: "^11.10.0"
+
 allowBuilds:
   better-sqlite3: true
   core-js: true


### PR DESCRIPTION
This change moves the endpoints to /xrpc so atproto clients can access it if they are signed in with a client via oauth with scopes or a password. Tested with goat xrpc.

I left the actual crud methods alone. But probably some questions like "Should these tokens be tied to a service did and should other service dids be able to delete other ones?" etc. But ideally good chance if you trust a service to have access to your openAPI keys to interact withe cocore you probably trust it fully? 