### PR TITLE
feat(tray): enable/disable Confidential from the app (0.9.22)

### DIFF
--- a/packages/console/src/components/docs/docs-topbar.tsx
+++ b/packages/console/src/components/docs/docs-topbar.tsx
@@ -36,6 +36,7 @@ const logoStyles = stylex.create({
 
 const NAV_ITEMS = [
   { label: "Inference", to: "/docs/inference" as const },
+  { label: "Security", to: "/docs/security" as const },
   { label: "XRPC", to: "/docs/api" as const },
   { label: "Lexicons", to: "/docs/lexicons" as const },
 ] as const;

--- a/packages/console/src/components/docs/security-page.tsx
+++ b/packages/console/src/components/docs/security-page.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import { Link } from "@tanstack/react-router";
+
+import { docsStyles } from "@/components/docs/docs-page.stylex.tsx";
+
+/**
+ * Detailed explainer for the two — orthogonal — security postures a co/core
+ * provider can hold: Secure Mode (hardware attestation) and the Confidential
+ * tier (operator-blind inference). The provider app links here from its
+ * Status → Security section.
+ */
+export function SecurityDocsPage() {
+  return (
+    <>
+      <div {...stylex.props(docsStyles.masthead)}>
+        <div {...stylex.props(docsStyles.kicker)}>Security</div>
+        <h1 {...stylex.props(docsStyles.title)}>Secure Mode &amp; the Confidential tier</h1>
+        <p {...stylex.props(docsStyles.dek)}>
+          A co/core provider can carry two independent security guarantees. They answer different
+          questions and are earned separately — you can have either, both, or neither. This page
+          explains what each one proves, how it works, and what it means for the prompts you send
+          (as a requestor) or serve (as an operator).
+        </p>
+      </div>
+
+      <div {...stylex.props(docsStyles.introProse)}>
+        <h2 {...stylex.props(docsStyles.h2, docsStyles.h2First)}>The two are orthogonal</h2>
+        <p {...stylex.props(docsStyles.prose)}>
+          <strong>Secure Mode</strong> answers{" "}
+          <em>“is this genuine, untampered Apple hardware?”</em> The{" "}
+          <strong>Confidential tier</strong> answers{" "}
+          <em>“can the machine&apos;s operator read the prompts a requestor sends it?”</em> One is
+          about the integrity of the hardware; the other is about who can observe the data. A
+          machine can prove its hardware and still run inference somewhere its operator can read, or
+          seal inference from its operator without an Apple hardware-root proof. The strongest
+          providers carry both.
+        </p>
+
+        <h2 {...stylex.props(docsStyles.h2)}>Secure Mode — “this is a real Mac, provably”</h2>
+        <p {...stylex.props(docsStyles.prose)}>
+          Secure Mode enrolls the Mac with co/core&apos;s device management and obtains an Apple{" "}
+          <strong>Managed Device Attestation</strong> certificate chain — an Apple-signed credential
+          rooted in the device&apos;s Secure Enclave that proves the silicon is genuine, the OS is
+          intact, and System Integrity Protection is on. It sets the provider&apos;s trust level to{" "}
+          <strong>hardware-attested</strong>.
+        </p>
+        <p {...stylex.props(docsStyles.prose)}>
+          What it defends against: a spoofed or tampered provider — a VM pretending to be a Mac, or
+          a machine with SIP disabled. What it does <em>not</em> say: anything about whether the
+          operator can see your data. A genuine, hardware-attested Mac can still run inference in a
+          process its operator reads. Secure Mode is optional and additive — turning it on never
+          changes how the machine serves, only how strongly it can prove what it is.
+        </p>
+
+        <h2 {...stylex.props(docsStyles.h2)}>
+          The Confidential tier — “the operator can&apos;t read the prompts”
+        </h2>
+        <p {...stylex.props(docsStyles.prose)}>
+          This is the guarantee that matters to a <strong>requestor</strong>: when you send a prompt
+          to a confidential provider, the machine&apos;s own operator cannot read it. A best-effort
+          provider runs inference in a helper process the operator controls and could observe. A
+          confidential provider instead runs inference{" "}
+          <strong>entirely inside the measured, signed co/core agent</strong> — the in-process
+          engine, with no subprocess and no IPC to tap — so the plaintext never leaves the attested
+          binary. There is no observation surface for the operator to use.
+        </p>
+        <p {...stylex.props(docsStyles.prose)}>
+          “Operator” here means the person running the provider machine. If you&apos;re an operator
+          reading this in the app: confidential means that <em>you</em> can&apos;t read what
+          requestors send you — and that&apos;s the point. It&apos;s what lets requestors trust your
+          machine with sensitive work.
+        </p>
+        <p {...stylex.props(docsStyles.prose)}>
+          How it&apos;s proven, so a requestor doesn&apos;t have to take the operator&apos;s word
+          for it: the matchmaker challenges the running agent with an AMFI-gated push that only the
+          genuine, team-signed binary can answer, and the binary&apos;s measured code identity (its
+          code-directory hash) must be in the blessed-build set, under a hardened runtime with
+          library validation and verified SIP. Only when all of that holds does the provider
+          advertise the <strong>attested-confidential</strong> tier.
+        </p>
+
+        <h2 {...stylex.props(docsStyles.h2)}>Why they&apos;re independent</h2>
+        <p {...stylex.props(docsStyles.prose)}>
+          <strong>Neither</strong> — fast best-effort serving: a real-enough machine whose operator
+          can read prompts. <strong>Secure Mode only</strong> — proven genuine hardware, but
+          inference still runs where the operator can read it. <strong>Confidential only</strong> —
+          the operator can&apos;t read prompts, but you&apos;re trusting the code-identity proof
+          without an Apple hardware-root attestation of the silicon. <strong>Both</strong> — genuine
+          attested hardware <em>and</em> a sealed, operator-blind inference path.
+        </p>
+
+        <h2 {...stylex.props(docsStyles.h2)}>The model constraint for operators</h2>
+        <p {...stylex.props(docsStyles.prose)}>
+          Confidential serving runs in the agent&apos;s in-process engine, which only loads certain
+          model architectures — Qwen2 / Qwen3 / Llama / Gemma / Phi / Mistral-class weights. A model
+          outside that set (for example a newer Qwen3.5+, Gemma 4, or Llama 4 architecture) can only
+          be served best-effort, in the readable helper process. The provider app marks each model
+          in the picker as <strong>“Confidential&nbsp;✓”</strong> or{" "}
+          <strong>“Best-effort only”</strong>: choosing a best-effort-only model means your machine
+          can&apos;t offer requestors the confidential guarantee while serving it, even if the
+          machine is otherwise confidential-capable. Pick a confidential-capable model to keep the
+          guarantee.
+        </p>
+
+        <h2 {...stylex.props(docsStyles.h2)}>Turning them on</h2>
+        <p {...stylex.props(docsStyles.prose)}>
+          Both are controlled from the provider app under{" "}
+          <strong>Open co/core → Status → Security</strong>: <em>Enable Secure Mode</em> runs the
+          device-enrollment wizard, and <em>Enable confidential</em> opts the machine into the
+          attested-confidential tier (the same intent the console&apos;s per-machine control
+          writes). The machine then restarts serving to earn the posture; it only advertises the
+          higher tier once actually earned, so opting in never overstates what a machine can prove.
+          For the receipt and lexicon fields these map to, see the{" "}
+          <Link to="/docs/lexicons" {...stylex.props(docsStyles.proseLink)}>
+            lexicon reference
+          </Link>
+          .
+        </p>
+      </div>
+    </>
+  );
+}

--- a/packages/console/src/routeTree.gen.ts
+++ b/packages/console/src/routeTree.gen.ts
@@ -75,6 +75,7 @@ import { Route as HeaderLayoutMachinesRkeyRouteImport } from './routes/_header-l
 import { Route as HeaderLayoutDevicesNewRouteImport } from './routes/_header-layout.devices.new'
 import { Route as HeaderLayoutBlogSlugRouteImport } from './routes/_header-layout.blog.$slug'
 import { Route as HeaderLayoutAdminDisputesRouteImport } from './routes/_header-layout.admin.disputes'
+import { Route as DocsHeaderLayoutDocsSecurityRouteImport } from './routes/_docs-header-layout.docs.security'
 import { Route as DocsHeaderLayoutDocsLexiconsRouteImport } from './routes/_docs-header-layout.docs.lexicons'
 import { Route as DocsHeaderLayoutDocsInferenceRouteImport } from './routes/_docs-header-layout.docs.inference'
 import { Route as DocsHeaderLayoutDocsCommunityToolsRouteImport } from './routes/_docs-header-layout.docs.community-tools'
@@ -444,6 +445,12 @@ const HeaderLayoutAdminDisputesRoute =
     path: '/admin/disputes',
     getParentRoute: () => HeaderLayoutRoute,
   } as any)
+const DocsHeaderLayoutDocsSecurityRoute =
+  DocsHeaderLayoutDocsSecurityRouteImport.update({
+    id: '/docs/security',
+    path: '/docs/security',
+    getParentRoute: () => DocsHeaderLayoutRoute,
+  } as any)
 const DocsHeaderLayoutDocsLexiconsRoute =
   DocsHeaderLayoutDocsLexiconsRouteImport.update({
     id: '/docs/lexicons',
@@ -592,6 +599,7 @@ export interface FileRoutesByFullPath {
   '/docs/community-tools': typeof DocsHeaderLayoutDocsCommunityToolsRoute
   '/docs/inference': typeof DocsHeaderLayoutDocsInferenceRouteWithChildren
   '/docs/lexicons': typeof DocsHeaderLayoutDocsLexiconsRoute
+  '/docs/security': typeof DocsHeaderLayoutDocsSecurityRoute
   '/admin/disputes': typeof HeaderLayoutAdminDisputesRoute
   '/blog/$slug': typeof HeaderLayoutBlogSlugRoute
   '/devices/new': typeof HeaderLayoutDevicesNewRoute
@@ -676,6 +684,7 @@ export interface FileRoutesByTo {
   '/docs/api': typeof DocsHeaderLayoutDocsApiRoute
   '/docs/community-tools': typeof DocsHeaderLayoutDocsCommunityToolsRoute
   '/docs/lexicons': typeof DocsHeaderLayoutDocsLexiconsRoute
+  '/docs/security': typeof DocsHeaderLayoutDocsSecurityRoute
   '/admin/disputes': typeof HeaderLayoutAdminDisputesRoute
   '/blog/$slug': typeof HeaderLayoutBlogSlugRoute
   '/devices/new': typeof HeaderLayoutDevicesNewRoute
@@ -764,6 +773,7 @@ export interface FileRoutesById {
   '/_docs-header-layout/docs/community-tools': typeof DocsHeaderLayoutDocsCommunityToolsRoute
   '/_docs-header-layout/docs/inference': typeof DocsHeaderLayoutDocsInferenceRouteWithChildren
   '/_docs-header-layout/docs/lexicons': typeof DocsHeaderLayoutDocsLexiconsRoute
+  '/_docs-header-layout/docs/security': typeof DocsHeaderLayoutDocsSecurityRoute
   '/_header-layout/admin/disputes': typeof HeaderLayoutAdminDisputesRoute
   '/_header-layout/blog/$slug': typeof HeaderLayoutBlogSlugRoute
   '/_header-layout/devices/new': typeof HeaderLayoutDevicesNewRoute
@@ -851,6 +861,7 @@ export interface FileRouteTypes {
     | '/docs/community-tools'
     | '/docs/inference'
     | '/docs/lexicons'
+    | '/docs/security'
     | '/admin/disputes'
     | '/blog/$slug'
     | '/devices/new'
@@ -935,6 +946,7 @@ export interface FileRouteTypes {
     | '/docs/api'
     | '/docs/community-tools'
     | '/docs/lexicons'
+    | '/docs/security'
     | '/admin/disputes'
     | '/blog/$slug'
     | '/devices/new'
@@ -1022,6 +1034,7 @@ export interface FileRouteTypes {
     | '/_docs-header-layout/docs/community-tools'
     | '/_docs-header-layout/docs/inference'
     | '/_docs-header-layout/docs/lexicons'
+    | '/_docs-header-layout/docs/security'
     | '/_header-layout/admin/disputes'
     | '/_header-layout/blog/$slug'
     | '/_header-layout/devices/new'
@@ -1587,6 +1600,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof HeaderLayoutAdminDisputesRouteImport
       parentRoute: typeof HeaderLayoutRoute
     }
+    '/_docs-header-layout/docs/security': {
+      id: '/_docs-header-layout/docs/security'
+      path: '/docs/security'
+      fullPath: '/docs/security'
+      preLoaderRoute: typeof DocsHeaderLayoutDocsSecurityRouteImport
+      parentRoute: typeof DocsHeaderLayoutRoute
+    }
     '/_docs-header-layout/docs/lexicons': {
       id: '/_docs-header-layout/docs/lexicons'
       path: '/docs/lexicons'
@@ -1749,6 +1769,7 @@ interface DocsHeaderLayoutRouteChildren {
   DocsHeaderLayoutDocsCommunityToolsRoute: typeof DocsHeaderLayoutDocsCommunityToolsRoute
   DocsHeaderLayoutDocsInferenceRoute: typeof DocsHeaderLayoutDocsInferenceRouteWithChildren
   DocsHeaderLayoutDocsLexiconsRoute: typeof DocsHeaderLayoutDocsLexiconsRoute
+  DocsHeaderLayoutDocsSecurityRoute: typeof DocsHeaderLayoutDocsSecurityRoute
   DocsHeaderLayoutDocsIndexRoute: typeof DocsHeaderLayoutDocsIndexRoute
 }
 
@@ -1759,6 +1780,7 @@ const DocsHeaderLayoutRouteChildren: DocsHeaderLayoutRouteChildren = {
   DocsHeaderLayoutDocsInferenceRoute:
     DocsHeaderLayoutDocsInferenceRouteWithChildren,
   DocsHeaderLayoutDocsLexiconsRoute: DocsHeaderLayoutDocsLexiconsRoute,
+  DocsHeaderLayoutDocsSecurityRoute: DocsHeaderLayoutDocsSecurityRoute,
   DocsHeaderLayoutDocsIndexRoute: DocsHeaderLayoutDocsIndexRoute,
 }
 
@@ -1908,12 +1930,3 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
-
-import type { getRouter } from './router.tsx'
-import type { createStart } from '@tanstack/react-start'
-declare module '@tanstack/react-start' {
-  interface Register {
-    ssr: true
-    router: Awaited<ReturnType<typeof getRouter>>
-  }
-}

--- a/packages/console/src/routes/_docs-header-layout.docs.security.tsx
+++ b/packages/console/src/routes/_docs-header-layout.docs.security.tsx
@@ -1,0 +1,36 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { SecurityDocsPage } from "@/components/docs/security-page.tsx";
+import { InferenceDocsLayout } from "@/components/inference-docs/inference-docs-layout.tsx";
+import { ogImageHref, socialMeta } from "@/lib/og-image.shared.ts";
+
+const TITLE = "Secure Mode & Confidential · co/core";
+const DESCRIPTION =
+  "How co/core's two orthogonal provider guarantees work: Secure Mode (hardware attestation) and the Confidential tier (operator-blind inference).";
+
+export const Route = createFileRoute("/_docs-header-layout/docs/security")({
+  head: () => ({
+    meta: [
+      { title: TITLE },
+      { name: "description", content: DESCRIPTION },
+      ...socialMeta({
+        title: TITLE,
+        description: DESCRIPTION,
+        image: ogImageHref({
+          eyebrow: "Docs · Security",
+          title: "Secure Mode & Confidential",
+          description: DESCRIPTION,
+        }),
+      }),
+    ],
+  }),
+  component: SecurityRoute,
+});
+
+function SecurityRoute() {
+  return (
+    <InferenceDocsLayout>
+      <SecurityDocsPage />
+    </InferenceDocsLayout>
+  );
+}

--- a/provider-shell/Sources/CoCoreShell/MainTabView.swift
+++ b/provider-shell/Sources/CoCoreShell/MainTabView.swift
@@ -32,6 +32,7 @@ final class MainWindowController {
     private let onOpenSetupGuide: () -> Void
     private let onSignOut: () -> Void
     private let onEnableSecureMode: () -> Void
+    private let onSetConfidential: (Bool) -> Void
     private let onSendBugReport: () -> Void
     private let onCheckUpdates: () -> Void
     private let onInstallUpdate: () -> Void
@@ -46,6 +47,7 @@ final class MainWindowController {
         onOpenSetupGuide: @escaping () -> Void,
         onSignOut: @escaping () -> Void,
         onEnableSecureMode: @escaping () -> Void,
+        onSetConfidential: @escaping (Bool) -> Void,
         onSendBugReport: @escaping () -> Void,
         onCheckUpdates: @escaping () -> Void,
         onInstallUpdate: @escaping () -> Void,
@@ -59,6 +61,7 @@ final class MainWindowController {
         self.onOpenSetupGuide = onOpenSetupGuide
         self.onSignOut = onSignOut
         self.onEnableSecureMode = onEnableSecureMode
+        self.onSetConfidential = onSetConfidential
         self.onSendBugReport = onSendBugReport
         self.onCheckUpdates = onCheckUpdates
         self.onInstallUpdate = onInstallUpdate
@@ -75,7 +78,8 @@ final class MainWindowController {
                         onOpenProfile: onOpenProfile,
                         onOpenSetupGuide: onOpenSetupGuide,
                         onSignOut: onSignOut,
-                        onEnableSecureMode: onEnableSecureMode)),
+                        onEnableSecureMode: onEnableSecureMode,
+                        onSetConfidential: onSetConfidential)),
                 tab("Models", "cpu", ModelsView(manager: modelManager)),
                 tab("Settings", "gearshape", PreferencesView(supervisor: supervisor)),
                 tab("About", "info.circle",
@@ -144,11 +148,12 @@ private struct StatusTab: View {
     let onOpenSetupGuide: () -> Void
     let onSignOut: () -> Void
     let onEnableSecureMode: () -> Void
+    let onSetConfidential: (Bool) -> Void
     @EnvironmentObject private var state: AppState
 
     var body: some View {
         Form {
-            StatusRows(onEnableSecureMode: onEnableSecureMode)
+            StatusRows(onEnableSecureMode: onEnableSecureMode, onSetConfidential: onSetConfidential)
             Section {
                 Button("View my profile on console", action: onOpenProfile)
                     .disabled(state.session == nil)

--- a/provider-shell/Sources/CoCoreShell/MenuBarController.swift
+++ b/provider-shell/Sources/CoCoreShell/MenuBarController.swift
@@ -457,6 +457,41 @@ final class MenuBarController {
         }
     }
 
+    /// Opt this machine in/out of the attested-confidential tier from the
+    /// Security section (Open co/core → Status). Writes the owner's
+    /// `desiredTier` via the bundled CLI — the same field the console's
+    /// "Upgrade to confidential" sets — then bounces the agent so the
+    /// supervisor re-selects the right worker (confidential ↔ default). Enabling
+    /// confirms first and warns about the native-engine model constraint.
+    @MainActor
+    func setConfidential(_ on: Bool) {
+        Task { @MainActor in
+            if on {
+                let alert = NSAlert()
+                alert.messageText = "Enable confidential serving?"
+                alert.informativeText =
+                    "Inference will run entirely inside the measured, signed agent, so this machine's operator can't read prompts.\n\nThe confidential engine serves Qwen2 / Llama / Gemma / Phi models — an incompatible model (e.g. a Qwen3 model) will show a fault, so pick a compatible one under Models. The agent will restart to switch over."
+                alert.addButton(withTitle: "Enable")
+                alert.addButton(withTitle: "Cancel")
+                guard alert.runModal() == .alertFirstButtonReturn else { return }
+            }
+            let args = on ? ["agent", "confidential"] : ["agent", "confidential", "--off"]
+            let (status, out) = await ModelManager.run(args)
+            guard status == 0 else {
+                NSLog("cocore: set confidential (%@) failed (status %d): %@", on ? "on" : "off", status, out)
+                presentServeSwitchError(
+                    action: on ? "enable confidential" : "turn off confidential", detail: out)
+                return
+            }
+            // Bounce so the fresh serve reads the new desiredTier and the
+            // supervisor selects the right worker (same as Restart serving).
+            await supervisor.stop()
+            await supervisor.start()
+            refreshServing()
+            rebuildMenu()
+        }
+    }
+
     /// Surface a failed Pause / Resume switch write so the user knows the
     /// menu state didn't change (and can retry) instead of silently desyncing
     /// from what the console believes about this machine.
@@ -554,6 +589,7 @@ final class MenuBarController {
         onOpenSetupGuide: { [weak self] in self?.openWelcome() },
         onSignOut: { [weak self] in self?.signOut() },
         onEnableSecureMode: { [weak self] in self?.secureModeWizard.show() },
+        onSetConfidential: { [weak self] on in self?.setConfidential(on) },
         onSendBugReport: { [weak self] in self?.sendBugReport() },
         onCheckUpdates: { [weak self] in self?.checkUpdates() },
         onInstallUpdate: { [weak self] in self?.installUpdate() },

--- a/provider-shell/Sources/CoCoreShell/ModelsView.swift
+++ b/provider-shell/Sources/CoCoreShell/ModelsView.swift
@@ -468,6 +468,38 @@ final class ModelManager: ObservableObject {
         CatalogEntry(nsid: "mlx-community/Llama-3.3-70B-Instruct-4bit", label: "Llama 3.3 70B", minRamGB: 64, recommended: false, blurb: "Legacy flagship model."),
     ]
 
+    /// Whether a model's architecture can run in the confidential (in-process
+    /// native MLX) engine — the property that decides if this machine can offer
+    /// the attested-confidential tier while serving it.
+    enum ConfidentialCompat {
+        case capable  // a family the in-process engine loads → can serve confidentially
+        case incapable  // an arch the engine can't load → best-effort only, no confidential
+        case unknown  // can't tell from the id; agent faults at load if it can't run
+    }
+
+    /// Classify a model's confidential capability from its id. The confidential
+    /// engine is the vendored mlx-swift-examples LLM set, which loads
+    /// Qwen2 / Qwen3 / Llama(≤3) / Gemma(2,3) / Phi / Mistral-class archs — but
+    /// NOT the newer Qwen3.5+ / Gemma4 / Llama4 architectures. We assert
+    /// `incapable` only for archs we KNOW it can't load, `capable` for the
+    /// known-good families, and `unknown` otherwise (so we never over-claim — an
+    /// unknown that can't load surfaces honestly as an engineFault at serve).
+    static func confidentialCompat(_ nsid: String) -> ConfidentialCompat {
+        let id = nsid.lowercased()
+        // Newer than the vendored engine's arch set — definitionally best-effort.
+        let unsupported = [
+            "qwen3.5", "qwen3_5", "qwen3.6", "qwen3_6", "gemma-4", "gemma4", "llama-4", "llama4",
+        ]
+        if unsupported.contains(where: id.contains) { return .incapable }
+        // Families the in-process engine loads.
+        let supported = [
+            "qwen2", "qwen3", "gemma-2", "gemma2", "gemma-3", "gemma3", "llama-2", "llama2",
+            "llama-3", "llama3", "phi", "mistral",
+        ]
+        if supported.contains(where: id.contains) { return .capable }
+        return .unknown
+    }
+
     /// The recommended (latest & greatest) subset of the catalog mirror.
     static var recommendedCatalog: [CatalogEntry] { catalog.filter { $0.recommended } }
 
@@ -1109,7 +1141,7 @@ struct ModelsView: View {
                 Text("Add a model")
             } footer: {
                 sectionFooter(
-                    "Search any MLX model on HuggingFace, or pick a suggestion. co/core runs MLX weights (mlx-community/… or another 4-bit MLX conversion); a stock PyTorch repo won't load."
+                    "Search any MLX model on HuggingFace, or pick a suggestion. co/core runs MLX weights (mlx-community/… or another 4-bit MLX conversion); a stock PyTorch repo won't load.\n\nOnly “Confidential ✓” models can serve in the confidential engine (Qwen2/Qwen3/Llama/Gemma/Phi-class). A “Best-effort only” model (newer Qwen3.5+/Gemma4/Llama4 archs) runs in a helper the operator can read — choosing one means this machine can't offer confidential guarantees to requestors for it."
                 )
             }
             .onChange(of: searchQuery) { query in runSearch(query) }
@@ -1156,6 +1188,38 @@ struct ModelsView: View {
     /// A ready model: name + a red trash that frees the disk. No global
     /// `busy` disable — removal is optimistic (the row vanishes on click), so
     /// the other trashes stay live.
+    /// A small capsule marking whether a model can serve confidentially. Shown
+    /// in the picker + active list so the operator sees — before choosing — that
+    /// some models (the newer Qwen3.5+ / Gemma4 / Llama4 archs) can only serve
+    /// best-effort: picking one means this machine can't offer requestors the
+    /// confidential guarantee for it.
+    @ViewBuilder private func confidentialBadge(_ nsid: String) -> some View {
+        switch ModelManager.confidentialCompat(nsid) {
+        case .capable:
+            Text("Confidential ✓")
+                .font(.caption2.weight(.semibold))
+                .padding(.horizontal, 5).padding(.vertical, 1)
+                .background(Brand.success.opacity(0.18))
+                .foregroundStyle(Brand.success)
+                .clipShape(Capsule())
+                .help(
+                    "Runs in the in-process confidential engine — this machine can serve it with the attested-confidential guarantee."
+                )
+        case .incapable:
+            Text("Best-effort only")
+                .font(.caption2.weight(.semibold))
+                .padding(.horizontal, 5).padding(.vertical, 1)
+                .background(Color.orange.opacity(0.18))
+                .foregroundStyle(.orange)
+                .clipShape(Capsule())
+                .help(
+                    "This architecture can't run in the confidential engine. Serving it means this machine can't offer confidential guarantees to requestors for this model."
+                )
+        case .unknown:
+            EmptyView()
+        }
+    }
+
     @ViewBuilder private func activeRow(_ m: String) -> some View {
         let ram = ModelManager.minRamGB(for: m)
         HStack {
@@ -1175,6 +1239,7 @@ struct ModelsView: View {
                     .clipShape(Capsule())
                     .help("Approximate RAM this model needs while serving")
             }
+            confidentialBadge(m)
             Spacer()
             Button(role: .destructive) {
                 Task { await manager.remove(m) }
@@ -1341,6 +1406,7 @@ struct ModelsView: View {
                             .font(.caption)
                             .foregroundStyle(.tint)
                     }
+                    confidentialBadge(item.nsid)
                 }
                 if !item.blurb.isEmpty {
                     Text(item.blurb)
@@ -1379,9 +1445,12 @@ struct ModelsView: View {
             .compactMap { $0 }.joined(separator: " · ")
         HStack {
             VStack(alignment: .leading, spacing: 2) {
-                Text(r.id)
-                    .font(.system(.callout, design: .monospaced))
-                    .lineLimit(1).truncationMode(.middle)
+                HStack(spacing: 6) {
+                    Text(r.id)
+                        .font(.system(.callout, design: .monospaced))
+                        .lineLimit(1).truncationMode(.middle)
+                    confidentialBadge(r.id)
+                }
                 if let subtitle = r.subtitle {
                     Text(subtitle)
                         .font(.footnote).foregroundStyle(.secondary)

--- a/provider-shell/Sources/CoCoreShell/Resources/Info.plist
+++ b/provider-shell/Sources/CoCoreShell/Resources/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleName</key>
 	<string>co/core</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.21</string>
+	<string>0.9.22</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -22,7 +22,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>921</string>
+	<string>922</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/provider-shell/Sources/CoCoreShell/StatusView.swift
+++ b/provider-shell/Sources/CoCoreShell/StatusView.swift
@@ -74,17 +74,23 @@ struct StatusRows: View {
                 Text(state.confidential ? "🔒 Confidential" : "Best-effort")
                     .foregroundStyle(state.confidential ? .green : .secondary)
             }
-            // Honest one-liner so nobody mistakes Secure Mode (genuine Mac, SIP
-            // verified) for confidential (operator can't read prompts).
+            // Whose data, and from whom: confidential seals the REQUESTOR's
+            // prompts against YOU (this Mac's operator) — not the other way
+            // round. Written from the operator's seat so "operator" isn't
+            // mistaken for some third party.
             Text(state.confidential
-                ? "Your prompts run inside the measured, signed agent — the operator can't read them."
-                : "Seals inference so the operator can't read your prompts. The confidential engine serves Qwen2 / Llama / Gemma / Phi models.")
+                ? "Requests run sealed inside the measured, signed agent, so not even you — this Mac's operator — can read what requestors send or receive. That unreadable-by-the-operator guarantee is what requestors get."
+                : "Requests run in a local helper process that you, this Mac's operator, could read — fine for non-sensitive work. Enable confidential to seal them so requestors get a no-snooping guarantee. The confidential engine serves Qwen2 / Qwen3 / Llama / Gemma / Phi-class models.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
             if let setConfidential = onSetConfidential {
                 Button(state.confidential ? "Turn off confidential" : "Enable confidential…") {
                     setConfidential(!state.confidential)
                 }
+            }
+            if let url = URL(string: "\(Endpoints.consoleURL)/docs/security") {
+                Link("Learn more about Secure Mode & Confidential", destination: url)
+                    .font(.caption)
             }
         }
         Section("Credits") {

--- a/provider-shell/Sources/CoCoreShell/StatusView.swift
+++ b/provider-shell/Sources/CoCoreShell/StatusView.swift
@@ -17,6 +17,11 @@ struct StatusRows: View {
     /// just hides the button.
     var onEnableSecureMode: (() -> Void)? = nil
 
+    /// When provided, the Security section shows an Enable/Turn-off Confidential
+    /// toggle (writes the owner's `desiredTier`). The Bool is the desired state
+    /// (true = enable). Left `nil` to hide the control (read-only contexts).
+    var onSetConfidential: ((Bool) -> Void)? = nil
+
     var body: some View {
         Section("Identity") {
             if let s = state.session {
@@ -73,9 +78,14 @@ struct StatusRows: View {
             // verified) for confidential (operator can't read prompts).
             Text(state.confidential
                 ? "Your prompts run inside the measured, signed agent — the operator can't read them."
-                : "Seals inference so the operator can't read your prompts. Enable per-machine from the console (\u{201C}Upgrade to confidential\u{201D}).")
+                : "Seals inference so the operator can't read your prompts. The confidential engine serves Qwen2 / Llama / Gemma / Phi models.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
+            if let setConfidential = onSetConfidential {
+                Button(state.confidential ? "Turn off confidential" : "Enable confidential…") {
+                    setConfidential(!state.confidential)
+                }
+            }
         }
         Section("Credits") {
             if let bal = state.balanceCredits {

--- a/provider/Cargo.lock
+++ b/provider/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "cocore-provider"
-version = "0.9.21"
+version = "0.9.22"
 dependencies = [
  "anyhow",
  "asn1-rs",

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cocore-provider"
-version = "0.9.21"
+version = "0.9.22"
 edition = "2021"
 description = "co/core provider agent: runs hardened compute and publishes signed receipts to AT Protocol."
 license = "MIT OR Apache-2.0"

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -71,6 +71,16 @@ enum AgentCmd {
     /// CLI). Prints `best-effort` when not paired / no record yet / on a read
     /// error — the safe default.
     Tier,
+    /// Opt this machine IN to the attested-confidential tier (or out with
+    /// `--off`). Writes the owner's `desiredTier` on the provider record —
+    /// exactly what the console's "Upgrade to confidential" does — so the
+    /// serving agent restarts and re-selects the confidential worker. The tray's
+    /// Security section drives this; also runnable by hand.
+    Confidential {
+        /// Revert to best-effort instead of enabling confidential.
+        #[arg(long)]
+        off: bool,
+    },
     /// Diagnose this install end-to-end: LaunchAgent state,
     /// session.json, API key validity, and the console's view of
     /// whether the advisor sees us + a fresh provider record is
@@ -192,6 +202,7 @@ async fn main() -> Result<()> {
         Cmd::Agent(AgentCmd::Serve { advisor }) => cmd_serve_entry(advisor).await,
         Cmd::Agent(AgentCmd::Whoami) => cmd_whoami(),
         Cmd::Agent(AgentCmd::Tier) => cmd_print_tier().await,
+        Cmd::Agent(AgentCmd::Confidential { off }) => cmd_set_confidential(!off).await,
         Cmd::Agent(AgentCmd::Doctor { console, fix }) => doctor::run(&console, fix).await,
         Cmd::Agent(AgentCmd::Update { console, check }) => update::run(&console, check).await,
         Cmd::Agent(AgentCmd::Models(cmd)) => models_cli::run(cmd),
@@ -289,6 +300,78 @@ async fn cmd_set_active(active: bool) -> Result<()> {
                 tracing::warn!(
                     attempt,
                     "active-switch swap lost a race; re-reading and retrying"
+                );
+                continue;
+            }
+            Err(e) => return Err(e.into()),
+        }
+    }
+    unreachable!("loop returns on success, on the final attempt, or on a non-swap error")
+}
+
+/// Apply the desired confidential tier to a provider-record JSON value in
+/// place. `on` sets `desiredTier="attested-confidential"`; `off` removes the
+/// field entirely (absent ≡ best-effort, matching the console's downgrade).
+/// Returns true if the value actually changed.
+fn apply_desired_tier(value: &mut serde_json::Value, on: bool) -> bool {
+    let current = value.get("desiredTier").and_then(|v| v.as_str());
+    let already_set = matches!(current, Some("attested-confidential"));
+    if already_set == on {
+        return false;
+    }
+    if let Some(obj) = value.as_object_mut() {
+        if on {
+            obj.insert(
+                "desiredTier".to_string(),
+                serde_json::json!("attested-confidential"),
+            );
+        } else {
+            obj.remove("desiredTier");
+        }
+    }
+    true
+}
+
+/// `cocore agent confidential [--off]`: opt this machine in/out of the
+/// attested-confidential tier by writing the owner's `desiredTier` to its
+/// provider record — the same field the console's "Upgrade to confidential"
+/// sets. Source of truth is the owner's PDS, so the console + tray + CLI all
+/// converge. The serving agent's reconciler sees the change and restarts, and
+/// the supervisor re-selects the confidential worker. CAS on the CID with a
+/// bounded retry, exactly like `cmd_set_active`.
+async fn cmd_set_confidential(on: bool) -> Result<()> {
+    let (pds, pubkey) = open_pds()?;
+    let label = if on {
+        "attested-confidential"
+    } else {
+        "best-effort"
+    };
+    const MAX_ATTEMPTS: u32 = 4;
+    for attempt in 1..=MAX_ATTEMPTS {
+        let find = find_my_provider_record(&pds, &pubkey).await;
+        if find.is_err() && !on {
+            // No provider record yet — an absent `desiredTier` already reads as
+            // best-effort, so disabling is a no-op.
+            println!("{label} (no change)");
+            return Ok(());
+        }
+        let (rkey, mut value, cid) = find?;
+        if !apply_desired_tier(&mut value, on) {
+            println!("{label} (no change)");
+            return Ok(());
+        }
+        match pds
+            .put_record("dev.cocore.compute.provider", &rkey, &value, Some(&cid))
+            .await
+        {
+            Ok(_) => {
+                println!("{label}");
+                return Ok(());
+            }
+            Err(e) if is_swap_conflict(&e) && attempt < MAX_ATTEMPTS => {
+                tracing::warn!(
+                    attempt,
+                    "desiredTier swap lost a race; re-reading and retrying"
                 );
                 continue;
             }
@@ -2148,6 +2231,37 @@ mod inference_models_action_tests {
             inference_models_action(false, &[]),
             InferenceModelsAction::Leave
         );
+    }
+}
+
+#[cfg(test)]
+mod apply_desired_tier_tests {
+    use super::*;
+
+    #[test]
+    fn enabling_sets_field_and_reports_change() {
+        let mut v = serde_json::json!({ "machineLabel": "Mac" });
+        assert!(apply_desired_tier(&mut v, true));
+        assert_eq!(v["desiredTier"], serde_json::json!("attested-confidential"));
+        // Idempotent: already on → no change.
+        assert!(!apply_desired_tier(&mut v, true));
+    }
+
+    #[test]
+    fn disabling_removes_field_and_reports_change() {
+        let mut v = serde_json::json!({ "desiredTier": "attested-confidential", "x": 1 });
+        assert!(apply_desired_tier(&mut v, false));
+        assert!(v.get("desiredTier").is_none());
+        assert_eq!(v["x"], serde_json::json!(1)); // other fields preserved
+                                                  // Idempotent: already off (absent) → no change.
+        assert!(!apply_desired_tier(&mut v, false));
+    }
+
+    #[test]
+    fn absent_field_is_best_effort() {
+        let mut v = serde_json::json!({});
+        assert!(!apply_desired_tier(&mut v, false)); // absent == off already
+        assert!(apply_desired_tier(&mut v, true)); // off -> on
     }
 }
 


### PR DESCRIPTION
Adds the symmetric in-app Confidential toggle (Secure Mode already had a button).

- **CLI** `cocore agent confidential [--off]` writes the owner's `desiredTier` (same field as the console's "Upgrade to confidential"), CAS+retry like pause/resume. Extracted `apply_desired_tier` + unit tests.
- **Tray** Security section: "Enable confidential…" / "Turn off confidential" button; enabling confirms + warns about the native model constraint (Qwen2/Llama/Gemma/Phi); the agent bounces so the supervisor re-selects the worker.

cargo fmt/check (default + apns) + new tests green; swift build green; CLI smoke-tested (no-op path). Bumps to 0.9.22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)