### PR TITLE
feat(confidential): productionize attested-confidential into 0.9.20

### DIFF
--- a/provider-shell/Sources/CoCoreShell/AgentSupervisor.swift
+++ b/provider-shell/Sources/CoCoreShell/AgentSupervisor.swift
@@ -225,7 +225,7 @@ final class AgentSupervisor {
         // A fresh deliberate start clears the stop latch so a later
         // unexpected exit is treated as a crash and respawned.
         intentionalStop = false
-        guard let bin = Self.locateBinary() else {
+        guard let bin = Self.serveBinary() else {
             NSLog("cocore: provider binary not found")
             return
         }
@@ -362,7 +362,10 @@ final class AgentSupervisor {
     private static func killStrayAgents() {
         let pgrep = Process()
         pgrep.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
-        pgrep.arguments = ["-f", "cocore agent serve"]
+        // Match both the default CLI (`cocore agent serve`) and the nested
+        // confidential worker (`cocore-provider agent serve`) — a confidential
+        // machine runs the latter, and an orphan of either kind must be reaped.
+        pgrep.arguments = ["-f", "cocore(-provider)? agent serve"]
         let pipe = Pipe()
         pgrep.standardOutput = pipe
         pgrep.standardError = FileHandle.nullDevice
@@ -641,5 +644,55 @@ final class AgentSupervisor {
             candidate = candidate.deletingLastPathComponent()
         }
         return nil
+    }
+
+    /// This machine's owner-chosen trust tier, read by running the bundled
+    /// CLI's `agent tier` (which consults the PDS provider record). Returns
+    /// `"best-effort"` on any error — the safe default that runs the
+    /// non-entitled default binary. Synchronous + called once per spawn (the
+    /// same pattern as the other CLI shell-outs in this type).
+    nonisolated static func probeTier() -> String {
+        guard let bin = locateBinary() else { return "best-effort" }
+        let p = Process()
+        p.executableURL = bin
+        p.arguments = ["agent", "tier"]
+        let pipe = Pipe()
+        p.standardOutput = pipe
+        p.standardError = FileHandle.nullDevice
+        do {
+            try p.run()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            p.waitUntilExit()
+            let out = (String(data: data, encoding: .utf8) ?? "")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return out == "attested-confidential" ? "attested-confidential" : "best-effort"
+        } catch {
+            return "best-effort"
+        }
+    }
+
+    /// The binary to run for `agent serve`. On a machine the owner opted into
+    /// attested-confidential we spawn the nested, measured push-receiver bundle
+    /// `Contents/CoCoreProvider.app/Contents/MacOS/cocore-provider` — it holds
+    /// the embedded provisioning profile + aps-environment entitlement that lets
+    /// it answer the advisor's APNs code-identity challenge, and it runs the
+    /// in-process MLX engine so plaintext never leaves the measured binary.
+    /// Every other machine runs the default `cocore`: no provisioning profile
+    /// to expire, behaviour identical to a normal release. Falls back to the
+    /// default binary when the worker bundle isn't present (a non-apns build).
+    nonisolated static func serveBinary() -> URL? {
+        if probeTier() == "attested-confidential" {
+            let worker = Bundle.main.bundleURL
+                .appendingPathComponent(
+                    "Contents/CoCoreProvider.app/Contents/MacOS/cocore-provider")
+            if FileManager.default.isExecutableFile(atPath: worker.path) {
+                NSLog("cocore: confidential tier — spawning nested worker %@", worker.path)
+                return worker
+            }
+            NSLog(
+                "cocore: confidential tier requested but nested worker bundle missing; using default binary"
+            )
+        }
+        return locateBinary()
     }
 }

--- a/provider-shell/Sources/CoCoreShell/Resources/Info.plist
+++ b/provider-shell/Sources/CoCoreShell/Resources/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleName</key>
 	<string>co/core</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.19</string>
+	<string>0.9.20</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -22,7 +22,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>919</string>
+	<string>920</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/provider/Cargo.lock
+++ b/provider/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "cocore-provider"
-version = "0.9.19"
+version = "0.9.20"
 dependencies = [
  "anyhow",
  "asn1-rs",

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cocore-provider"
-version = "0.9.19"
+version = "0.9.20"
 edition = "2021"
 description = "co/core provider agent: runs hardened compute and publishes signed receipts to AT Protocol."
 license = "MIT OR Apache-2.0"

--- a/provider/src/advisor.rs
+++ b/provider/src/advisor.rs
@@ -110,6 +110,12 @@ impl AdvisorClient {
         // reload — compared to THIS set (not what loaded) so a model that
         // won't fit RAM doesn't look like a perpetual change.
         desired_at_start: &[String],
+        // The `desiredTier` this serve loaded against (`None` == best-effort).
+        // If the owner flips it on the console (opt in to / out of
+        // attested-confidential) we detect the change here and restart, so the
+        // supervisor re-selects the right worker binary on the next spawn (the
+        // confidential push-receiver bundle vs. the default best-effort CLI).
+        desired_tier_at_start: Option<&str>,
         // Per-model schedules + the full configured set they apply to. The
         // serve loop watches for a window boundary (a model's active state
         // flipping) and restarts to reload the new active set.
@@ -318,12 +324,26 @@ impl AdvisorClient {
                 }
                 // A control re-read finished. Honour two owner changes: a
                 // stop (disconnect) and a model-set edit (restart to reload).
-                Some((next_active, desired)) = active_reads.next(), if !active_reads.is_empty() => {
+                Some((next_active, desired, desired_tier)) = active_reads.next(), if !active_reads.is_empty() => {
                     if !next_active {
                         // Owner stopped us — disconnect and let the outer loop
                         // hold us out of the registry until they start us again.
                         tracing::info!("owner stopped this machine from the console; disconnecting");
                         return Ok(());
+                    }
+                    if tier_changed(desired_tier.as_deref(), desired_tier_at_start) {
+                        // Owner changed this machine's trust tier on the console
+                        // (opted in to / out of attested-confidential). The
+                        // confidential path needs a different process shape — the
+                        // measured push-receiver bundle vs. the default CLI — which
+                        // only the supervisor can select at spawn. Exit non-zero so
+                        // launchd / the app supervisor respawns; the fresh boot reads
+                        // the new tier and the supervisor picks the right binary.
+                        tracing::info!(
+                            from = ?desired_tier_at_start, to = ?desired_tier,
+                            "owner changed this machine's trust tier from the console; restarting to re-select the worker"
+                        );
+                        std::process::exit(3);
                     }
                     if models_changed(&desired, desired_at_start) {
                         // Owner edited the model set on the website. Engines
@@ -581,8 +601,21 @@ impl AdvisorClient {
 /// PDS. A free fn (rather than two inline `async` blocks) so both
 /// `active_reads.push` sites produce the SAME future type — `FuturesUnordered`
 /// holds one anonymous type.
-async fn read_provider_control(pds: &PdsClient, rkey: &str) -> (bool, Vec<String>) {
+async fn read_provider_control(pds: &PdsClient, rkey: &str) -> (bool, Vec<String>, Option<String>) {
     pds.get_provider_control(rkey).await
+}
+
+/// Whether two `desiredTier` values differ, normalising `None` to the
+/// best-effort default so an absent field and an explicit `"best-effort"` are
+/// the same thing (no spurious restart). A real change — e.g. the owner opting
+/// into `attested-confidential` from the console, or back out — returns true,
+/// which restarts the agent so the supervisor re-selects the right binary.
+fn tier_changed(a: Option<&str>, b: Option<&str>) -> bool {
+    let norm = |t: Option<&str>| match t {
+        Some("attested-confidential") => "attested-confidential",
+        _ => "best-effort",
+    };
+    norm(a) != norm(b)
 }
 
 /// Whether two model sets differ, ignoring order and duplicates — so a
@@ -1419,6 +1452,29 @@ mod tests {
         assert!(models_changed(&a(&["x", "y"]), &a(&["x"]))); // removed
         assert!(models_changed(&a(&["x"]), &[])); // cleared → local default
         assert!(models_changed(&[], &a(&["x"]))); // newly pinned
+    }
+
+    #[test]
+    fn tier_changed_normalises_default_and_catches_opt_in_out() {
+        // Absent and explicit best-effort are the same → no restart.
+        assert!(!tier_changed(None, None));
+        assert!(!tier_changed(None, Some("best-effort")));
+        assert!(!tier_changed(Some("best-effort"), None));
+        assert!(!tier_changed(Some("best-effort"), Some("best-effort")));
+        // An unknown/garbage tier normalises to best-effort, not a restart loop.
+        assert!(!tier_changed(Some("wat"), None));
+        // Staying confidential → no restart.
+        assert!(!tier_changed(
+            Some("attested-confidential"),
+            Some("attested-confidential")
+        ));
+        // Opting in and opting back out → a real change (restart to re-select).
+        assert!(tier_changed(Some("attested-confidential"), None));
+        assert!(tier_changed(None, Some("attested-confidential")));
+        assert!(tier_changed(
+            Some("attested-confidential"),
+            Some("best-effort")
+        ));
     }
 
     use crate::engines::stub::StubEngine;

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -64,6 +64,13 @@ enum AgentCmd {
     },
     /// Print the active session's identity for debugging.
     Whoami,
+    /// Print this machine's owner-chosen trust tier from its PDS provider
+    /// record: `attested-confidential` or `best-effort`. The macOS tray's
+    /// agent supervisor runs this to decide which worker binary to spawn (the
+    /// measured confidential push-receiver bundle vs. the default best-effort
+    /// CLI). Prints `best-effort` when not paired / no record yet / on a read
+    /// error — the safe default.
+    Tier,
     /// Diagnose this install end-to-end: LaunchAgent state,
     /// session.json, API key validity, and the console's view of
     /// whether the advisor sees us + a fresh provider record is
@@ -184,6 +191,7 @@ async fn main() -> Result<()> {
         Cmd::Agent(AgentCmd::Pair { console }) => cmd_pair(&console).await,
         Cmd::Agent(AgentCmd::Serve { advisor }) => cmd_serve_entry(advisor).await,
         Cmd::Agent(AgentCmd::Whoami) => cmd_whoami(),
+        Cmd::Agent(AgentCmd::Tier) => cmd_print_tier().await,
         Cmd::Agent(AgentCmd::Doctor { console, fix }) => doctor::run(&console, fix).await,
         Cmd::Agent(AgentCmd::Update { console, check }) => update::run(&console, check).await,
         Cmd::Agent(AgentCmd::Models(cmd)) => models_cli::run(cmd),
@@ -295,6 +303,35 @@ async fn cmd_set_active(active: bool) -> Result<()> {
 /// fresh CID is the correct response.
 fn is_swap_conflict(e: &cocore_provider::error::ProviderError) -> bool {
     matches!(e, cocore_provider::error::ProviderError::Pds(msg) if msg.contains("InvalidSwap"))
+}
+
+/// Read this machine's owner-chosen `desiredTier` from its PDS provider
+/// record. Returns `None` when not paired, when this machine has no record yet
+/// (never served), or on any read error — all of which the caller treats as
+/// best-effort. Backs both the confidential entry gate and the `agent tier`
+/// probe the macOS supervisor runs to pick a worker binary.
+async fn read_my_desired_tier() -> Option<String> {
+    let session = oauth::load_session().ok()??;
+    let pds = PdsClient::new(session);
+    let pubkey = secure_enclave::load_or_create_identity().ok()?.public_key_b64();
+    let (_rkey, value, _cid) = find_my_provider_record(&pds, &pubkey).await.ok()?;
+    value
+        .get("desiredTier")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+}
+
+/// `cocore agent tier`: print this machine's owner-chosen trust tier
+/// (`attested-confidential` or `best-effort`). Normalises an absent/unknown
+/// value to `best-effort` so the caller (the macOS supervisor) always gets one
+/// of the two binary-selection answers.
+async fn cmd_print_tier() -> Result<()> {
+    let tier = match read_my_desired_tier().await.as_deref() {
+        Some("attested-confidential") => "attested-confidential",
+        _ => "best-effort",
+    };
+    println!("{tier}");
+    Ok(())
 }
 
 /// `cocore agent active`: print `serving` or `paused` from the shared switch.
@@ -596,6 +633,33 @@ async fn wait_until_active(pds: &cocore_provider::pds::PdsClient, rkey: Option<&
 #[cfg(all(target_os = "macos", feature = "apns"))]
 async fn cmd_serve_entry(advisor: String) -> Result<()> {
     use tokio::sync::mpsc::unbounded_channel;
+    // Runtime tier gate (fleet-safety keystone). This apns worker binary holds
+    // the AppKit push host + the in-process MLX engine, but it must only take
+    // the confidential process shape when the owner actually opted THIS machine
+    // in (desiredTier=attested-confidential). On every other machine it behaves
+    // byte-for-byte like the default best-effort build: serve directly on the
+    // main runtime, no push receiver, no AppKit, subprocess engine, same model.
+    // (The macOS supervisor normally only spawns this binary for confidential
+    // machines via `agent tier`; this in-process gate is the backstop so a
+    // stale/raced spawn can never silently flip a machine's behaviour.)
+    let confidential =
+        read_my_desired_tier().await.as_deref() == Some("attested-confidential");
+    if !confidential {
+        tracing::info!(
+            "desiredTier is not attested-confidential — serving best-effort (no push host, subprocess engine)"
+        );
+        return cmd_serve(&advisor, None).await;
+    }
+    tracing::info!(
+        "desiredTier=attested-confidential — confidential path (push host + in-process MLX engine)"
+    );
+    // Make sure the confidential model's weights are present and point the
+    // native engine at the resolved Hugging Face snapshot dir BEFORE the serve
+    // thread builds engines. Non-fatal: on failure `build_engines` publishes an
+    // honest engineFault and the machine serves `stub` until the owner picks a
+    // confidential-compatible model from the console.
+    prepare_native_confidential_model().await;
+
     // The push host (main thread) forwards `E_K(nonce)` challenges on this
     // channel; the serve loop (worker thread) drains it. Unbounded so the
     // Cocoa-thread callback never blocks.
@@ -626,6 +690,150 @@ async fn cmd_serve_entry(advisor: String) -> Result<()> {
         .map_err(|e| anyhow::anyhow!("spawn serve thread: {e}"))?;
     // Hand the main thread to the push host. Never returns.
     cocore_provider::push_host::run_blocking(push_tx)
+}
+
+/// Confidential tier (apns build): make sure the in-process MLX engine's model
+/// is downloaded and pointed at its local Hugging Face snapshot before engines
+/// are built. Public model weights aren't security-sensitive — only *serving*
+/// must stay inside the measured binary — so we reuse the venv's
+/// `huggingface_hub` as a download-only step, then resolve the snapshot dir it
+/// returns and export the two env vars `build_engines` reads
+/// (`COCORE_NATIVE_MLX_MODEL` + `COCORE_NATIVE_MLX_MODEL_DIR`). The native
+/// engine serves exactly ONE model — the owner's first non-`stub`
+/// `desiredModels`, else a small default. An incompatible pick (a non
+/// Qwen2/Llama/Gemma/Phi arch, e.g. `qwen3_5`) downloads fine but fails native
+/// load, which `build_engines` turns into an honest engineFault.
+#[cfg(all(target_os = "macos", feature = "apns"))]
+async fn prepare_native_confidential_model() {
+    const DEFAULT_MODEL: &str = "mlx-community/Qwen2.5-0.5B-Instruct-4bit";
+    // Already wired by the environment (e.g. a LaunchAgent that pre-set both
+    // vars, like the canary) — respect it and skip the download probe.
+    if std::env::var_os("COCORE_NATIVE_MLX_MODEL").is_some()
+        && std::env::var_os("COCORE_NATIVE_MLX_MODEL_DIR").is_some()
+    {
+        tracing::info!("native MLX model already configured via env; skipping download probe");
+        return;
+    }
+    // Choose the model: the owner's first non-`stub` desiredModels, else the
+    // small default. The native engine serves a single model.
+    let model = read_my_desired_models()
+        .await
+        .into_iter()
+        .find(|m| m != "stub")
+        .unwrap_or_else(|| DEFAULT_MODEL.to_string());
+
+    // Resolve the venv interpreter the install script bootstrapped.
+    let venv_python = std::env::var("COCORE_PYTHON_VENV")
+        .ok()
+        .map(std::path::PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|h| h.join(".cocore/python")))
+        .map(|venv| venv.join("bin/python"));
+    let Some(venv_python) = venv_python.filter(|p| p.exists()) else {
+        tracing::warn!(
+            "no venv python to download the confidential model; build_engines will publish a fault"
+        );
+        // Flag the intended model (without a dir) so build_engines faults honestly.
+        std::env::set_var("COCORE_NATIVE_MLX_MODEL", &model);
+        return;
+    };
+
+    tracing::info!(
+        model = %model,
+        "downloading confidential model weights (download-only; serving stays in the measured binary)"
+    );
+    // Surface progress in the tray while the (potentially multi-GB, multi-minute)
+    // download runs; the serve loop's own monitor takes over once engines build.
+    write_provision_status(
+        "provisioning",
+        std::slice::from_ref(&model),
+        model_download_bytes(std::slice::from_ref(&model)),
+        None,
+    );
+
+    let dir = tokio::task::spawn_blocking({
+        let model = model.clone();
+        let venv_python = venv_python.clone();
+        move || download_hf_snapshot(&venv_python, &model)
+    })
+    .await
+    .ok()
+    .flatten();
+
+    std::env::set_var("COCORE_NATIVE_MLX_MODEL", &model);
+    match dir {
+        Some(dir) => {
+            tracing::info!(model = %model, dir = %dir, "confidential model ready");
+            std::env::set_var("COCORE_NATIVE_MLX_MODEL_DIR", dir);
+        }
+        None => tracing::warn!(
+            model = %model,
+            "confidential model download failed; build_engines will publish a fault"
+        ),
+    }
+}
+
+/// Run the venv's `huggingface_hub.snapshot_download` as a download-only step
+/// and return the resolved local snapshot directory (which is exactly what the
+/// native engine needs). Blocking — spawns the venv python and waits for the
+/// weight download; a no-op when the weights are already cached. Call from
+/// `spawn_blocking`.
+#[cfg(all(target_os = "macos", feature = "apns"))]
+fn download_hf_snapshot(venv_python: &std::path::Path, model: &str) -> Option<String> {
+    // `{model:?}` emits a correctly-quoted/escaped Rust string literal, which is
+    // also a valid Python double-quoted literal for HuggingFace model ids.
+    let code =
+        format!("from huggingface_hub import snapshot_download; print(snapshot_download({model:?}))");
+    let out = std::process::Command::new(venv_python)
+        .arg("-c")
+        .arg(&code)
+        // Accelerated parallel download (hf_transfer is installed by
+        // scripts/bootstrap-python-venv.sh alongside vllm-mlx).
+        .env("HF_HUB_ENABLE_HF_TRANSFER", "1")
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        tracing::warn!(
+            model = %model,
+            stderr = %String::from_utf8_lossy(&out.stderr).lines().last().unwrap_or_default(),
+            "huggingface snapshot_download failed"
+        );
+        return None;
+    }
+    let dir = String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .last()
+        .map(|l| l.trim().to_string())?;
+    if dir.is_empty() {
+        None
+    } else {
+        Some(dir)
+    }
+}
+
+/// Read this machine's owner-chosen `desiredModels` from its PDS provider
+/// record (empty when not paired / no record / read error). Used to pick the
+/// confidential native model.
+#[cfg(all(target_os = "macos", feature = "apns"))]
+async fn read_my_desired_models() -> Vec<String> {
+    let Some(session) = oauth::load_session().ok().flatten() else {
+        return Vec::new();
+    };
+    let pds = PdsClient::new(session);
+    let Ok(signer) = secure_enclave::load_or_create_identity() else {
+        return Vec::new();
+    };
+    match find_my_provider_record(&pds, &signer.public_key_b64()).await {
+        Ok((_, value, _)) => value
+            .get("desiredModels")
+            .and_then(|v| v.as_array())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|m| m.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default(),
+        Err(_) => Vec::new(),
+    }
 }
 
 /// Non-confidential builds: no push host, serve directly on the main runtime.
@@ -775,20 +983,36 @@ async fn cmd_serve(
     // local default. `build_engines` reads `COCORE_INFERENCE_MODELS`, so we
     // point it there before building. We remember the set we started from so
     // a later change (owner edits the list on the site) triggers a reload.
-    let desired_at_start: Vec<String> =
+    // This serve's confidential standing. `push_rx.is_some()` is the
+    // process-shape signal: only the confidential entry path (the apns worker)
+    // hands us a push receiver, so it doubles as "this is the confidential
+    // worker". On a confidential machine inference must stay inside the
+    // measured binary — the native in-process MLX engine — so we DON'T point
+    // the subprocess engine at the owner's models (that would serve them out
+    // of an unmeasured Python child, defeating the tier). We still read
+    // `desiredModels` below so a change still triggers a reload restart.
+    let confidential = push_rx.is_some();
+    let (desired_at_start, desired_tier_at_start): (Vec<String>, Option<String>) =
         match find_my_provider_record(&pds, &attestation_pub_key).await {
-            Ok((_, value, _)) => value
-                .get("desiredModels")
-                .and_then(|v| v.as_array())
-                .map(|a| {
-                    a.iter()
-                        .filter_map(|m| m.as_str().map(str::to_string))
-                        .collect()
-                })
-                .unwrap_or_default(),
-            Err(_) => Vec::new(),
+            Ok((_, value, _)) => {
+                let models = value
+                    .get("desiredModels")
+                    .and_then(|v| v.as_array())
+                    .map(|a| {
+                        a.iter()
+                            .filter_map(|m| m.as_str().map(str::to_string))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                let tier = value
+                    .get("desiredTier")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string);
+                (models, tier)
+            }
+            Err(_) => (Vec::new(), None),
         };
-    if !desired_at_start.is_empty() {
+    if !desired_at_start.is_empty() && !confidential {
         tracing::info!(models = ?desired_at_start, "loading owner-selected models from the console");
         std::env::set_var("COCORE_INFERENCE_MODELS", desired_at_start.join(","));
     }
@@ -1125,6 +1349,7 @@ async fn cmd_serve(
                             &engines,
                             provider_rkey.as_deref(),
                             &desired_at_start,
+                            desired_tier_at_start.as_deref(),
                             &model_schedules,
                             &configured_models,
                             push_rx.as_mut(),
@@ -1187,7 +1412,7 @@ async fn cmd_serve(
                         );
                         let client = AdvisorClient::new(advisor_url);
                         tokio::select! {
-                            res = client.run(register.clone(), &*signer, &enc, &pds, attestation, &eng, provider_rkey.as_deref(), &desired_at_start, &model_schedules, &configured_models, push_rx.as_mut()) => {
+                            res = client.run(register.clone(), &*signer, &enc, &pds, attestation, &eng, provider_rkey.as_deref(), &desired_at_start, desired_tier_at_start.as_deref(), &model_schedules, &configured_models, push_rx.as_mut()) => {
                                 if let Err(e) = res {
                                     tracing::warn!(error = %e, "advisor run ended; reconnecting within window in 5s");
                                 }
@@ -1428,28 +1653,77 @@ fn build_engines(
     let mut registry = cocore_provider::engines::EngineRegistry::new();
     registry.register("stub", std::sync::Arc::new(StubEngine));
 
+    // A confidential machine's native engine failed to come up. Surfaced as
+    // the serve's engineFault so the console shows an honest "couldn't serve
+    // confidentially" instead of a green machine that silently only runs
+    // `stub`. Stays `None` on best-effort builds/machines (no native env set),
+    // so their behaviour is unchanged.
+    #[cfg_attr(not(feature = "native_mlx"), allow(unused_mut, unused_assignments))]
+    let mut native_fault: Option<EngineFault> = None;
+
     // WS-ENGINE: the native in-process MLX engine (confidential tier). Opt-in
     // and feature-gated so it never disrupts the subprocess path. Configure a
     // model id + its local snapshot dir; the prompt is then served entirely
     // inside the measured binary (flips inProcessBackend + metallibHash true).
     #[cfg(feature = "native_mlx")]
-    if let (Ok(model), Ok(dir)) = (
-        std::env::var("COCORE_NATIVE_MLX_MODEL"),
-        std::env::var("COCORE_NATIVE_MLX_MODEL_DIR"),
-    ) {
+    if let Ok(model) = std::env::var("COCORE_NATIVE_MLX_MODEL") {
         use cocore_provider::engines::native_mlx::NativeMlxEngine;
         use cocore_provider::engines::Engine;
-        match NativeMlxEngine::load(std::path::PathBuf::from(dir), None) {
-            Ok(engine) if engine.ready() => {
-                tracing::info!(model = %model, "loaded native in-process MLX engine (confidential-capable)");
-                registry.register(model, std::sync::Arc::new(engine));
-            }
-            Ok(_) => tracing::warn!(
-                model = %model,
-                "native MLX engine loaded but metallib not located; not registering (confidential tier unavailable)"
-            ),
-            Err(e) => {
-                tracing::warn!(error = %e, model = %model, "failed to load native MLX engine")
+        match std::env::var("COCORE_NATIVE_MLX_MODEL_DIR") {
+            Ok(dir) => match NativeMlxEngine::load(std::path::PathBuf::from(dir), None) {
+                Ok(engine) if engine.ready() => {
+                    tracing::info!(model = %model, "loaded native in-process MLX engine (confidential-capable)");
+                    registry.register(model, std::sync::Arc::new(engine));
+                }
+                Ok(_) => {
+                    tracing::warn!(
+                        model = %model,
+                        "native MLX engine loaded but metallib not located; not registering (confidential tier unavailable)"
+                    );
+                    native_fault = Some(EngineFault {
+                        code: "native-metallib-missing".to_string(),
+                        message: format!(
+                            "The confidential (in-process MLX) engine for `{model}` loaded but its \
+                             signed Metal kernel library couldn't be located, so it won't serve. \
+                             This is a packaging problem on this build, not your configuration. \
+                             The machine is online but only serving the no-op `stub` engine."
+                        ),
+                        models: vec![model.clone()],
+                        at: chrono::Utc::now(),
+                    });
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, model = %model, "failed to load native MLX engine");
+                    native_fault = Some(EngineFault {
+                        code: "native-load-failed".to_string(),
+                        message: format!(
+                            "The confidential (in-process MLX) engine couldn't load `{model}`. The \
+                             native engine supports Qwen2/Llama/Gemma/Phi-family MLX models; a \
+                             different architecture (e.g. a Qwen3 model) won't load in-process. \
+                             Pick a confidential-compatible model in the console. The machine is \
+                             online but only serving the no-op `stub` engine. ({e})"
+                        ),
+                        models: vec![model.clone()],
+                        at: chrono::Utc::now(),
+                    });
+                }
+            },
+            Err(_) => {
+                tracing::warn!(
+                    model = %model,
+                    "confidential model selected but weights not downloaded yet; serving stub until provisioned"
+                );
+                native_fault = Some(EngineFault {
+                    code: "native-model-missing".to_string(),
+                    message: format!(
+                        "The confidential model `{model}` isn't downloaded on this machine yet, so \
+                         the in-process engine can't serve it. The machine is online but only \
+                         serving the no-op `stub` engine; it will recover once the weights finish \
+                         downloading and it restarts."
+                    ),
+                    models: vec![model.clone()],
+                    at: chrono::Utc::now(),
+                });
             }
         }
     }
@@ -1461,7 +1735,10 @@ fn build_engines(
         tracing::info!(
             "no inference models configured (set COCORE_INFERENCE_MODELS to enable real inference; this agent will serve `stub` only)"
         );
-        return (registry, None);
+        // On a confidential machine the subprocess set is intentionally empty
+        // (inference runs in-process), so a native failure is the fault to
+        // surface here. On best-effort machines `native_fault` is `None`.
+        return (registry, native_fault);
     }
 
     // Resolve the venv interpreter once. The install script writes it

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -313,7 +313,9 @@ fn is_swap_conflict(e: &cocore_provider::error::ProviderError) -> bool {
 async fn read_my_desired_tier() -> Option<String> {
     let session = oauth::load_session().ok()??;
     let pds = PdsClient::new(session);
-    let pubkey = secure_enclave::load_or_create_identity().ok()?.public_key_b64();
+    let pubkey = secure_enclave::load_or_create_identity()
+        .ok()?
+        .public_key_b64();
     let (_rkey, value, _cid) = find_my_provider_record(&pds, &pubkey).await.ok()?;
     value
         .get("desiredTier")
@@ -642,8 +644,7 @@ async fn cmd_serve_entry(advisor: String) -> Result<()> {
     // (The macOS supervisor normally only spawns this binary for confidential
     // machines via `agent tier`; this in-process gate is the backstop so a
     // stale/raced spawn can never silently flip a machine's behaviour.)
-    let confidential =
-        read_my_desired_tier().await.as_deref() == Some("attested-confidential");
+    let confidential = read_my_desired_tier().await.as_deref() == Some("attested-confidential");
     if !confidential {
         tracing::info!(
             "desiredTier is not attested-confidential — serving best-effort (no push host, subprocess engine)"
@@ -781,8 +782,9 @@ async fn prepare_native_confidential_model() {
 fn download_hf_snapshot(venv_python: &std::path::Path, model: &str) -> Option<String> {
     // `{model:?}` emits a correctly-quoted/escaped Rust string literal, which is
     // also a valid Python double-quoted literal for HuggingFace model ids.
-    let code =
-        format!("from huggingface_hub import snapshot_download; print(snapshot_download({model:?}))");
+    let code = format!(
+        "from huggingface_hub import snapshot_download; print(snapshot_download({model:?}))"
+    );
     let out = std::process::Command::new(venv_python)
         .arg("-c")
         .arg(&code)

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -313,9 +313,8 @@ fn is_swap_conflict(e: &cocore_provider::error::ProviderError) -> bool {
 async fn read_my_desired_tier() -> Option<String> {
     let session = oauth::load_session().ok()??;
     let pds = PdsClient::new(session);
-    let pubkey = secure_enclave::load_or_create_identity()
-        .ok()?
-        .public_key_b64();
+    let signer = secure_enclave::load_or_create_identity().ok()?;
+    let pubkey = signer.public_key_b64();
     let (_rkey, value, _cid) = find_my_provider_record(&pds, &pubkey).await.ok()?;
     value
         .get("desiredTier")
@@ -644,7 +643,8 @@ async fn cmd_serve_entry(advisor: String) -> Result<()> {
     // (The macOS supervisor normally only spawns this binary for confidential
     // machines via `agent tier`; this in-process gate is the backstop so a
     // stale/raced spawn can never silently flip a machine's behaviour.)
-    let confidential = read_my_desired_tier().await.as_deref() == Some("attested-confidential");
+    let desired_tier = read_my_desired_tier().await;
+    let confidential = desired_tier.as_deref() == Some("attested-confidential");
     if !confidential {
         tracing::info!(
             "desiredTier is not attested-confidential — serving best-effort (no push host, subprocess engine)"
@@ -780,14 +780,15 @@ async fn prepare_native_confidential_model() {
 /// `spawn_blocking`.
 #[cfg(all(target_os = "macos", feature = "apns"))]
 fn download_hf_snapshot(venv_python: &std::path::Path, model: &str) -> Option<String> {
-    // `{model:?}` emits a correctly-quoted/escaped Rust string literal, which is
-    // also a valid Python double-quoted literal for HuggingFace model ids.
-    let code = format!(
-        "from huggingface_hub import snapshot_download; print(snapshot_download({model:?}))"
-    );
+    // Pass the model id as argv (sys.argv[1]) instead of interpolating it into
+    // the snippet — no quoting/injection edge cases, and the snippet stays a
+    // plain string literal (which rustfmt never reflows).
+    let code =
+        "import sys; from huggingface_hub import snapshot_download; print(snapshot_download(sys.argv[1]))";
     let out = std::process::Command::new(venv_python)
         .arg("-c")
-        .arg(&code)
+        .arg(code)
+        .arg(model)
         // Accelerated parallel download (hf_transfer is installed by
         // scripts/bootstrap-python-venv.sh alongside vllm-mlx).
         .env("HF_HUB_ENABLE_HF_TRANSFER", "1")

--- a/provider/src/pds.rs
+++ b/provider/src/pds.rs
@@ -413,21 +413,24 @@ impl PdsClient {
         rec.value.get("active").and_then(|v| v.as_bool())
     }
 
-    /// Read both owner-set controls — the `active` start/stop switch and the
-    /// `desiredModels` list — from this DID's provider record at `rkey` in
-    /// one list. Defaults: `active` true (serving) when absent, `desired`
-    /// empty when absent. On any read error returns the serving default with
-    /// an empty list so a transient blip never looks like a stop or a model
-    /// change. The agent polls this to honour remote pause + model changes.
-    pub async fn get_provider_control(&self, rkey: &str) -> (bool, Vec<String>) {
+    /// Read the owner-set controls — the `active` start/stop switch, the
+    /// `desiredModels` list, and the `desiredTier` intent — from this DID's
+    /// provider record at `rkey` in one list. Defaults: `active` true
+    /// (serving) when absent, `desired` empty when absent, `desiredTier` None
+    /// when absent. On any read error returns the serving default with an
+    /// empty list and no tier so a transient blip never looks like a stop, a
+    /// model change, or a tier change. The agent polls this to honour remote
+    /// pause + model changes; the serve loop also restarts on a `desiredTier`
+    /// change so the supervisor can re-select the confidential worker binary.
+    pub async fn get_provider_control(&self, rkey: &str) -> (bool, Vec<String>, Option<String>) {
         let Ok(listed) = self.list_my_records("dev.cocore.compute.provider").await else {
-            return (true, Vec::new());
+            return (true, Vec::new(), None);
         };
         let Some(rec) = listed
             .iter()
             .find(|r| r.uri.rsplit('/').next() == Some(rkey))
         else {
-            return (true, Vec::new());
+            return (true, Vec::new(), None);
         };
         let active = rec
             .value
@@ -444,7 +447,12 @@ impl PdsClient {
                     .collect()
             })
             .unwrap_or_default();
-        (active, desired)
+        let desired_tier = rec
+            .value
+            .get("desiredTier")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        (active, desired, desired_tier)
     }
 
     /// Walk the DID PLC directory to find this DID's PDS host. The

--- a/scripts/build-confidential-worker.sh
+++ b/scripts/build-confidential-worker.sh
@@ -36,10 +36,25 @@ die()  { printf '\033[31m  error:\033[0m %s\n' "$*" >&2; exit 1; }
 [[ -f "$PROFILE" ]] || die "provisioning profile not found at $PROFILE (set COCORE_PROVISION_PROFILE)"
 xcodebuild -version >/dev/null 2>&1 || die "needs full Xcode (Metal toolchain) for the native engine + metallib"
 
-SIGN_ID="$(security find-identity -p codesigning -v 2>/dev/null \
-  | sed -n 's/.*"\(Developer ID Application: .*\)"/\1/p' | head -1)"
-[[ -n "$SIGN_ID" ]] || die "no Developer ID Application identity in the keychain"
+# Version comes from provider/Cargo.toml so the worker bundle never drifts from
+# the agent it wraps (one version source, not a 4th place to bump). CFBundleVersion
+# mirrors the outer app's scheme: 0.MINOR.PATCH → MINOR*100+PATCH (0.9.20 → 920).
+VERSION="$(sed -n 's/^version = "\(.*\)"/\1/p' "$PROVIDER/Cargo.toml" | head -1)"
+[[ -n "$VERSION" ]] || die "could not read version from $PROVIDER/Cargo.toml"
+BUNDLE_VERSION="$(printf '%s' "$VERSION" | awk -F. '{printf "%d", $2*100 + $3}')"
+
+# Signing identity. The outer build (build-mac-app.sh) passes COCORE_SIGN_ID so
+# the worker is signed by the SAME Developer ID as the app that nests it;
+# standalone, we auto-detect. A real Developer ID is REQUIRED — the confidential
+# tier's code-identity leg depends on it (an ad-hoc/forked sign is AMFI-rejected).
+SIGN_ID="${COCORE_SIGN_ID:-}"
+if [[ -z "$SIGN_ID" || "$SIGN_ID" == "-" ]]; then
+  SIGN_ID="$(security find-identity -p codesigning -v 2>/dev/null \
+    | sed -n 's/.*"\(Developer ID Application: .*\)"/\1/p' | head -1)"
+fi
+[[ -n "$SIGN_ID" && "$SIGN_ID" != "-" ]] || die "no Developer ID Application identity (set COCORE_SIGN_ID or install one)"
 note "signing identity: $SIGN_ID"
+note "version: $VERSION (CFBundleVersion $BUNDLE_VERSION)"
 
 bold "==> build the apns (native + push host) agent binary"
 ( cd "$PROVIDER" && cargo build --release --locked --features apns )
@@ -80,8 +95,8 @@ cat > "$APP/Contents/Info.plist" <<PLIST
     <key>CFBundleName</key><string>co/core provider</string>
     <key>CFBundleExecutable</key><string>cocore-provider</string>
     <key>CFBundlePackageType</key><string>APPL</string>
-    <key>CFBundleShortVersionString</key><string>0.9.19</string>
-    <key>CFBundleVersion</key><string>919</string>
+    <key>CFBundleShortVersionString</key><string>${VERSION}</string>
+    <key>CFBundleVersion</key><string>${BUNDLE_VERSION}</string>
     <key>LSMinimumSystemVersion</key><string>13.0</string>
     <key>LSUIElement</key><true/>
 </dict>

--- a/scripts/build-mac-app.sh
+++ b/scripts/build-mac-app.sh
@@ -45,6 +45,17 @@ OPEN="${OPEN:-0}"
 # Opt-in secure/native build (WS-A). When 1, the bundled cocore CLI is built
 # with the in-process MLX engine so it can serve the confidential tier.
 COCORE_BUILD_NATIVE="${COCORE_BUILD_NATIVE:-0}"
+# Fleet confidential build. When 1, the outer cocore.app stays the DEFAULT
+# (best-effort, subprocess engine) build — so best-effort machines are
+# byte-identical to a normal release and never depend on the (expiring)
+# provisioning profile — and we ADD a nested, measured push-receiver bundle
+# `Contents/CoCoreProvider.app` (the `--features apns` worker, built by
+# scripts/build-confidential-worker.sh). The tray's AgentSupervisor spawns the
+# nested worker only on machines the owner opted into attested-confidential
+# (desiredTier), via `cocore agent tier`. One notarytool submit of the outer
+# app covers the nested bundle. Requires a Developer ID identity + the
+# provisioning profile (COCORE_PROVISION_PROFILE).
+COCORE_BUILD_APNS="${COCORE_BUILD_APNS:-0}"
 # DEV=1 builds a side-by-side dev identity: a distinct bundle id, app name,
 # and display name so the local build never collides with a prod cocore.app
 # already installed in /Applications (same bundle id = they fight over the one
@@ -237,6 +248,7 @@ if [[ -z "$COCORE_SIGN_ID" ]]; then
 fi
 
 if [[ "$COCORE_SIGN_ID" == "-" ]]; then
+  [[ "$COCORE_BUILD_APNS" == "1" ]] && die "COCORE_BUILD_APNS=1 needs a Developer ID identity (the confidential worker can't be ad-hoc signed). Install a Developer ID cert or unset COCORE_BUILD_APNS."
   bold "==> ad-hoc codesign (no Developer ID identity)"
   note "Gatekeeper will warn on other Macs; install a Developer ID cert for distribution."
   codesign --force --deep --sign - "$APP" 2>&1 | sed 's/^/  /' || die "codesign failed"
@@ -299,6 +311,30 @@ else
   codesign --force --options "$COCORE_CLI_OPTS" --timestamp \
     --sign "$COCORE_SIGN_ID" "$APP/Contents/MacOS/cocore" 2>&1 | sed 's/^/  /' \
     || die "codesign (bundled cocore CLI) failed"
+
+  # Fleet confidential build: nest the measured push-receiver worker bundle.
+  # build-confidential-worker.sh builds `--features apns` and produces a fully
+  # signed CoCoreProvider.app (inside-out: dylib + metallib + worker exe with
+  # the embedded provisioning profile + aps-environment entitlement, worker +
+  # bundle both signed runtime,library so CS_REQUIRE_LV survives → the
+  # attestation reports libraryValidation=true). We build it AFTER the outer
+  # cocore CLI is already installed into the bundle (its `cargo build --features
+  # apns` overwrites target/release/cocore, which we no longer read), then nest
+  # it under Contents/. The final outer `codesign "$APP"` below runs WITHOUT
+  # --deep, so it seals this already-signed nested bundle by reference — it does
+  # NOT re-sign the worker exe, so the worker keeps its runtime,library flags.
+  if [[ "$COCORE_BUILD_APNS" == "1" ]]; then
+    bold "==> build + nest the confidential worker (CoCoreProvider.app)"
+    COCORE_SIGN_ID="$COCORE_SIGN_ID" \
+      "$REPO_ROOT/scripts/build-confidential-worker.sh" 2>&1 | sed 's/^/  /' \
+      || die "confidential worker build failed"
+    WORKER_SRC="$SHELL_DIR/build/CoCoreProvider.app"
+    [[ -d "$WORKER_SRC" ]] || die "confidential worker bundle not found at $WORKER_SRC"
+    rm -rf "$APP/Contents/CoCoreProvider.app"
+    cp -R "$WORKER_SRC" "$APP/Contents/CoCoreProvider.app"
+    note "nested $APP/Contents/CoCoreProvider.app"
+  fi
+
   codesign --force --options runtime --timestamp \
     --entitlements "$ENTITLEMENTS" \
     --sign "$COCORE_SIGN_ID" "$APP" 2>&1 | sed 's/^/  /' || die "codesign failed"


### PR DESCRIPTION
Productionizes the attested-confidential pipeline (#43/#44) into a shippable fleet release. Three independent code chunks, gated so **best-effort machines behave exactly as 0.9.19** (and run a binary with no provisioning profile to expire), plus the 0.9.20 version bump.

## Chunk 1 — agent reconciliation gate (fleet-safety keystone)
- `agent serve` (apns worker) reads `desiredTier` from its PDS provider record at startup and only takes the confidential shape (AppKit push host + in-process MLX engine) when it's `attested-confidential`; otherwise serves exactly like the default build.
- Serve loop watches `desiredTier` like `desiredModels` and restarts (exit 3) on a flip so the supervisor re-selects the worker. Adds `tier_changed` (+test), threads `desiredTier` through `get_provider_control` / `AdvisorClient::run`.
- Confidential machines skip `COCORE_INFERENCE_MODELS` (inference stays in the measured binary).
- New `cocore agent tier` CLI for the supervisor.

## Chunk 2 — native confidential model download
- `prepare_native_confidential_model` picks the owner's first non-stub `desiredModels` (else a default), reuses the venv `huggingface_hub` as a download-only step, resolves the snapshot dir, exports `COCORE_NATIVE_MLX_MODEL`/`_DIR`.
- `build_engines` surfaces an honest engineFault when a confidential native model can't load (incompatible arch / missing weights / missing metallib).

## Chunk 3 — notarized nested-bundle packaging
- `build-mac-app.sh COCORE_BUILD_APNS=1` keeps the outer app the DEFAULT best-effort build and nests a fully-signed `Contents/CoCoreProvider.app` (the `--features apns` worker). Outer sign runs without `--deep` so it seals the nested bundle **without stripping the worker's `library-validation` flag** (verified: worker flags `0x12000(library-validation,runtime)`). One notarytool submit covers both.
- `build-confidential-worker.sh` derives its version from Cargo.toml + accepts `COCORE_SIGN_ID`.
- `AgentSupervisor.serveBinary()` spawns the nested worker only when `agent tier` reports confidential; stray-reaper matches both `cocore` and `cocore-provider`.

## Verification
- `cargo build` (default + apns) clean; 116 provider tests pass incl. new `tier_changed`.
- Swift compiles; `agent tier` smoke-tested against the live session.
- 0.9.20 app built + signed + notarized; nested worker cdHash `cbaf9932a84d538ad3283f525bb78003e9b97936`, `codesign --verify --strict --deep` passes.

Pairs with #45 (advisor APNs store-and-forward) for the canary verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)