### PR TITLE
fix(confidential): serve native-only — ignore COCORE_INFERENCE_MODELS (0.9.21)

### DIFF
--- a/provider-shell/Sources/CoCoreShell/AgentSupervisor.swift
+++ b/provider-shell/Sources/CoCoreShell/AgentSupervisor.swift
@@ -225,7 +225,12 @@ final class AgentSupervisor {
         // A fresh deliberate start clears the stop latch so a later
         // unexpected exit is treated as a crash and respawned.
         intentionalStop = false
-        guard let bin = Self.serveBinary() else {
+        // Probe the owner's trust tier ONCE: it selects the worker binary AND
+        // gates the inference-model env below (a confidential machine is
+        // native-only, so we must not inject subprocess models).
+        let tier = Self.probeTier()
+        let confidential = (tier == "attested-confidential")
+        guard let bin = Self.serveBinary(tier: tier) else {
             NSLog("cocore: provider binary not found")
             return
         }
@@ -250,9 +255,13 @@ final class AgentSupervisor {
             // but this also enriches the stderr line we persist below.
             "RUST_BACKTRACE": "full",
         ]
+        // Best-effort machines serve the owner's subprocess models; a
+        // confidential machine is native-only (inference stays in the measured
+        // binary), so never inject subprocess models there — the agent also
+        // clears them defensively, but not passing them avoids the spawn churn.
         let models = (UserDefaults.standard.string(forKey: "inferenceModels") ?? "")
             .trimmingCharacters(in: .whitespaces)
-        if !models.isEmpty { env["COCORE_INFERENCE_MODELS"] = models }
+        if !confidential, !models.isEmpty { env["COCORE_INFERENCE_MODELS"] = models }
         // Owner-chosen display name (set in the tray during setup), so the
         // provider record shows that instead of the raw `.local` hostname.
         let label = (UserDefaults.standard.string(forKey: "machineLabel") ?? "")
@@ -680,8 +689,8 @@ final class AgentSupervisor {
     /// Every other machine runs the default `cocore`: no provisioning profile
     /// to expire, behaviour identical to a normal release. Falls back to the
     /// default binary when the worker bundle isn't present (a non-apns build).
-    nonisolated static func serveBinary() -> URL? {
-        if probeTier() == "attested-confidential" {
+    nonisolated static func serveBinary(tier: String) -> URL? {
+        if tier == "attested-confidential" {
             let worker = Bundle.main.bundleURL
                 .appendingPathComponent(
                     "Contents/CoCoreProvider.app/Contents/MacOS/cocore-provider")

--- a/provider-shell/Sources/CoCoreShell/MainTabView.swift
+++ b/provider-shell/Sources/CoCoreShell/MainTabView.swift
@@ -31,6 +31,7 @@ final class MainWindowController {
     private let onOpenProfile: () -> Void
     private let onOpenSetupGuide: () -> Void
     private let onSignOut: () -> Void
+    private let onEnableSecureMode: () -> Void
     private let onSendBugReport: () -> Void
     private let onCheckUpdates: () -> Void
     private let onInstallUpdate: () -> Void
@@ -44,6 +45,7 @@ final class MainWindowController {
         onOpenProfile: @escaping () -> Void,
         onOpenSetupGuide: @escaping () -> Void,
         onSignOut: @escaping () -> Void,
+        onEnableSecureMode: @escaping () -> Void,
         onSendBugReport: @escaping () -> Void,
         onCheckUpdates: @escaping () -> Void,
         onInstallUpdate: @escaping () -> Void,
@@ -56,6 +58,7 @@ final class MainWindowController {
         self.onOpenProfile = onOpenProfile
         self.onOpenSetupGuide = onOpenSetupGuide
         self.onSignOut = onSignOut
+        self.onEnableSecureMode = onEnableSecureMode
         self.onSendBugReport = onSendBugReport
         self.onCheckUpdates = onCheckUpdates
         self.onInstallUpdate = onInstallUpdate
@@ -71,7 +74,8 @@ final class MainWindowController {
                     StatusTab(
                         onOpenProfile: onOpenProfile,
                         onOpenSetupGuide: onOpenSetupGuide,
-                        onSignOut: onSignOut)),
+                        onSignOut: onSignOut,
+                        onEnableSecureMode: onEnableSecureMode)),
                 tab("Models", "cpu", ModelsView(manager: modelManager)),
                 tab("Settings", "gearshape", PreferencesView(supervisor: supervisor)),
                 tab("About", "info.circle",
@@ -139,11 +143,12 @@ private struct StatusTab: View {
     let onOpenProfile: () -> Void
     let onOpenSetupGuide: () -> Void
     let onSignOut: () -> Void
+    let onEnableSecureMode: () -> Void
     @EnvironmentObject private var state: AppState
 
     var body: some View {
         Form {
-            StatusRows()
+            StatusRows(onEnableSecureMode: onEnableSecureMode)
             Section {
                 Button("View my profile on console", action: onOpenProfile)
                     .disabled(state.session == nil)

--- a/provider-shell/Sources/CoCoreShell/MenuBarController.swift
+++ b/provider-shell/Sources/CoCoreShell/MenuBarController.swift
@@ -265,7 +265,10 @@ final class MenuBarController {
         // up to date, a routine "Check for updates…" (also in the Help tab).
         addUpdateItems(to: menu)
         menu.addItem(.separator())
-        menu.addItem(action(title: "Enable Secure Mode…", #selector(openSecureModeWizard)))
+        // Secure Mode + Confidential live inside "Open co/core…" → Status now,
+        // not at the tray's top level — they're explained side-by-side there so
+        // the two postures aren't confused. The tray stays short: serving,
+        // updates, open, quit.
         menu.addItem(action(title: "Open co/core…", #selector(openMainWindow)))
         if let err = state.lastError, !err.isEmpty {
             // Catch-all for a surfaced error (e.g. a failed sign-in). Clip it
@@ -550,6 +553,7 @@ final class MenuBarController {
         onOpenProfile: { [weak self] in self?.openProfile() },
         onOpenSetupGuide: { [weak self] in self?.openWelcome() },
         onSignOut: { [weak self] in self?.signOut() },
+        onEnableSecureMode: { [weak self] in self?.secureModeWizard.show() },
         onSendBugReport: { [weak self] in self?.sendBugReport() },
         onCheckUpdates: { [weak self] in self?.checkUpdates() },
         onInstallUpdate: { [weak self] in self?.installUpdate() },
@@ -559,14 +563,15 @@ final class MenuBarController {
 
     /// The guided (manual) Secure Mode hardening wizard — MDM enrollment +
     /// step-ca attestation chain, then a recommended-models pin. Additive and
-    /// best-effort: nothing here gates serving.
+    /// best-effort: nothing here gates serving. Launched from "Open co/core…" →
+    /// Status → Security (via the mainWindow's `onEnableSecureMode` closure),
+    /// no longer a top-level tray item.
     private lazy var secureModeWizard: SecureModeWizardController = SecureModeWizardController(
         state: state,
         supervisor: supervisor,
         updater: updater,
         modelManager: modelManager
     )
-    @objc private func openSecureModeWizard() { secureModeWizard.show() }
 
     /// Public entry point so the AppDelegate can surface the main window when
     /// the app is re-launched (the dock/Finder "reopen" path) — the safety net

--- a/provider-shell/Sources/CoCoreShell/Resources/Info.plist
+++ b/provider-shell/Sources/CoCoreShell/Resources/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleName</key>
 	<string>co/core</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.20</string>
+	<string>0.9.21</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -22,7 +22,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>920</string>
+	<string>921</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/provider-shell/Sources/CoCoreShell/StatusView.swift
+++ b/provider-shell/Sources/CoCoreShell/StatusView.swift
@@ -11,6 +11,12 @@ import SwiftUI
 struct StatusRows: View {
     @EnvironmentObject private var state: AppState
 
+    /// When provided, the Security section shows an "Enable Secure Mode…"
+    /// action (the MDM/attestation wizard). Left `nil` where there's no place
+    /// to host the wizard (e.g. the read-only standalone Status window), which
+    /// just hides the button.
+    var onEnableSecureMode: (() -> Void)? = nil
+
     var body: some View {
         Section("Identity") {
             if let s = state.session {
@@ -35,34 +41,41 @@ struct StatusRows: View {
                     .foregroundStyle(.orange)
                     .fixedSize(horizontal: false, vertical: true)
             }
-            LabeledContent("Attestation") {
+        }
+        // Two ORTHOGONAL postures, deliberately separated so neither is mistaken
+        // for the other:
+        //   • Secure Mode (attestation) — proves this is genuine Apple hardware.
+        //   • Confidential — seals inference so the operator can't read prompts.
+        Section("Security") {
+            LabeledContent("Secure Mode") {
                 Text(state.trustLevel == .hardwareAttested
-                    ? "Hardware-attested"
-                    : "Self-attested (software)")
+                    ? "On — hardware-attested"
+                    : "Off — self-attested (software)")
                     .foregroundStyle(state.trustLevel == .hardwareAttested ? .green : .secondary)
             }
-            LabeledContent("Confidential tier") {
-                if state.confidential {
-                    // The honest, stronger claim: the operator can't read prompts.
-                    Text("🔒 Confidential")
-                        .foregroundStyle(.green)
-                } else {
-                    Text("Best-effort")
-                        .foregroundStyle(.secondary)
-                }
-            }
-            // Honest one-liner so nobody mistakes hardware-attested (genuine Mac,
-            // SIP verified) for confidential (operator can't read prompts).
-            Text(state.confidential
-                ? "Your prompts run inside the measured, signed agent — the operator can't read them."
-                : state.trustLevel == .hardwareAttested
-                    ? "Genuine Apple hardware, SIP verified. Inference still runs in a helper the operator can read — upgrade to confidential to seal it."
-                    : "Fast best-effort serving. The operator can read prompts. Upgrade in the console to go confidential.")
+            Text(state.trustLevel == .hardwareAttested
+                ? "This Mac is enrolled and proven to be genuine Apple hardware (SIP verified)."
+                : "Proves this is genuine, untampered Apple hardware (SIP verified). Optional.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
             if let exp = state.attestationExpiresAt {
                 LabeledContent("Attestation expires", value: exp.formatted(.dateTime))
             }
+            if state.trustLevel != .hardwareAttested, let enable = onEnableSecureMode {
+                Button("Enable Secure Mode…", action: enable)
+            }
+
+            LabeledContent("Confidential tier") {
+                Text(state.confidential ? "🔒 Confidential" : "Best-effort")
+                    .foregroundStyle(state.confidential ? .green : .secondary)
+            }
+            // Honest one-liner so nobody mistakes Secure Mode (genuine Mac, SIP
+            // verified) for confidential (operator can't read prompts).
+            Text(state.confidential
+                ? "Your prompts run inside the measured, signed agent — the operator can't read them."
+                : "Seals inference so the operator can't read your prompts. Enable per-machine from the console (\u{201C}Upgrade to confidential\u{201D}).")
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
         Section("Credits") {
             if let bal = state.balanceCredits {

--- a/provider/Cargo.lock
+++ b/provider/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "cocore-provider"
-version = "0.9.20"
+version = "0.9.21"
 dependencies = [
  "anyhow",
  "asn1-rs",

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cocore-provider"
-version = "0.9.20"
+version = "0.9.21"
 edition = "2021"
 description = "co/core provider agent: runs hardened compute and publishes signed receipts to AT Protocol."
 license = "MIT OR Apache-2.0"

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -1015,9 +1015,31 @@ async fn cmd_serve(
             }
             Err(_) => (Vec::new(), None),
         };
-    if !desired_at_start.is_empty() && !confidential {
-        tracing::info!(models = ?desired_at_start, "loading owner-selected models from the console");
-        std::env::set_var("COCORE_INFERENCE_MODELS", desired_at_start.join(","));
+    match inference_models_action(confidential, &desired_at_start) {
+        InferenceModelsAction::Clear => {
+            // Confidential = native-only. Inference MUST stay inside the
+            // measured binary, so the subprocess engine serves nothing — clear
+            // `COCORE_INFERENCE_MODELS` (both spellings) regardless of who set
+            // it. The macOS tray injects it from its `inferenceModels`
+            // preference and a launchd plist can set it too; without this clear,
+            // a confidential machine would spawn a Python child for that model,
+            // both leaking plaintext out of the measured binary and piling load
+            // onto small machines (enough to starve the advisor WS loop so
+            // code-attestation never sticks). `build_engines` then registers the
+            // native engine + `stub` only.
+            tracing::info!(
+                "confidential tier — serving the in-process native engine only (cleared COCORE_INFERENCE_MODELS)"
+            );
+            std::env::remove_var("COCORE_INFERENCE_MODELS");
+            std::env::remove_var("COCORE_INFERENCE_MODEL");
+        }
+        InferenceModelsAction::Set(models) => {
+            tracing::info!(models = %models, "loading owner-selected models from the console");
+            std::env::set_var("COCORE_INFERENCE_MODELS", models);
+        }
+        // No console selection on a best-effort machine: leave whatever the
+        // environment / install default already provides, exactly as before.
+        InferenceModelsAction::Leave => {}
     }
 
     // Per-model schedules + the full configured set they apply to. The serve
@@ -1607,6 +1629,34 @@ fn clear_provision_status() {
     }
 }
 
+/// What a serve should do with `COCORE_INFERENCE_MODELS` (the subprocess
+/// engine's model set) before building engines.
+#[derive(Debug, PartialEq, Eq)]
+enum InferenceModelsAction {
+    /// Clear the var (both spellings) — confidential = native-only, inference
+    /// stays in the measured binary, so the subprocess engine serves nothing.
+    Clear,
+    /// Set it to this CSV — the owner picked models on the console (best-effort).
+    Set(String),
+    /// Leave the existing env / install default untouched — best-effort machine
+    /// with no console selection.
+    Leave,
+}
+
+/// Decide the `COCORE_INFERENCE_MODELS` action for a serve. A confidential
+/// machine ALWAYS clears it (native-only — never a subprocess child, no matter
+/// what the supervisor injected); a best-effort machine sets the owner's
+/// `desiredModels` when present, else leaves whatever is already configured.
+fn inference_models_action(confidential: bool, desired: &[String]) -> InferenceModelsAction {
+    if confidential {
+        InferenceModelsAction::Clear
+    } else if desired.is_empty() {
+        InferenceModelsAction::Leave
+    } else {
+        InferenceModelsAction::Set(desired.join(","))
+    }
+}
+
 /// Build the per-model engine registry for this serve invocation.
 ///
 /// Every registry includes a `stub` entry — it's the no-cost
@@ -2058,6 +2108,47 @@ fn cmd_whoami() -> Result<()> {
         None => println!("not paired; run `cocore agent pair`"),
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod inference_models_action_tests {
+    use super::*;
+
+    fn v(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn confidential_always_clears_regardless_of_desired() {
+        // Native-only: even with owner-selected models (or an injected env), a
+        // confidential serve must never run the subprocess engine.
+        assert_eq!(
+            inference_models_action(true, &[]),
+            InferenceModelsAction::Clear
+        );
+        assert_eq!(
+            inference_models_action(true, &v(&["mlx-community/Qwen3.5-0.8B-MLX-4bit"])),
+            InferenceModelsAction::Clear
+        );
+        assert_eq!(
+            inference_models_action(true, &v(&["a", "b"])),
+            InferenceModelsAction::Clear
+        );
+    }
+
+    #[test]
+    fn best_effort_sets_desired_or_leaves_default() {
+        // Owner picked models → set them (joined CSV, order preserved).
+        assert_eq!(
+            inference_models_action(false, &v(&["a", "b"])),
+            InferenceModelsAction::Set("a,b".to_string())
+        );
+        // No console selection → leave whatever the env/default provides.
+        assert_eq!(
+            inference_models_action(false, &[]),
+            InferenceModelsAction::Leave
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Why

A confidential machine must run inference **only** in the measured binary (the in-process native MLX engine). 0.9.20's gate avoided *setting* `COCORE_INFERENCE_MODELS` from `desiredModels`, but the macOS tray injects it directly from the `inferenceModels` preference — so a confidential worker still spawned a Python subprocess for that model. That:
- **served it non-confidentially** (plaintext leaves the measured binary via the child while the machine advertises `attested-confidential`), and
- **overloaded small machines**: on an 8 GB M1, native Qwen2.5-0.5B + a Qwen3.5-0.8B subprocess hit ~3.7 GB of swap, starving the advisor WS loop so code-attestation never stuck (the canary couldn't go green until the subprocess model was removed by hand).

## Fix

- `cmd_serve`: when confidential, **clear** `COCORE_INFERENCE_MODELS`/`COCORE_INFERENCE_MODEL` before `build_engines` regardless of who set them → native engine + `stub` only. Still reads `desiredModels` for the native model choice + change detection. Extracted `inference_models_action` (Clear/Set/Leave) + unit tests.
- `AgentSupervisor`: probe the tier once; don't inject the `inferenceModels` env when `desiredTier=attested-confidential`.

## Test
`cargo fmt`/check (default + apns) + new unit tests green; `swift build` green.

Bumps to **0.9.21**. Follow-up to the 0.9.20 confidential release (live; canary green on cdHash `f39533…`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)