### PR TITLE
Add "reset connection" account repair flow

### DIFF
--- a/packages/appview/src/api/internal-reset.test.ts
+++ b/packages/appview/src/api/internal-reset.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Server } from "node:http";
+
+import { Store } from "../store.ts";
+import { AccountStore } from "../operational/account-store.ts";
+import { buildServer } from "./server.ts";
+
+// Exercises POST /internal/account/reset-did — the AppView half of the
+// console's "reset connection" repair flow. The route is gated on the
+// shared internal secret (console<->AppView trust boundary), so we build
+// the server with one and present it via the x-cocore-internal-secret
+// header.
+
+const SECRET = "test-internal-secret";
+const ALICE = "did:plc:alice";
+const BOB = "did:plc:bob";
+
+let server: Server | undefined;
+let base = "";
+let accountStore: AccountStore;
+
+function startServer(): Promise<{ base: string; server: Server }> {
+  const store = new Store(":memory:");
+  accountStore = new AccountStore(":memory:");
+  const srv = buildServer(store, {
+    accountStore,
+    appviewDid: "did:web:appview.test",
+    internalSecret: SECRET,
+  });
+  return new Promise((resolve) => {
+    srv.listen(0, () => {
+      const addr = srv.address();
+      if (typeof addr === "string" || !addr) throw new Error("no address");
+      resolve({ base: `http://127.0.0.1:${addr.port}`, server: srv });
+    });
+  });
+}
+
+beforeEach(async () => {
+  const s = await startServer();
+  server = s.server;
+  base = s.base;
+});
+
+afterEach(() => {
+  server?.close();
+  server = undefined;
+});
+
+function resetReq(body: unknown, secret: string | null): Promise<Response> {
+  return fetch(`${base}/internal/account/reset-did`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...(secret ? { "x-cocore-internal-secret": secret } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /internal/account/reset-did", () => {
+  it("rejects a missing/wrong secret with 403", async () => {
+    expect((await resetReq({ did: ALICE }, null)).status).toBe(403);
+    expect((await resetReq({ did: ALICE }, "wrong")).status).toBe(403);
+  });
+
+  it("requires a did", async () => {
+    expect((await resetReq({}, SECRET)).status).toBe(400);
+    expect((await resetReq({ did: "not-a-did" }, SECRET)).status).toBe(400);
+  });
+
+  it("revokes the DID's keys + drops its session, leaving other DIDs intact", async () => {
+    const a = accountStore.createKey({ did: ALICE, name: "laptop" });
+    accountStore.putOAuthSession(ALICE, '{"dpop":"v1"}');
+    const b = accountStore.createKey({ did: BOB, name: "desktop" });
+    accountStore.putOAuthSession(BOB, '{"dpop":"v1"}');
+
+    const res = await resetReq({ did: ALICE }, SECRET);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, keysRevoked: 1 });
+
+    // Alice is fully reset.
+    expect(accountStore.resolveBearerKey(a.secret)).toBeNull();
+    expect(accountStore.getOAuthSession(ALICE)).toBeNull();
+
+    // Bob is untouched.
+    expect(accountStore.resolveBearerKey(b.secret)?.did).toBe(BOB);
+    expect(accountStore.getOAuthSession(BOB)).toBe('{"dpop":"v1"}');
+  });
+});

--- a/packages/appview/src/api/server.ts
+++ b/packages/appview/src/api/server.ts
@@ -638,6 +638,40 @@ export function buildAppviewHandler(store: Store, opts: BuildServerOptions = {})
       const out = accountStore.createKey({ did: body.did, name });
       json(res, 200, { key: out.key, secret: out.secret });
     };
+
+    // Reset a DID's operational auth state: revoke every API key and drop
+    // the stored OAuth session. The console calls this (browser-authed to
+    // the DID) as the AppView half of "reset connection" — the repair flow
+    // that clears a wedged session/key without deleting any PDS records.
+    // Deliberately does NOT touch receipts or the firehose-indexed cache.
+    routes["/internal/account/reset-did"] = async (req, res) => {
+      if (req.method !== "POST") {
+        json(res, 405, { error: "MethodNotAllowed" });
+        return;
+      }
+      const presented = req.headers["x-cocore-internal-secret"];
+      if (typeof presented !== "string" || !secretEquals(presented, secret)) {
+        json(res, 403, { error: "Forbidden" });
+        return;
+      }
+      const chunks: Buffer[] = [];
+      for await (const c of req) chunks.push(c as Buffer);
+      let body: { did?: unknown };
+      try {
+        body = JSON.parse(Buffer.concat(chunks).toString("utf8")) as typeof body;
+      } catch {
+        json(res, 400, { error: "InvalidRequest", message: "body must be JSON" });
+        return;
+      }
+      if (typeof body.did !== "string" || !body.did.startsWith("did:")) {
+        json(res, 400, { error: "InvalidRequest", message: "did required" });
+        return;
+      }
+      const keysRevoked = accountStore.revokeAllKeysForDid(body.did);
+      accountStore.deleteOAuthSession(body.did);
+      console.error(`appview: reset auth state for ${body.did} (${keysRevoked} keys revoked)`);
+      json(res, 200, { ok: true, keysRevoked });
+    };
   }
 
   // Device pairing: in-memory pair-store + start/poll (public, agent-facing)

--- a/packages/appview/src/operational/account-store.test.ts
+++ b/packages/appview/src/operational/account-store.test.ts
@@ -67,6 +67,22 @@ describe("AccountStore api keys", () => {
     expect(mine).toHaveLength(1);
     expect(mine[0]?.name).toBe("a");
   });
+
+  it("revokeAllKeysForDid revokes only the DID's active keys and is idempotent", () => {
+    const s = freshStore();
+    const a = s.createKey({ did: DID, name: "a" });
+    const b = s.createKey({ did: DID, name: "b" });
+    s.createKey({ did: OTHER, name: "c" });
+
+    // Revokes both of DID's keys, leaving OTHER's untouched.
+    expect(s.revokeAllKeysForDid(DID)).toBe(2);
+    expect(s.resolveBearerKey(a.secret)).toBeNull();
+    expect(s.resolveBearerKey(b.secret)).toBeNull();
+    expect(s.listKeysForDid(OTHER)[0]?.revokedAt).toBeNull();
+
+    // Already-revoked keys aren't counted again.
+    expect(s.revokeAllKeysForDid(DID)).toBe(0);
+  });
 });
 
 describe("AccountStore oauth sessions", () => {

--- a/packages/appview/src/operational/account-store.ts
+++ b/packages/appview/src/operational/account-store.ts
@@ -186,6 +186,17 @@ export class AccountStore {
     return result.changes > 0;
   }
 
+  /** Revoke every still-active key for a DID. Used by the "reset
+   *  connection" repair flow: a wedged agent key is invalidated in one
+   *  shot without hunting per-key. Revoked rows stay (with `revoked_at`
+   *  set) so the audit trail survives. Returns the number revoked. */
+  revokeAllKeysForDid(did: string): number {
+    const result = this.db
+      .prepare(`UPDATE api_keys SET revoked_at = ? WHERE did = ? AND revoked_at IS NULL`)
+      .run(new Date().toISOString(), did);
+    return result.changes;
+  }
+
   /** Validate a presented bearer token: format, hash lookup, expiry,
    *  revocation. On success, bumps `last_used_at` and returns the owning
    *  DID. Returns null on any failure (caller should respond 401; the

--- a/packages/console/src/components/account/AccountSettings.tsx
+++ b/packages/console/src/components/account/AccountSettings.tsx
@@ -2,7 +2,7 @@
 
 import * as stylex from "@stylexjs/stylex";
 import { useMutation, useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Link } from "@tanstack/react-router";
+import { Link, useNavigate } from "@tanstack/react-router";
 import { CircleHelp } from "lucide-react";
 import { useMemo, useState } from "react";
 
@@ -10,9 +10,11 @@ import { highlightCodeQueryOptions } from "@/components/account/account.function
 import {
   deleteMyApiKeyMutationOptions,
   listMyApiKeysQueryOptions,
+  resetConnectionMutationOptions,
   revokeMyApiKeyMutationOptions,
   wipeMyDataMutationOptions,
 } from "@/components/api-keys/api-keys.functions.ts";
+import { clearChatStoreMemory } from "@/components/chat/chat-store.ts";
 import { CreateApiKeyButton } from "@/components/api-keys/CreateApiKeyButton.tsx";
 import { ProfileCard } from "@/components/account/ProfileCard.tsx";
 import { TokenBalanceCard } from "@/components/account/TokenBalanceCard.tsx";
@@ -217,6 +219,7 @@ function statusOf(row: {
 
 export function AccountSettings() {
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
   const { data: session } = useQuery(getSessionQueryOptions);
   const { mode, setMode } = useThemeMode();
 
@@ -224,8 +227,10 @@ export function AccountSettings() {
   const revokeM = useMutation(revokeMyApiKeyMutationOptions);
   const deleteM = useMutation(deleteMyApiKeyMutationOptions);
   const wipeM = useMutation(wipeMyDataMutationOptions);
+  const resetM = useMutation(resetConnectionMutationOptions);
 
   const [wipeOpen, setWipeOpen] = useState(false);
+  const [resetOpen, setResetOpen] = useState(false);
 
   const onRevoke = (id: string, name: string) => {
     revokeM.mutate(
@@ -267,6 +272,26 @@ export function AccountSettings() {
         queryClient.invalidateQueries({ queryKey: listMyApiKeysQueryOptions.queryKey });
       },
       onError: (e) => showToast(e instanceof Error ? e.message : "Wipe failed"),
+    });
+  };
+
+  const onReset = () => {
+    resetM.mutate(undefined, {
+      onSuccess: async () => {
+        // The server fn cleared the auth cookie, so the browser is now
+        // signed out. Send the user through a fresh login — that OAuth
+        // handshake is what re-establishes a working write session.
+        // Mirror the navbar logout teardown so no stale user-scoped
+        // cache lingers.
+        showToast("Connection reset — sign in again to finish");
+        setResetOpen(false);
+        clearChatStoreMemory();
+        queryClient.setQueryData(getSessionQueryOptions.queryKey, null);
+        await navigate({ to: "/login", search: { redirect: "/account" } });
+        queryClient.clear();
+        queryClient.setQueryData(getSessionQueryOptions.queryKey, null);
+      },
+      onError: (e) => showToast(e instanceof Error ? e.message : "Reset failed"),
     });
   };
 
@@ -511,6 +536,59 @@ export function AccountSettings() {
                 }}
               </TableBody>
             </Table>
+          </Card>
+          <Card size="md">
+            <CardHeader hasBorder>
+              <CardTitle style={styles.cardTitleMono}>Reset connection</CardTitle>
+              <CardDescription style={styles.cardDescription}>
+                Stuck with 401s from your agent? Rebuild your sign-in and keys without touching any
+                of your data.
+              </CardDescription>
+            </CardHeader>
+            <CardBody>
+              <Dialog
+                isOpen={resetOpen}
+                onOpenChange={setResetOpen}
+                trigger={
+                  <Button variant="secondary" size="sm">
+                    Reset connection
+                  </Button>
+                }
+              >
+                <DialogHeader>Reset your co/core connection?</DialogHeader>
+                <DialogBody>
+                  <DialogDescription>
+                    Revokes every API key you&apos;ve minted and drops your stored ATProto write
+                    session, then signs you out so you can sign back in fresh. This fixes a wedged
+                    agent (401 <InlineCode>invalid API key</InlineCode> /{" "}
+                    <InlineCode>AuthRequired</InlineCode>) — none of your{" "}
+                    <InlineCode>dev.cocore.*</InlineCode> PDS records, receipts, or indexed history
+                    are touched. Quit any running co/core agents first, then after you sign back in
+                    run <InlineCode>cocore agent pair</InlineCode> to re-link your machine.
+                  </DialogDescription>
+                </DialogBody>
+                <DialogFooter>
+                  <Flex direction="row" gap="md">
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      onPress={() => setResetOpen(false)}
+                      isDisabled={resetM.isPending}
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      variant="primary"
+                      size="sm"
+                      isDisabled={resetM.isPending}
+                      onPress={onReset}
+                    >
+                      {resetM.isPending ? "Resetting…" : "Reset connection"}
+                    </Button>
+                  </Flex>
+                </DialogFooter>
+              </Dialog>
+            </CardBody>
           </Card>
           <Card size="md">
             <CardHeader hasBorder>

--- a/packages/console/src/components/api-keys/api-keys.functions.ts
+++ b/packages/console/src/components/api-keys/api-keys.functions.ts
@@ -1,5 +1,6 @@
 import { mutationOptions, queryOptions } from "@tanstack/react-query";
 import { createServerFn } from "@tanstack/react-start";
+import { getRequest, setCookie } from "@tanstack/react-start/server";
 import { z } from "zod";
 
 import {
@@ -9,7 +10,12 @@ import {
   listKeysForDid,
   revokeKey,
 } from "@/lib/api-keys.server.ts";
+import { type ResetConnectionReport, resetMyConnection } from "@/lib/reset-connection.server.ts";
 import { wipeMyData } from "@/lib/wipe-my-data.server.ts";
+import { revokeAppSession } from "@/integrations/auth/app-session-store.server.ts";
+import { AUTH_SESSION_TOKEN_COOKIE } from "@/integrations/auth/constants.ts";
+import { authCookieDomain } from "@/integrations/auth/cookie-domain.ts";
+import { readAuthSessionToken } from "@/integrations/auth/cookie-parse.ts";
 import { authMiddleware } from "@/middleware/auth.ts";
 
 const createKeySchema = z.object({
@@ -78,6 +84,37 @@ const wipeMyDataServerFn = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
   .handler(({ context }) => wipeMyData(context.oauthSession));
 
+// Reset connection: rebuild the caller's auth plumbing (revoke keys, drop
+// the OAuth session in both stores) without deleting any data, then clear
+// the browser session so the next step is a fresh OAuth login — the
+// handshake that re-establishes a valid write session. Distinct from wipe,
+// which destroys PDS records + the AppView index.
+const resetConnectionServerFn = createServerFn({ method: "POST" })
+  .middleware([authMiddleware])
+  .handler(async ({ context }): Promise<ResetConnectionReport> => {
+    const report = await resetMyConnection(context.did);
+
+    // Force re-auth: drop the app-session row + clear its cookie. We do
+    // this AFTER the reset so this request still completes; the client
+    // redirects to /login on success. Mirrors signOutServerFn so the
+    // cookie's Domain matches what oauth-callback set.
+    const request = getRequest();
+    const token = readAuthSessionToken(request.headers.get("cookie"));
+    if (token) revokeAppSession(token);
+    const isHttps = request.url.startsWith("https://");
+    const cookieDomain = authCookieDomain(new URL(request.url).host);
+    setCookie(AUTH_SESSION_TOKEN_COOKIE, "", {
+      path: "/",
+      httpOnly: true,
+      sameSite: "lax",
+      maxAge: 0,
+      ...(isHttps ? { secure: true } : {}),
+      ...(cookieDomain ? { domain: cookieDomain } : {}),
+    });
+
+    return report;
+  });
+
 export type CreateMyApiKeyInput = z.infer<typeof createKeySchema>;
 export type RevokeMyApiKeyInput = z.infer<typeof revokeKeySchema>;
 export type DeleteMyApiKeyInput = z.infer<typeof deleteKeySchema>;
@@ -96,4 +133,8 @@ export const deleteMyApiKeyMutationOptions = mutationOptions({
 
 export const wipeMyDataMutationOptions = mutationOptions({
   mutationFn: () => wipeMyDataServerFn(),
+});
+
+export const resetConnectionMutationOptions = mutationOptions({
+  mutationFn: () => resetConnectionServerFn(),
 });

--- a/packages/console/src/lib/api-keys.server.ts
+++ b/packages/console/src/lib/api-keys.server.ts
@@ -144,6 +144,18 @@ export function deleteKey(input: { id: string; did: string }): boolean {
   return result.changes > 0;
 }
 
+/** Revoke every still-active key for a DID in one shot. Used by the
+ *  "reset connection" repair flow to invalidate a wedged agent key
+ *  without the user hunting through their key list. Revoked rows stay
+ *  with `revoked_at` set so the audit trail survives. Returns the count
+ *  revoked. */
+export function revokeAllKeysForDid(did: string): number {
+  const result = consoleDb()
+    .prepare(`UPDATE api_keys SET revoked_at = ? WHERE did = ? AND revoked_at IS NULL`)
+    .run(new Date().toISOString(), did);
+  return result.changes;
+}
+
 export interface ResolvedKey {
   id: string;
   did: string;

--- a/packages/console/src/lib/appview-session-handoff.server.ts
+++ b/packages/console/src/lib/appview-session-handoff.server.ts
@@ -51,6 +51,45 @@ export async function handOffSessionToAppview(did: string): Promise<boolean> {
   }
 }
 
+export interface AppviewResetResult {
+  /** Whether the handoff was configured + attempted at all. */
+  attempted: boolean;
+  /** Whether the AppView reported a successful reset. */
+  ok: boolean;
+  /** Keys the AppView revoked in its own store (0 if not attempted). */
+  keysRevoked: number;
+}
+
+/** Reset a DID's auth state on the AppView: revoke its keys + drop its
+ *  stored OAuth session. The AppView half of "reset connection" — needed
+ *  because post-cutover the authoritative write session (and minted keys)
+ *  live in the AppView's account store, not the console's. Best-effort and
+ *  gated on COCORE_APPVIEW_INTERNAL_URL + COCORE_INTERNAL_SECRET; a missing
+ *  config or a failure never throws (the console-side reset still stands). */
+export async function resetConnectionOnAppview(did: string): Promise<AppviewResetResult> {
+  const base = process.env["COCORE_APPVIEW_INTERNAL_URL"]?.replace(/\/$/, "");
+  const secret = process.env["COCORE_INTERNAL_SECRET"];
+  if (!base || !secret) return { attempted: false, ok: false, keysRevoked: 0 };
+
+  try {
+    const res = await fetch(`${base}/internal/account/reset-did`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-cocore-internal-secret": secret },
+      body: JSON.stringify({ did }),
+    });
+    if (!res.ok) {
+      console.warn(`[appview-reset] AppView returned ${res.status} for ${did}`);
+      return { attempted: true, ok: false, keysRevoked: 0 };
+    }
+    const body = (await res.json()) as { keysRevoked?: number };
+    console.log(`[appview-reset] reset auth state for ${did} on AppView`);
+    return { attempted: true, ok: true, keysRevoked: body.keysRevoked ?? 0 };
+  } catch (e) {
+    console.warn(`[appview-reset] reset failed for ${did}:`, (e as Error).message);
+    return { attempted: true, ok: false, keysRevoked: 0 };
+  }
+}
+
 export interface SessionMigrationResult {
   total: number;
   pushed: number;

--- a/packages/console/src/lib/reset-connection.server.ts
+++ b/packages/console/src/lib/reset-connection.server.ts
@@ -1,0 +1,60 @@
+// "Reset connection" — repair a wedged auth/connection state without
+// destroying any data.
+//
+// This is the non-destructive twin of `wipe-my-data.server.ts`. Where a
+// wipe deletes the user's PDS records + AppView index + keys ("start over
+// from zero"), a reset rebuilds only the auth plumbing that gets wedged
+// ("fix my connection"):
+//
+//   1. Revoke every API key for the DID (console store + AppView store).
+//      A wedged agent key — e.g. left over from a wipe, or split-brained
+//      across the console/AppView stores after the cutover — is gone, so
+//      `cocore agent pair` mints a clean one.
+//   2. Drop the stored OAuth session for the DID (console store + AppView
+//      store). A poisoned session `restore()`s successfully but 401s on
+//      write (its refresh token was rotated out from under it — the
+//      two-daemon race), so we must DELETE it: the only cure is a fresh
+//      browser OAuth handshake, which the caller is sent through next.
+//
+// What this deliberately does NOT do (the line that separates it from a
+// wipe):
+//   * Touch ANY `dev.cocore.*` PDS records — receipts, jobs, provider,
+//     attestation, settlement all survive.
+//   * Purge the AppView's firehose-indexed receipt cache.
+//   * Delete `console_user_prefs`.
+//   * Touch any other DID.
+//
+// The server fn that calls this (api-keys.functions.ts) additionally
+// clears the browser session so the user is forced through a fresh login
+// — that login is what re-establishes a valid OAuth session.
+
+import type { Did } from "@atcute/lexicons";
+
+import { revokeAllKeysForDid } from "@/lib/api-keys.server.ts";
+import { resetConnectionOnAppview } from "@/lib/appview-session-handoff.server.ts";
+import { SqliteOauthSessionStore } from "@/lib/oauth-session-store.server.ts";
+
+export interface ResetConnectionReport {
+  /** Active keys revoked in the console store. */
+  apiKeysRevoked: number;
+  /** Whether the console's OAuth session row was dropped. */
+  oauthClearedConsole: boolean;
+  /** Outcome of the AppView half (no-op when handoff isn't configured). */
+  appview: { attempted: boolean; ok: boolean; keysRevoked: number };
+}
+
+export async function resetMyConnection(did: string): Promise<ResetConnectionReport> {
+  const apiKeysRevoked = revokeAllKeysForDid(did);
+
+  let oauthClearedConsole = false;
+  try {
+    new SqliteOauthSessionStore().delete(did as Did);
+    oauthClearedConsole = true;
+  } catch {
+    oauthClearedConsole = false;
+  }
+
+  const appview = await resetConnectionOnAppview(did);
+
+  return { apiKeysRevoked, oauthClearedConsole, appview };
+}


### PR DESCRIPTION
## What

A non-destructive **"reset connection"** action on `/account`, distinct from the existing **"wipe my data"** nuke.

|  | **Wipe** (exists) | **Reset** (this PR) |
|---|---|---|
| Intent | "Start over from zero" | "Fix my connection" |
| PDS `dev.cocore.*` records | **deleted** | **untouched** |
| AppView receipt index | **purged** | **untouched** |
| API keys | hard-deleted | **revoked** (both stores) |
| OAuth write session | *left alone* (the bug) | **dropped + rebuilt** |
| Scope | caller's own DID | caller's own DID |

## Why

Reported failure: after `wipe-my-data` drops the agent's API key, a clean uninstall + reinstall + re-pair still yields `401 invalid API key` from `/api/agent/whoami` **and** `401 AuthRequired` on the daemon's publish. Two separate auth surfaces are wedged:

- **API key** (`api_keys`, keyed by DID) — gone after wipe; re-pair mints a fresh one.
- **OAuth write session** (`oauth_sessions`, one row per DID) — re-pair never refreshes it. It `restore()`s *successfully* but 401s on write because its refresh token was rotated out from under it (the "two daemons" race against a single-row, last-write-wins session store). The only cure is a fresh **browser OAuth handshake** — which re-pair skips when a cookie is already present.

Only the user can complete that handshake, so the repair belongs in the UI. (`session.functions.ts` already anticipated this: a future affordance that "clears the oauth_sessions row + revokes all keys".)

## How

Reset, scoped to the caller's own DID via `authMiddleware`:
1. Revoke every API key — console store **and** AppView account store (covers the post-cutover split where the authoritative key/session live on the AppView).
2. Drop the stored OAuth session in both stores.
3. Clear the browser auth cookie + app-session row, then send the user to `/login` — the fresh handshake re-establishes a valid write session.

Then the user quits any running agents and runs `cocore agent pair` once to re-link. Dialog copy sets that expectation.

## Changes

- **appview**: `AccountStore.revokeAllKeysForDid()`; secret-gated `POST /internal/account/reset-did` (revoke keys + drop session; touches no receipts/index).
- **console**: `revokeAllKeysForDid()`, `resetConnectionOnAppview()`, `resetMyConnection()` orchestrator, auth-gated `resetConnectionServerFn` (clears the cookie like sign-out), and the "Reset connection" card on `/account`.
- **tests**: `AccountStore.revokeAllKeysForDid` + the `/internal/account/reset-did` route.

## Verification

- `@cocore/appview` tests: **87 passed** (incl. the 2 new suites).
- `tsc` typecheck (console + appview), `oxlint`, `oxfmt --check`, `knip`: all clean.
- Console vitest: the 71 tests that run pass; 8 files fail to load with `Cannot find package '@/...'` — a path-alias resolution artifact of installing with `pnpm` instead of the repo's `aube` in this environment. Confirmed identical on a clean checkout (stash), so not introduced here.

## Follow-ups (out of scope, noted from the investigation)

- **`serve` singleton lock** — root cause of the session race; without it, users can re-wedge after reset. Highest-leverage next change.
- **doctor/health** can't distinguish a dead key from a dead session (whoami only checks the key), so the publish-side 401 gets a misleading "re-pair" hint.
- **Cutover split-brain** — post-Stage-B `devicePair.confirm` mints into the AppView store while `/api/agent/whoami` reads the console store; worth confirming this is the affected user's actual blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198DQmd4rJ3YHJCfz2wp8mB

---
_Generated by [Claude Code](https://claude.ai/code/session_0198DQmd4rJ3YHJCfz2wp8mB)_