### PR TITLE
feat(confidential): wire APNs code-identity end-to-end + decouple tier from MDA

### DIFF
--- a/infra/advisor/src/apns.ts
+++ b/infra/advisor/src/apns.ts
@@ -10,6 +10,7 @@
 // (provider/spikes/apns) — this is the same flow in TypeScript.
 
 import crypto from "node:crypto";
+import http2 from "node:http2";
 import nacl from "tweetnacl";
 
 const APNS_HOST = "https://api.push.apple.com";
@@ -102,39 +103,83 @@ export interface ApnsSendResult {
   apnsId?: string;
 }
 
-/** Push a sealed code-identity challenge to a provider's device token. */
+/** How long to wait for the whole APNs round-trip before giving up. */
+const APNS_TIMEOUT_MS = 10_000;
+
+/** Push a sealed code-identity challenge to a provider's device token.
+ *
+ *  APNs REQUIRES HTTP/2. Node's global `fetch` (undici) is HTTP/1.1 only and
+ *  fails every push to `api.push.apple.com` with `TypeError: fetch failed`
+ *  (status 0) — which is exactly why code-attestation never completed in the
+ *  field. We therefore open an HTTP/2 session with `node:http2` directly. The
+ *  S5 spike used Swift/URLSession (HTTP/2 by default), so this gap only
+ *  surfaced once the TypeScript advisor tried to send. */
 export async function sendCodeChallenge(
   cfg: ApnsConfig,
   deviceToken: string,
   encryptionPubKeyB64: string,
   nonce: string,
-  fetchImpl: typeof fetch = fetch,
 ): Promise<ApnsSendResult> {
   const cc = sealCodeChallenge(nonce, encryptionPubKeyB64);
-  const body = JSON.stringify({ aps: { "content-available": 1 }, cc });
-  let res: Response;
+  const body = Buffer.from(JSON.stringify({ aps: { "content-available": 1 }, cc }));
+  let jwt: string;
   try {
-    res = await fetchImpl(`${APNS_HOST}/3/device/${deviceToken}`, {
-      method: "POST",
-      headers: {
-        authorization: `bearer ${buildApnsJwt(cfg)}`,
-        "apns-topic": cfg.topic,
-        "apns-push-type": "background",
-        "apns-priority": "5",
-        "apns-expiration": "0",
-      },
-      body,
-    });
+    jwt = buildApnsJwt(cfg);
   } catch (e) {
-    return { ok: false, status: 0, reason: String(e) };
+    return { ok: false, status: 0, reason: `jwt: ${String(e)}` };
   }
-  const apnsId = res.headers.get("apns-id") ?? undefined;
-  if (res.status === 200) return { ok: true, status: 200, apnsId };
-  let reason: string | undefined;
-  try {
-    reason = (JSON.parse(await res.text()) as { reason?: string }).reason;
-  } catch {
-    // non-JSON body; leave reason undefined
-  }
-  return { ok: false, status: res.status, reason, apnsId };
+  return await new Promise<ApnsSendResult>((resolve) => {
+    let settled = false;
+    const client = http2.connect(APNS_HOST);
+    const finish = (r: ApnsSendResult): void => {
+      if (settled) return;
+      settled = true;
+      try {
+        client.close();
+      } catch {
+        // already closing
+      }
+      resolve(r);
+    };
+    client.on("error", (e) => finish({ ok: false, status: 0, reason: String(e) }));
+    const req = client.request({
+      ":method": "POST",
+      ":path": `/3/device/${deviceToken}`,
+      authorization: `bearer ${jwt}`,
+      "apns-topic": cfg.topic,
+      "apns-push-type": "background",
+      "apns-priority": "5",
+      "apns-expiration": "0",
+      "content-type": "application/json",
+      "content-length": String(body.length),
+    });
+    req.setTimeout(APNS_TIMEOUT_MS, () => {
+      req.close();
+      finish({ ok: false, status: 0, reason: "apns request timeout" });
+    });
+    let status = 0;
+    let apnsId: string | undefined;
+    const chunks: Buffer[] = [];
+    req.on("response", (headers) => {
+      status = Number(headers[":status"]) || 0;
+      apnsId = (headers["apns-id"] as string | undefined) ?? undefined;
+    });
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("error", (e) => finish({ ok: false, status: 0, reason: String(e) }));
+    req.on("end", () => {
+      if (status === 200) {
+        finish({ ok: true, status: 200, apnsId });
+        return;
+      }
+      let reason: string | undefined;
+      try {
+        reason = (JSON.parse(Buffer.concat(chunks).toString()) as { reason?: string }).reason;
+      } catch {
+        // non-JSON body; leave reason undefined
+      }
+      finish({ ok: false, status, reason, apnsId });
+    });
+    req.write(body);
+    req.end();
+  });
 }

--- a/provider/src/advisor.rs
+++ b/provider/src/advisor.rs
@@ -115,6 +115,13 @@ impl AdvisorClient {
         // flipping) and restarts to reload the new active set.
         model_schedules: &crate::schedule::ModelSchedules,
         configured_models: &[String],
+        // APNs code-identity push receiver (confidential tier; `apns` build).
+        // The process main thread runs the AppKit push host (see
+        // `push_host::run_blocking`) and forwards each received `E_K(nonce)`
+        // challenge here. `None` on non-apns builds and on headless sessions
+        // that never registered for push — the corresponding `select!` arm is
+        // then inert and the loop behaves exactly as before.
+        mut push_rx: Option<&mut mpsc::UnboundedReceiver<String>>,
     ) -> Result<()> {
         tracing::info!(url = %self.url, "connecting to advisor");
         let (ws, _resp) =
@@ -412,6 +419,29 @@ impl AdvisorClient {
                     write.send(Message::Text(payload.into()))
                         .await
                         .map_err(|e| ProviderError::Advisor(e.to_string()))?;
+                }
+                // APNs code-identity challenge (confidential tier). The push
+                // host on the main thread forwarded an `E_K(nonce)` payload:
+                // open it with `K`, SE-sign the recovered nonce, and emit a
+                // `CodeAttestationResponse` over the existing outbound channel
+                // so the advisor can mark this measured binary `codeAttested`.
+                // Inert when `push_rx` is None (non-apns / headless).
+                Some(payload) = next_push(&mut push_rx) => {
+                    match handle_code_challenge_payload(encryption, signer, &payload) {
+                        Ok(Some(resp)) => {
+                            match serde_json::to_string(&AdvisorMessage::CodeAttestationResponse(resp)) {
+                                Ok(s) => {
+                                    // Route through outbound_tx so the single
+                                    // `write` half stays uncontended.
+                                    let _ = outbound_tx.send(s);
+                                    tracing::info!("answered APNs code-identity challenge");
+                                }
+                                Err(e) => tracing::warn!(error = %e, "serialize code-attestation response failed"),
+                            }
+                        }
+                        Ok(None) => tracing::warn!("code-identity push payload was not a parseable challenge"),
+                        Err(e) => tracing::warn!(error = %e, "failed to answer code-identity challenge"),
+                    }
                 }
                 // An in-flight job finished — flush its replies. Guarded so
                 // the branch is disabled (rather than spinning on a `None`)
@@ -1316,6 +1346,18 @@ pub fn parse_code_challenge_payload(json_str: &str) -> Option<(String, String)> 
 /// recover the nonce and produce the signed response. `Ok(None)` means the
 /// push wasn't a code challenge (ignore it); `Err` means it was but couldn't
 /// be opened (fail-closed — no response goes out).
+/// Await the next APNs push payload from an optional receiver. When the
+/// receiver is absent (non-apns build, or a headless session that never got a
+/// push host), this future never resolves, so the `select!` arm that uses it
+/// stays permanently inert — the serve loop behaves exactly as it did before
+/// code identity existed.
+async fn next_push(rx: &mut Option<&mut mpsc::UnboundedReceiver<String>>) -> Option<String> {
+    match rx {
+        Some(rx) => rx.recv().await,
+        None => std::future::pending().await,
+    }
+}
+
 pub fn handle_code_challenge_payload(
     encryption: &ProviderKeypair,
     signer: &dyn SigningIdentity,

--- a/provider/src/attestation.rs
+++ b/provider/src/attestation.rs
@@ -109,6 +109,33 @@ pub struct AttestationRecord {
 ///
 /// Used by `cmd_serve` to publish a fresh attestation on each boot
 /// so receipts have something to strong-ref.
+/// Apple Silicon Secure Boot status. There's no cheap syscall for the boot
+/// policy (`bputil` needs sudo), but `system_profiler SPiBridgeDataType`
+/// reports it as `Secure Boot: Full Security` — the ONLY level that counts as
+/// fully enabled (Reduced / Permissive do not). Returns false on any
+/// uncertainty so the confidential posture is never over-claimed. ~1–2s; run
+/// once per attestation build (boot + the 23h refresh).
+#[cfg(target_os = "macos")]
+fn detect_secure_boot() -> bool {
+    use std::process::Command;
+    let out = match Command::new("/usr/sbin/system_profiler")
+        .arg("SPiBridgeDataType")
+        .output()
+    {
+        Ok(o) if o.status.success() => o.stdout,
+        _ => return false,
+    };
+    String::from_utf8_lossy(&out).lines().any(|l| {
+        let l = l.trim();
+        l.starts_with("Secure Boot:") && l.contains("Full Security")
+    })
+}
+
+#[cfg(not(target_os = "macos"))]
+fn detect_secure_boot() -> bool {
+    false
+}
+
 pub fn build_stub_inputs(provider_did: &str, encryption_pub_key_b64: &str) -> AttestationInputs {
     let binary_path =
         std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("cocore-provider"));
@@ -128,11 +155,13 @@ pub fn build_stub_inputs(provider_did: &str, encryption_pub_key_b64: &str) -> At
         serial_number: "stub-serial".into(),
         os_version,
         binary_path,
-        // sysctl exposes `kern.bootargs` etc but reading them
-        // reliably across macOS versions is fiddly; we report the
-        // honest "we did not verify" state for the stub build.
+        // SIP is verified ON before we ever get here: `security::apply_all`
+        // runs `csrutil status` at startup and refuses to serve if it's off.
         sip_enabled: true,
-        secure_boot_enabled: false,
+        // Apple Silicon Secure Boot policy, measured live (Full Security only).
+        // Reduced/Permissive and any read failure report false (the honest
+        // floor) so we never over-claim the confidential posture.
+        secure_boot_enabled: detect_secure_boot(),
         secure_enclave_available: false,
         authenticated_root_enabled: false,
         rdma_disabled: true,
@@ -226,11 +255,20 @@ pub fn build(
     };
     let mda_chain_b64: Vec<String> = mda_chain.iter().map(|c| B64.encode(c)).collect();
 
-    // Producer's HONEST self-asserted tier. `attested-confidential` requires
-    // the full confidential posture AND a bound MDA chain that survived
-    // verification above; everything else is best-effort. Verifiers recompute
-    // this from evidence (and the requester's known-good set + session key) and
-    // never trust the field — but the producer must not over-claim.
+    // Producer's HONEST self-asserted tier. `attested-confidential` is the
+    // CONFIDENTIALITY axis — "the prompt is handled only inside this measured,
+    // signed binary, and the operator can't read it." It is ORTHOGONAL to
+    // `trustLevel` (the hardware-attestation axis): the bound Apple MDA chain
+    // gates `trustLevel: hardware-attested` (computed by the caller from
+    // `mda_cert_chain`), NOT the tier. A machine can therefore be
+    // self-attested (software) AND attested-confidential — its confidentiality
+    // is backed by the in-process native engine + the hardened posture +
+    // (off-record) the advisor's APNs code-identity challenge + cdHash
+    // known-good gate, while its hardware is not independently Apple-attested.
+    // The tier requires the FULL confidential posture; everything else is
+    // best-effort. Verifiers recompute this from evidence (known-good set +
+    // session key + code-attestation) and never trust the field — but the
+    // producer must not over-claim.
     let confidential_capable = inputs.in_process_backend
         && !inputs.get_task_allow
         && inputs.hardened_runtime
@@ -240,8 +278,7 @@ pub fn build(
         && inputs.env_scrubbed
         && inputs.sip_enabled
         && inputs.secure_boot_enabled
-        && inputs.cd_hash.is_some()
-        && !mda_chain_b64.is_empty();
+        && inputs.cd_hash.is_some();
     let tier = if confidential_capable {
         "attested-confidential"
     } else {
@@ -394,8 +431,9 @@ mod tests {
         assert!(!rec.selfSignature.is_empty());
         assert_eq!(rec.serialNumberHash.len(), 64);
         assert!(rec.expiresAt > rec.attestedAt);
-        // No MDA chain + no native engine → must self-assert best-effort,
-        // never attested-confidential.
+        // No native in-process engine (inProcessBackend=false) → must
+        // self-assert best-effort, never attested-confidential. (The MDA chain
+        // is irrelevant to the tier; it gates trustLevel only.)
         assert_eq!(rec.tier, "best-effort");
         assert!(!rec.inProcessBackend);
     }
@@ -440,11 +478,14 @@ mod tests {
             rec.mdaCertChain.is_empty(),
             "an unverifiable / unbound chain must be dropped, not embedded"
         );
-        // Even with a full in-process confidential posture, a DROPPED MDA chain
-        // means the producer must NOT self-assert attested-confidential.
+        // tier ⊥ trustLevel: a dropped/absent MDA chain caps the HARDWARE axis
+        // (the caller computes trustLevel: self-attested), but does NOT cap the
+        // CONFIDENTIALITY tier — a full in-process confidential posture still
+        // earns attested-confidential. The chain being dropped only means this
+        // machine isn't ALSO hardware-attested.
         assert_eq!(
-            rec.tier, "best-effort",
-            "without a bound MDA chain the tier caps at best-effort"
+            rec.tier, "attested-confidential",
+            "a full confidential posture earns the tier regardless of the MDA chain"
         );
     }
 }

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -182,7 +182,7 @@ async fn main() -> Result<()> {
 
     match cli.cmd {
         Cmd::Agent(AgentCmd::Pair { console }) => cmd_pair(&console).await,
-        Cmd::Agent(AgentCmd::Serve { advisor }) => cmd_serve(&advisor).await,
+        Cmd::Agent(AgentCmd::Serve { advisor }) => cmd_serve_entry(advisor).await,
         Cmd::Agent(AgentCmd::Whoami) => cmd_whoami(),
         Cmd::Agent(AgentCmd::Doctor { console, fix }) => doctor::run(&console, fix).await,
         Cmd::Agent(AgentCmd::Update { console, check }) => update::run(&console, check).await,
@@ -586,7 +586,62 @@ async fn wait_until_active(pds: &cocore_provider::pds::PdsClient, rkey: Option<&
     }
 }
 
-async fn cmd_serve(advisor_url: &str) -> Result<()> {
+/// Serve entrypoint. On the confidential (`apns`) build it hands the process
+/// **main thread** to the AppKit APNs push host while the tokio serve loop runs
+/// on a dedicated thread's runtime: AppKit's run loop must own the main thread,
+/// and the measured worker binary (this process — it holds `K` and the SE key)
+/// must be the push receiver, so the code-identity challenge can only be
+/// answered with this split. On every other build it's a thin async
+/// passthrough with no push receiver.
+#[cfg(all(target_os = "macos", feature = "apns"))]
+async fn cmd_serve_entry(advisor: String) -> Result<()> {
+    use tokio::sync::mpsc::unbounded_channel;
+    // The push host (main thread) forwards `E_K(nonce)` challenges on this
+    // channel; the serve loop (worker thread) drains it. Unbounded so the
+    // Cocoa-thread callback never blocks.
+    let (push_tx, push_rx) = unbounded_channel::<String>();
+    // Drive the async serve loop on its own multi-threaded runtime, leaving the
+    // main OS thread free for `NSApplication.run`.
+    std::thread::Builder::new()
+        .name("cocore-serve".into())
+        .spawn(move || {
+            let rt = match tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(rt) => rt,
+                Err(e) => {
+                    tracing::error!(error = %e, "failed to build serve runtime");
+                    std::process::exit(1);
+                }
+            };
+            if let Err(e) = rt.block_on(cmd_serve(&advisor, Some(push_rx))) {
+                tracing::error!(error = %e, "serve loop exited with error");
+            }
+            // The serve loop only returns on a fatal / owner-stop path; the push
+            // host owns main and never returns, so exit and let the supervisor
+            // restart us cleanly rather than leaving a half-dead process.
+            std::process::exit(0);
+        })
+        .map_err(|e| anyhow::anyhow!("spawn serve thread: {e}"))?;
+    // Hand the main thread to the push host. Never returns.
+    cocore_provider::push_host::run_blocking(push_tx)
+}
+
+/// Non-confidential builds: no push host, serve directly on the main runtime.
+#[cfg(not(all(target_os = "macos", feature = "apns")))]
+async fn cmd_serve_entry(advisor: String) -> Result<()> {
+    cmd_serve(&advisor, None).await
+}
+
+async fn cmd_serve(
+    advisor_url: &str,
+    // APNs code-identity push receiver (confidential tier; `apns` build). The
+    // process main thread runs the AppKit push host and forwards challenges
+    // here; we thread it into every `AdvisorClient::run` so it survives
+    // reconnects. `None` on non-apns builds / headless sessions.
+    mut push_rx: Option<tokio::sync::mpsc::UnboundedReceiver<String>>,
+) -> Result<()> {
     // No session yet → the user installed but hasn't paired. Sleep
     // forever in this process rather than exit-1 → launchd
     // restart → exit-1 → launchd restart… The KeepAlive loop fills
@@ -1072,6 +1127,7 @@ async fn cmd_serve(advisor_url: &str) -> Result<()> {
                             &desired_at_start,
                             &model_schedules,
                             &configured_models,
+                            push_rx.as_mut(),
                         )
                         .await;
                     let lived = connected_at.elapsed();
@@ -1131,7 +1187,7 @@ async fn cmd_serve(advisor_url: &str) -> Result<()> {
                         );
                         let client = AdvisorClient::new(advisor_url);
                         tokio::select! {
-                            res = client.run(register.clone(), &*signer, &enc, &pds, attestation, &eng, provider_rkey.as_deref(), &desired_at_start, &model_schedules, &configured_models) => {
+                            res = client.run(register.clone(), &*signer, &enc, &pds, attestation, &eng, provider_rkey.as_deref(), &desired_at_start, &model_schedules, &configured_models, push_rx.as_mut()) => {
                                 if let Err(e) = res {
                                     tracing::warn!(error = %e, "advisor run ended; reconnecting within window in 5s");
                                 }

--- a/scripts/build-confidential-worker.sh
+++ b/scripts/build-confidential-worker.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Build the CONFIDENTIAL worker bundle — `CoCoreProvider.app` — for the
+# attested-confidential canary.
+#
+# This is the measured push-receiver bundle the runbook (Phase 5.2 / 6.1)
+# describes: the `--features apns` agent binary packaged as its OWN app bundle
+# with CFBundleIdentifier = dev.cocore.provider + an embedded Developer ID
+# provisioning profile carrying aps-environment=production, so AMFI grants the
+# binary the right to register for APNs and receive the advisor's code-identity
+# challenge. A re-signed fork (no profile / Developer ID) is rejected by AMFI —
+# the un-forgeable property the confidential tier's code-identity leg depends on.
+#
+# Output: provider-shell/build/CoCoreProvider.app  (Developer-ID signed; NOT
+# notarized — fine for a local canary, the binary launches on the build machine
+# without Gatekeeper quarantine. Notarize for distribution.)
+#
+# Usage:
+#   COCORE_PROVISION_PROFILE=~/Downloads/cocore_provisioning_profile.provisionprofile \
+#     ./scripts/build-confidential-worker.sh
+
+set -euo pipefail
+
+readonly REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly PROVIDER="$REPO_ROOT/provider"
+readonly OUT_DIR="$REPO_ROOT/provider-shell/build"
+readonly APP="$OUT_DIR/CoCoreProvider.app"
+readonly TEAM_ID="4L45P7CP9M"
+readonly BUNDLE_ID="dev.cocore.provider"
+readonly PROFILE="${COCORE_PROVISION_PROFILE:-$HOME/Downloads/cocore_provisioning_profile.provisionprofile}"
+
+bold() { printf '\033[1m%s\033[0m\n' "$*"; }
+note() { printf '  %s\n' "$*"; }
+die()  { printf '\033[31m  error:\033[0m %s\n' "$*" >&2; exit 1; }
+
+[[ "$(uname -s)" == "Darwin" ]] || die "macOS only"
+[[ -f "$PROFILE" ]] || die "provisioning profile not found at $PROFILE (set COCORE_PROVISION_PROFILE)"
+xcodebuild -version >/dev/null 2>&1 || die "needs full Xcode (Metal toolchain) for the native engine + metallib"
+
+SIGN_ID="$(security find-identity -p codesigning -v 2>/dev/null \
+  | sed -n 's/.*"\(Developer ID Application: .*\)"/\1/p' | head -1)"
+[[ -n "$SIGN_ID" ]] || die "no Developer ID Application identity in the keychain"
+note "signing identity: $SIGN_ID"
+
+bold "==> build the apns (native + push host) agent binary"
+( cd "$PROVIDER" && cargo build --release --locked --features apns )
+WORKER_BIN="$PROVIDER/target/release/cocore"
+[[ -x "$WORKER_BIN" ]] || die "apns binary not found at $WORKER_BIN"
+note "built $("$WORKER_BIN" --version)"
+
+bold "==> compile the MLX metallib (xcodebuild PrepareMetalShaders — swift build skips it)"
+MLX_ENGINE_DIR="$PROVIDER/mlx-engine"
+XCBUILD_DIR="$MLX_ENGINE_DIR/.xcbuild-metallib"
+( cd "$MLX_ENGINE_DIR" && xcodebuild -scheme CoCoreMLX \
+    -destination 'platform=macOS,arch=arm64' -configuration Release \
+    -derivedDataPath "$XCBUILD_DIR" build >/dev/null 2>&1 ) \
+  || die "metallib compile failed (xcodebuild -scheme CoCoreMLX)"
+METALLIB="$(find "$XCBUILD_DIR" -path '*Cmlx*' -name 'default.metallib' -print -quit 2>/dev/null || true)"
+[[ -n "$METALLIB" && -f "$METALLIB" ]] || die "no default.metallib produced under $XCBUILD_DIR"
+DYLIB="$MLX_ENGINE_DIR/.build/release/libCoCoreMLX.dylib"
+[[ -f "$DYLIB" ]] || die "libCoCoreMLX.dylib not found (cargo build.rs should have produced it)"
+
+bold "==> assemble CoCoreProvider.app"
+rm -rf "$APP"
+mkdir -p "$APP/Contents/MacOS"
+install -m 755 "$WORKER_BIN" "$APP/Contents/MacOS/cocore-provider"
+install -m 755 "$DYLIB"      "$APP/Contents/MacOS/libCoCoreMLX.dylib"
+install -m 644 "$METALLIB"   "$APP/Contents/MacOS/mlx.metallib"
+cp "$PROFILE" "$APP/Contents/embedded.provisionprofile"
+note "metallib: $(du -h "$METALLIB" | cut -f1); profile embedded"
+
+# Info.plist: a background (LSUIElement) app whose bundle id matches the App ID
+# the provisioning profile authorizes, so Bundle.main resolves to this bundle
+# and AMFI maps the embedded profile + aps-environment to the running binary.
+cat > "$APP/Contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key><string>${BUNDLE_ID}</string>
+    <key>CFBundleName</key><string>co/core provider</string>
+    <key>CFBundleExecutable</key><string>cocore-provider</string>
+    <key>CFBundlePackageType</key><string>APPL</string>
+    <key>CFBundleShortVersionString</key><string>0.9.19</string>
+    <key>CFBundleVersion</key><string>919</string>
+    <key>LSMinimumSystemVersion</key><string>13.0</string>
+    <key>LSUIElement</key><true/>
+</dict>
+</plist>
+PLIST
+
+# Resolved entitlements: ONLY what the provisioning profile authorizes (an
+# ungranted restricted entitlement → amfid kills the worker at spawn). The
+# profile grants application-identifier, team-identifier, aps-environment, and
+# keychain-access-groups; it does NOT grant `com.apple.security.hypervisor`, so
+# that defense-in-depth flag is dropped (the native engine runs fine without
+# it). The hardened-runtime cs.* flags + get-task-allow=false are plain
+# code-signing flags (always permitted) and are what the attestation reports as
+# hardenedRuntime / libraryValidation / getTaskAllow=false.
+ENTITLEMENTS="$OUT_DIR/cocore-provider.entitlements.resolved"
+cat > "$ENTITLEMENTS" <<ENT
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.application-identifier</key><string>${TEAM_ID}.${BUNDLE_ID}</string>
+    <key>com.apple.developer.team-identifier</key><string>${TEAM_ID}</string>
+    <key>com.apple.developer.aps-environment</key><string>production</string>
+    <key>keychain-access-groups</key>
+    <array><string>${TEAM_ID}.${BUNDLE_ID}</string></array>
+    <key>com.apple.security.cs.allow-jit</key><false/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key><false/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key><false/>
+    <key>com.apple.security.cs.disable-library-validation</key><false/>
+    <key>com.apple.security.cs.disable-executable-page-protection</key><false/>
+    <key>com.apple.security.get-task-allow</key><false/>
+</dict>
+</plist>
+ENT
+
+bold "==> codesign inside-out (Developer ID + hardened runtime)"
+# Nested code first: the engine dylib (library validation, so the worker's
+# enforced CS_REQUIRE_LV accepts it — same team), then the metallib (nested
+# Mach-O code object), then the worker executable WITH entitlements + the
+# embedded profile context, then the bundle.
+codesign --force --options runtime,library --timestamp \
+  --sign "$SIGN_ID" "$APP/Contents/MacOS/libCoCoreMLX.dylib"
+codesign --force --options runtime --timestamp \
+  --sign "$SIGN_ID" "$APP/Contents/MacOS/mlx.metallib"
+# Sign the worker binary directly with entitlements (it is the bundle main
+# executable; codesign applies the entitlements to it). runtime,library →
+# CS_REQUIRE_LV set, which the attestation reports as libraryValidation=true.
+codesign --force --options runtime,library --timestamp \
+  --entitlements "$ENTITLEMENTS" \
+  --sign "$SIGN_ID" "$APP/Contents/MacOS/cocore-provider"
+# Sign the bundle (picks up the embedded profile + nested code). MUST keep
+# `library` here too: a bundle sign re-signs the main executable, so signing it
+# with plain `runtime` would STRIP the CS_REQUIRE_LV flag set above and the
+# attestation would report libraryValidation=false → tier caps at best-effort.
+codesign --force --options runtime,library --timestamp \
+  --entitlements "$ENTITLEMENTS" \
+  --sign "$SIGN_ID" "$APP"
+
+bold "==> verify signature + entitlements"
+codesign --verify --strict --verbose=2 "$APP" || die "signature verify failed"
+echo "--- worker entitlements (must show aps-environment=production) ---"
+codesign -d --entitlements - --xml "$APP/Contents/MacOS/cocore-provider" 2>/dev/null | plutil -p - | grep -E "aps-environment|get-task-allow|application-identifier" || true
+echo "--- cdHash / flags ---"
+codesign -dvvv "$APP/Contents/MacOS/cocore-provider" 2>&1 | grep -iE "CDHash|TeamIdentifier|flags|Identifier=" || true
+
+bold "==> done"
+note "bundle: $APP"
+note "cdHash above is the value to add to COCORE_KNOWN_GOOD_CDHASHES on the advisor."


### PR DESCRIPTION
Makes a cocore machine able to actually **earn the `attested-confidential` tier**, and fixes the production bug that was silently blocking it for everyone. Proven end-to-end on a real M1 (serial `H2WHW38LQ6NV`, "Mac Mini 1"): the full code-identity round-trip completed — `-> code-challenge` → agent `answered APNs code-identity challenge` → advisor `code-attestation OK`.

## Critical fix — advisor APNs sender (HTTP/2)
`infra/advisor/src/apns.ts` pushed via `fetch()`, but **APNs requires HTTP/2** and Node's `fetch` (undici) is HTTP/1.1 only — so every code-challenge push failed with `TypeError: fetch failed` (status 0). **Code-attestation could never complete in the field.** Rewritten with `node:http2`; verified reaching Apple (a bad token now returns a real `400 BadDeviceToken` + `apns-id` instead of a transport error). The S5 spike used Swift/URLSession (HTTP/2 by default), so this gap only surfaced once the TypeScript advisor tried to send.

## Agent main-thread APNs handoff
`provider/src/main.rs` + `advisor.rs`: wired the previously-unconnected push host. On the `apns` build the process **main thread** runs the AppKit push receiver (`push_host::run_blocking`) while the tokio serve loop runs on its own runtime thread; received `E_K(nonce)` challenges flow through a `push_rx` into a new `select!` arm that opens with `K`, SE-signs, and emits `CodeAttestationResponse`. **cfg-gated to the `apns` build** — default/published builds are byte-for-byte unchanged.

## Decouple tier from MDA
`provider/src/attestation.rs`: per the 0.9.19 orthogonal model (tier = confidentiality, trustLevel = hardware attestation), `attested-confidential` no longer requires a bound Apple MDA chain — it requires the native in-process engine + the full hardened posture + cdHash. The MDA chain still gates `trustLevel: hardware-attested`. **This matches the advisor's own confidential gate, which never checked MDA** (the two were inconsistent).

## Secure Boot detection
`secure_boot_enabled` was hardcoded `false` (the stub default) — which **alone** capped every Apple-silicon machine at best-effort. Now measured live via `system_profiler SPiBridgeDataType` (Full Security only); read failures report false so the posture is never over-claimed.

## Confidential worker bundle
`scripts/build-confidential-worker.sh` builds `CoCoreProvider.app` — the `--features apns` agent packaged as a `dev.cocore.provider` bundle with the embedded Developer ID provisioning profile (`aps-environment=production`) + native engine, signed `runtime,library` so `libraryValidation` holds. AMFI gates the push topic to this signature, so a re-signed fork cannot receive the challenge.

## Verification
- Provider: 99 lib tests + clippy clean (apns feature).
- Advisor: 79 tests + typecheck.
- Live on the canary M1: native in-process Qwen2.5-0.5B, APNs token issued, attestation publishes `tier: attested-confidential` + `secureBootEnabled: true`, and the **full code-attestation round-trip verified** against a local advisor with the known-good cdHash.

## To enable in production (ops)
1. Merge → advisor auto-deploys the HTTP/2 fix.
2. Set `COCORE_KNOWN_GOOD_CDHASHES=49e206dedc9e099fc2a4a62084ae8bb3bc62afcc` on the advisor (this build's cdHash).

Then the canary machine flips to `confidentialEligible` with no further machine-side action.

## Known follow-ups
- APNs **background-push throttling**: rapid re-challenges get rate-limited by Apple (runbook §13). The production 300s interval is within limits; if delivery proves unreliable, switch to alert-priority push (the agent never requests user-notification authorization, so it stays silent).
- Productionize the worker into the **notarized tray app** (nested `CoCoreProvider.app` + `AgentSupervisor` spawn) so the confidential path ships via the normal release instead of a standalone LaunchAgent.
- Client-edge verifier (`verify-provider.ts`) still requires MDA for the confidential seal (advisor-trustless by design); decoupling it there is a separate consuming-side decision (code-attestation is advisor-asserted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)