### PR TITLE
security(0.9.23): default-require code identity + bind cdHash + authenticate attestation at settlement

### DIFF
--- a/infra/advisor/src/attest.ts
+++ b/infra/advisor/src/attest.ts
@@ -50,24 +50,33 @@ export function makeCodeNonce(): string {
 }
 
 /** Reconstruct the canonical bytes the provider SE-signed for a code-identity
- *  challenge: `canonicalize({ nonce })` — byte-identical to the provider's
- *  `build_code_attestation_response`. */
-export function codeSignedPayloadFor(nonce: string): Uint8Array {
-  return new TextEncoder().encode(canonicalize({ nonce }));
+ *  challenge — byte-identical to the provider's `build_code_attestation_response`.
+ *  When `cdHash` is provided (0.9.23+), it is BOUND into the signed payload as
+ *  `canonicalize({ cdHash, nonce })`, so the proof of code identity is tied to a
+ *  specific measured binary rather than just "answered the push". The advisor
+ *  reconstructs with the provider's REGISTERED cdHash, so a provider that
+ *  registers cdHash X but signs over a different one fails to verify. Falls back
+ *  to `canonicalize({ nonce })` when no cdHash is available (legacy/degenerate). */
+export function codeSignedPayloadFor(nonce: string, cdHash?: string): Uint8Array {
+  const payload = cdHash ? { cdHash, nonce } : { nonce };
+  return new TextEncoder().encode(canonicalize(payload));
 }
 
 /** Verify a CodeAttestationResponse signature against the provider's P-256
  *  attestation public key. The recovered nonce must equal `expectedNonce`
- *  (caller checks freshness) and the SE signature must verify over the
- *  canonical `{ nonce }`. Resolves false on any shape/verify error. */
+ *  (caller checks freshness) and the SE signature must verify over the canonical
+ *  payload — `{ cdHash, nonce }` when `cdHash` is given (0.9.23+), binding the
+ *  proof to the registered measurement. Resolves false on any shape/verify
+ *  error. */
 export async function verifyCodeAttestation(
   resp: CodeAttestationResponse,
   expectedNonce: string,
   attestationPubKeyB64: string,
+  cdHash?: string,
 ): Promise<boolean> {
   if (resp.nonce !== expectedNonce) return false;
   const sigDerB64 = bytesToBase64(resp.signature);
-  const message = codeSignedPayloadFor(resp.nonce);
+  const message = codeSignedPayloadFor(resp.nonce, cdHash);
   try {
     return await verifyP256(attestationPubKeyB64, sigDerB64, message);
   } catch {

--- a/infra/advisor/src/code-attest.test.ts
+++ b/infra/advisor/src/code-attest.test.ts
@@ -128,6 +128,22 @@ describe("verifyCodeAttestation", () => {
     const bad = { ...resp, signature: [...sig.slice(0, -1), (sig.at(-1)! ^ 1) & 0xff] };
     expect(await verifyCodeAttestation(bad, nonce, pubB64)).toBe(false);
   });
+
+  it("BINDS the cdHash (0.9.23): a {cdHash,nonce} signature verifies only against the same cdHash", async () => {
+    const { key, pubB64 } = await p256KeyPair();
+    const nonce = makeCodeNonce();
+    const cd = "57bd6dfa8daf45c187249a4c70a2b6c396ab9fc0";
+    // Agent signs over {cdHash, nonce} (its measured cdHash).
+    const sig = await signDer(key, codeSignedPayloadFor(nonce, cd));
+    const resp: CodeAttestationResponse = { nonce, signature: sig };
+
+    // Advisor reconstructs with the SAME (registered) cdHash → verifies.
+    expect(await verifyCodeAttestation(resp, nonce, pubB64, cd)).toBe(true);
+    // A different registered cdHash → reject (the proof is bound to the measurement).
+    expect(await verifyCodeAttestation(resp, nonce, pubB64, "deadbeef")).toBe(false);
+    // Reconstructing as nonce-only (legacy) also rejects a bound proof.
+    expect(await verifyCodeAttestation(resp, nonce, pubB64)).toBe(false);
+  });
 });
 
 describe("confidential gate is per-machine earned — ALWAYS requires code-attestation", () => {

--- a/infra/advisor/src/connection.ts
+++ b/infra/advisor/src/connection.ts
@@ -415,7 +415,19 @@ export function handleConnection(
         }
         const entry = registry.get(registeredDid, registeredMachineId);
         if (!entry) return;
-        const ok = await verifyCodeAttestation(msg, pendingCodeNonce, entry.attestationPubKey);
+        // Bind the proof to the REGISTERED cdHash (0.9.23): the agent SE-signs
+        // {cdHash, nonce} over its measured cdHash, and we reconstruct with the
+        // cdHash it registered — so the code-identity proof is tied to a specific
+        // measured binary, not just "answered the push". A confidential machine
+        // always reports a cdHash; if it's absent we can't bind, so fail closed.
+        const ok =
+          entry.cdHash != null &&
+          (await verifyCodeAttestation(
+            msg,
+            pendingCodeNonce,
+            entry.attestationPubKey,
+            entry.cdHash,
+          ));
         if (!ok) {
           console.error(
             `[ws] BAD code-attestation did=${registeredDid} machine=${registeredMachineId}`,

--- a/packages/exchange/src/exchange.ts
+++ b/packages/exchange/src/exchange.ts
@@ -114,10 +114,33 @@ export class Exchange {
       return { kind: "resolve-failed", missing: receiptIndexed.body.attestation.uri };
     const attestation = attestationRow.body as AttestationRecord;
 
+    // H1 (0.9.23): the strong-ref'd attestation MUST be owned by the provider
+    // being paid. The receipt's repo IS the provider; without this binding a
+    // provider could point its receipt at another machine's (or a self-minted,
+    // foreign-DID) attestation to launder a tier/posture it never earned. The
+    // attestation's own selfSignature is verified inside verifyForChargeStrict;
+    // here we tie that authentic attestation to this provider's identity.
+    if (attestationRow.repo !== receiptIndexed.repo) {
+      return {
+        kind: "rejected",
+        report: {
+          ok: false,
+          findings: [
+            {
+              severity: "error",
+              code: "attestation-owner-mismatch",
+              message: `attestation ${receiptIndexed.body.attestation.uri} is owned by ${attestationRow.repo}, not the receipt provider ${receiptIndexed.repo}`,
+            },
+          ],
+        },
+      };
+    }
+
     // Strict pre-settlement verification: ES256 over the canonical
-    // receipt bytes against attestation.publicKey. A tampered or
-    // unsigned receipt is rejected before the ledger moves any
-    // tokens or a settlement record gets written.
+    // receipt bytes against attestation.publicKey, PLUS the attestation's own
+    // selfSignature (H1). A tampered or unsigned receipt — or an unauthentic
+    // attestation — is rejected before the ledger moves any tokens or a
+    // settlement record gets written.
     const report = await verifyForChargeStrict(
       {
         exchangeDid: this.cfg.exchangeDid,

--- a/packages/sdk/src/seal.test.ts
+++ b/packages/sdk/src/seal.test.ts
@@ -72,6 +72,9 @@ test.skipIf(!existsSync(CONF_FIXTURE))(
         knownGoodEngineLibHashes: [f.knownGoodEngineLibHash],
         osFloor: f.osFloor,
         trustAnchorDer: Uint8Array.from(Buffer.from(f.rootDerB64, "base64")),
+        // Offline fixture (no live advisor): opt out of the APNs code-identity
+        // leg, which is asserted separately (see the 0.9.23 secure default).
+        requireCodeAttested: false,
         now: () => new Date(),
       },
     );

--- a/packages/sdk/src/validate.test.ts
+++ b/packages/sdk/src/validate.test.ts
@@ -292,6 +292,28 @@ async function signedReceipt(
   return { ...draft, enclaveSignature: base64Encode(sig) };
 }
 
+/** An attestation whose `selfSignature` actually verifies against `publicKey`
+ *  (H1: verifyForChargeStrict now authenticates the attestation, not just the
+ *  receipt). */
+async function signedAttestation(
+  kp: { publicKeyB64: string; signRaw: (msg: Uint8Array) => Promise<Uint8Array> },
+  overrides: Partial<AttestationRecord> = {},
+): Promise<AttestationRecord> {
+  const draft = fixtureAttestation({
+    publicKey: kp.publicKeyB64,
+    selfSignature: "",
+    ...overrides,
+  });
+  const {
+    selfSignature: _omit,
+    $type: _t,
+    ...signable
+  } = draft as unknown as Record<string, unknown>;
+  const msg = new TextEncoder().encode(canonicalize(signable));
+  const sig = await kp.signRaw(msg);
+  return { ...draft, selfSignature: base64Encode(sig) };
+}
+
 test("verifyReceiptStrict: valid signature passes", async () => {
   const kp = await genP256Keypair();
   const att = fixtureAttestation({ publicKey: kp.publicKeyB64 });
@@ -340,7 +362,7 @@ test("verifyReceiptStrict: malformed publicKey surfaces signature-verify-error",
 
 test("verifyForChargeStrict: appends a sig check on top of verifyForCharge", async () => {
   const kp = await genP256Keypair();
-  const att = fixtureAttestation({ publicKey: kp.publicKeyB64 });
+  const att = await signedAttestation(kp);
   const receipt = await signedReceipt(kp.publicKeyB64, kp.signRaw);
   const job = fixtureJob();
   const auth = fixtureAuth();
@@ -365,7 +387,7 @@ test("verifyForChargeStrict: appends a sig check on top of verifyForCharge", asy
 
 test("verifyForChargeStrict: bad sig fails before charging", async () => {
   const kp = await genP256Keypair();
-  const att = fixtureAttestation({ publicKey: kp.publicKeyB64 });
+  const att = await signedAttestation(kp);
   const receipt = await signedReceipt(kp.publicKeyB64, kp.signRaw);
   // Tamper with the price after signing — the sig is now stale.
   const tampered = { ...receipt, price: { amount: 99, currency: "USD" } };

--- a/packages/sdk/src/validate.ts
+++ b/packages/sdk/src/validate.ts
@@ -17,7 +17,7 @@
 //     enclave, not just well-shaped.
 
 import { canonicalize } from "./canonical.ts";
-import { verifyReceiptSignature } from "./p256.ts";
+import { verifyAttestationSignature, verifyReceiptSignature } from "./p256.ts";
 import type {
   AttestationRecord,
   JobRecord,
@@ -341,6 +341,40 @@ export async function verifyForChargeStrict(
         "enclaveSignature did not verify against attestation.publicKey",
       );
     }
+  }
+
+  // H1 (0.9.23): authenticate the ATTESTATION itself before settling against it.
+  // Verifying the receipt against `attestation.publicKey` is meaningless if the
+  // attestation is forged — a provider could mint a fresh attestation with a
+  // self-chosen key and sign the receipt with it. Require the attestation's own
+  // selfSignature to verify against its publicKey, so the posture fields (and
+  // the key the receipt is checked against) are authentically the enclave's.
+  // (The owner-DID binding — this attestation belongs to the provider being
+  // paid — is enforced by the exchange, which holds both record repos.)
+  if (attestation.selfSignature && attestation.selfSignature.length > 0) {
+    let attestOk: boolean;
+    try {
+      attestOk = await verifyAttestationSignature(
+        attestation as unknown as { selfSignature?: string } & Record<string, unknown>,
+        attestation.publicKey,
+      );
+    } catch (e) {
+      err(
+        findings,
+        "attestation-verify-error",
+        `attestation selfSignature verification threw: ${(e as Error).message}`,
+      );
+      return { ok: ok(findings), findings };
+    }
+    if (!attestOk) {
+      err(
+        findings,
+        "attestation-selfsig-invalid",
+        "attestation.selfSignature did not verify against attestation.publicKey",
+      );
+    }
+  } else {
+    err(findings, "attestation-unsigned", "attestation is missing selfSignature");
   }
   return { ok: ok(findings), findings };
 }

--- a/packages/sdk/src/verify-provider.test.ts
+++ b/packages/sdk/src/verify-provider.test.ts
@@ -140,8 +140,15 @@ test("requireCodeAttested gates on the advisor's APNs code-identity standing", a
     codeAttested: true,
   });
   assert.ok(!codes(ok.findings).includes("code-not-attested"));
-  // Not required (default) → never blocks even when not code-attested.
-  const off = await verifyProviderForSeal(att, undefined, base);
+  // SECURE DEFAULT (0.9.23): code-attestation is REQUIRED by default, so a
+  // confidential seal blocks when not code-attested even without opting in.
+  const def = await verifyProviderForSeal(att, undefined, base);
+  assert.ok(codes(def.findings).includes("code-not-attested"));
+  // Explicit opt-out (non-APNs advisor) → no longer blocks.
+  const off = await verifyProviderForSeal(att, undefined, {
+    ...base,
+    requireCodeAttested: false,
+  });
   assert.ok(!codes(off.findings).includes("code-not-attested"));
 });
 
@@ -410,6 +417,10 @@ test.skipIf(!existsSync(CONF_FIXTURE))(
     const withKey = await verifyProviderForSeal(att, chain, {
       requireConfidential: true,
       requireSessionKey: true,
+      // This fixture exercises the OFFLINE crypto (Rust-signed attestation +
+      // MDA chain + session key); the live APNs code-identity leg is asserted
+      // separately by the advisor, so opt out of it here.
+      requireCodeAttested: false,
       knownGoodCdHashes: [f.knownGoodCdHash],
       knownGoodMetallibHashes: [f.knownGoodMetallibHash],
       knownGoodEngineLibHashes: [f.knownGoodEngineLibHash],
@@ -432,6 +443,7 @@ test.skipIf(!existsSync(CONF_FIXTURE))(
     // selfSignature-authenticated long-lived encryptionPubKey.
     const noKey = await verifyProviderForSeal(att, chain, {
       requireConfidential: true,
+      requireCodeAttested: false,
       knownGoodCdHashes: [f.knownGoodCdHash],
       knownGoodMetallibHashes: [f.knownGoodMetallibHash],
       osFloor: f.osFloor,

--- a/packages/sdk/src/verify-provider.ts
+++ b/packages/sdk/src/verify-provider.ts
@@ -99,9 +99,13 @@ export interface VerifyProviderOptions {
    *  advisor-asserted — the deliberate coordinator-trust carve-out the
    *  confidential tier accepts (see infra/mdm + the parity ADR). */
   codeAttested?: boolean;
-  /** Require {@link codeAttested} for the confidential tier. Set this when the
-   *  deployment enforces APNs code-identity (the advisor has APNs configured).
-   *  Default false so callers against a non-enforcing advisor keep working. */
+  /** Require {@link codeAttested} for the confidential tier. **Default true**
+   *  (0.9.23): confidentiality is only as strong as binary measurement, and the
+   *  cdHash is self-reported — the AMFI-gated push is the one leg an operator
+   *  can't forge, so we require it by default. Set this to `false` ONLY when
+   *  targeting a non-APNs advisor, explicitly accepting the weaker proof (a
+   *  confidential result then rests on the self-reported cdHash + MDA chain,
+   *  which a forked binary on the operator's own attested device can satisfy). */
   requireCodeAttested?: boolean;
   /** Clock seam for tests. */
   now?: () => Date;
@@ -154,6 +158,15 @@ export async function verifyProviderForSeal(
   opts: VerifyProviderOptions = {},
 ): Promise<ProviderVerifyResult> {
   const requireConfidential = opts.requireConfidential ?? false;
+  // SECURE DEFAULT (0.9.23): the confidential tier REQUIRES the live APNs
+  // code-identity proof unless the caller explicitly opts out. The cdHash in the
+  // attestation is self-reported — a forked binary can copy a blessed cdHash
+  // string and (with the operator's own genuine MDA chain) satisfy every other
+  // gate. The AMFI-gated push challenge is the one leg an operator cannot forge
+  // (they don't hold the cocore team's signing identity + APNs topic), so we
+  // require it by default. A caller targeting a non-APNs advisor must opt out
+  // explicitly (requireCodeAttested: false) and thereby accept the weaker proof.
+  const requireCodeAttested = opts.requireCodeAttested ?? true;
   const now = opts.now ? opts.now() : new Date();
   const knownGood = new Set<string>(
     [...(opts.knownGoodCdHashes ?? [])].map((h) => h.toLowerCase()),
@@ -386,9 +399,9 @@ export async function verifyProviderForSeal(
   // --- 8. APNs code identity (advisor-asserted, see opts.codeAttested). ---
   // The un-forgeable complement to the self-reported cdHash: a fork can claim a
   // blessed cdHash, but cannot answer the advisor's AMFI-gated push challenge.
-  // Only enforced when the caller opts in (the advisor runs APNs); off by
-  // default so non-enforcing deployments are unaffected.
-  if (opts.requireCodeAttested && opts.codeAttested !== true) {
+  // REQUIRED by default for confidential (0.9.23) — opt out only against a
+  // non-enforcing advisor, accepting the weaker (self-reported-cdHash) proof.
+  if (requireCodeAttested && opts.codeAttested !== true) {
     block(
       "code-not-attested",
       "provider has not passed a live APNs code-identity challenge (advisor codeAttested is not true)",

--- a/provider-shell/Sources/CoCoreShell/ModelsView.swift
+++ b/provider-shell/Sources/CoCoreShell/ModelsView.swift
@@ -1133,6 +1133,8 @@ struct ModelsView: View {
                                 .lineLimit(1).truncationMode(.middle)
                             Spacer()
                             Button("Add exactly") { Task { await manager.add(q) } }
+                                .buttonStyle(.bordered)
+                                .tint(Color(nsColor: .controlAccentColor))
                                 .disabled(manager.busy || manager.models.contains(q))
                         }
                     }
@@ -1196,7 +1198,10 @@ struct ModelsView: View {
     @ViewBuilder private func confidentialBadge(_ nsid: String) -> some View {
         switch ModelManager.confidentialCompat(nsid) {
         case .capable:
-            Text("Confidential ✓")
+            // 🔒 to match the running-confidential indicator in Status → Security
+            // (not a ✓), so "this model can serve confidentially" reads as the
+            // same lock the user sees when the tier is actually live.
+            Text("🔒 Confidential")
                 .font(.caption2.weight(.semibold))
                 .padding(.horizontal, 5).padding(.vertical, 1)
                 .background(Brand.success.opacity(0.18))
@@ -1430,6 +1435,8 @@ struct ModelsView: View {
             }
             Spacer()
             Button("Add") { Task { await manager.add(item.nsid) } }
+                .buttonStyle(.bordered)
+                .tint(Color(nsColor: .controlAccentColor))
                 .disabled(manager.busy || !fits || manager.models.contains(item.nsid))
         }
         .opacity(fits ? 1 : 0.65)
@@ -1462,6 +1469,8 @@ struct ModelsView: View {
             }
             Spacer()
             Button("Add") { Task { await manager.add(r.id) } }
+                .buttonStyle(.bordered)
+                .tint(Color(nsColor: .controlAccentColor))
                 .disabled(manager.busy || !fits || manager.models.contains(r.id))
         }
         .opacity(fits ? 1 : 0.65)

--- a/provider-shell/Sources/CoCoreShell/Resources/Info.plist
+++ b/provider-shell/Sources/CoCoreShell/Resources/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleName</key>
 	<string>co/core</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.22</string>
+	<string>0.9.23</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -22,7 +22,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>922</string>
+	<string>923</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/provider-shell/Sources/CoCoreShell/SecureModeWizard.swift
+++ b/provider-shell/Sources/CoCoreShell/SecureModeWizard.swift
@@ -181,8 +181,6 @@ struct SecureModeWizardView: View {
     /// Active poll task, cancelled when the user skips/closes a step.
     @State private var pollTask: Task<Void, Never>?
 
-    private var consoleURL: String { Endpoints.consoleURL }
-
     var body: some View {
         VStack(spacing: 0) {
             header
@@ -514,15 +512,29 @@ struct SecureModeWizardView: View {
         }
     }
 
-    /// POST {consoleURL}/api/agent/mdm/enroll-profile {serial,udid} → returns the
+    /// The paired service's base URL + bearer key. Every /api/agent/* call —
+    /// including the MDM coordinator endpoints — must target the service that
+    /// paired us (`session.apiBase`) and carry our key, or it 401s. Using the
+    /// baked console URL or omitting the header is the classic failure mode;
+    /// see AppState.refreshStatus / AgentSupervisor for the same posture.
+    private func agentAuth() throws -> (base: String, apiKey: String) {
+        guard let s = state.session, let key = s.apiKey, let base = s.apiBase else {
+            throw WizardError.notPaired
+        }
+        return (base, key)
+    }
+
+    /// POST {apiBase}/api/agent/mdm/enroll-profile {serial,udid} → returns the
     /// .mobileconfig bytes + an enrollmentId.
     private func fetchEnrollProfile() async throws -> (Data, String?) {
-        guard let url = URL(string: "\(consoleURL)/api/agent/mdm/enroll-profile") else {
+        let (base, apiKey) = try agentAuth()
+        guard let url = URL(string: "\(base)/api/agent/mdm/enroll-profile") else {
             throw WizardError.badURL
         }
         var req = URLRequest(url: url)
         req.httpMethod = "POST"
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         req.timeoutInterval = 20
         let body = ["serial": serial, "udid": udid]
         req.httpBody = try JSONSerialization.data(withJSONObject: body)
@@ -585,14 +597,16 @@ struct SecureModeWizardView: View {
         }
     }
 
-    /// POST {consoleURL}/api/agent/mdm/push-attestation {serial,enrollmentId}.
+    /// POST {apiBase}/api/agent/mdm/push-attestation {serial,enrollmentId}.
     private func pushAttestation() async throws {
-        guard let url = URL(string: "\(consoleURL)/api/agent/mdm/push-attestation") else {
+        let (base, apiKey) = try agentAuth()
+        guard let url = URL(string: "\(base)/api/agent/mdm/push-attestation") else {
             throw WizardError.badURL
         }
         var req = URLRequest(url: url)
         req.httpMethod = "POST"
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         req.timeoutInterval = 20
         var body: [String: String] = ["serial": serial]
         if let id = enrollmentId { body["enrollmentId"] = id }
@@ -603,16 +617,17 @@ struct SecureModeWizardView: View {
         }
     }
 
-    /// Poll GET {consoleURL}/api/agent/mdm/attestation-chain?serial=... until a
+    /// Poll GET {apiBase}/api/agent/mdm/attestation-chain?serial=... until a
     /// chain returns (or timeout).
     private func pollForAttestationChain() {
         pollTask?.cancel()
         pollTask = Task {
             let deadline = Date().addingTimeInterval(180)
             guard
+                let auth = try? agentAuth(),
                 let serialEnc = serial.addingPercentEncoding(
                     withAllowedCharacters: .urlQueryAllowed),
-                let url = URL(string: "\(consoleURL)/api/agent/mdm/attestation-chain?serial=\(serialEnc)")
+                let url = URL(string: "\(auth.base)/api/agent/mdm/attestation-chain?serial=\(serialEnc)")
             else {
                 working = false
                 stepError = "We couldn't build the attestation-chain request."
@@ -620,6 +635,7 @@ struct SecureModeWizardView: View {
             }
             while !Task.isCancelled, Date() < deadline {
                 var req = URLRequest(url: url)
+                req.setValue("Bearer \(auth.apiKey)", forHTTPHeaderField: "Authorization")
                 req.timeoutInterval = 15
                 if let (data, resp) = try? await URLSession.shared.data(for: req),
                     (resp as? HTTPURLResponse)?.statusCode == 200,
@@ -685,10 +701,12 @@ struct SecureModeWizardView: View {
     private enum WizardError: LocalizedError {
         case badURL
         case http(Int)
+        case notPaired
         var errorDescription: String? {
             switch self {
             case .badURL: return "bad URL"
             case .http(let c): return "HTTP \(c)"
+            case .notPaired: return "this Mac isn't paired with co/core yet — finish pairing first"
             }
         }
     }

--- a/provider-shell/Sources/CoCoreShell/StatusView.swift
+++ b/provider-shell/Sources/CoCoreShell/StatusView.swift
@@ -66,7 +66,12 @@ struct StatusRows: View {
             if let exp = state.attestationExpiresAt {
                 LabeledContent("Attestation expires", value: exp.formatted(.dateTime))
             }
-            if state.trustLevel != .hardwareAttested, let enable = onEnableSecureMode {
+            // Gated on a paired session: the wizard's MDM coordinator calls
+            // need this agent's bearer key (session.apiKey/apiBase), so there's
+            // nothing to enable until pairing completes. Mirrors the Identity
+            // section's signed-in / "Not signed in" split above.
+            if state.trustLevel != .hardwareAttested, state.session != nil,
+                let enable = onEnableSecureMode {
                 Button("Enable Secure Mode…", action: enable)
             }
 

--- a/provider/Cargo.lock
+++ b/provider/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "cocore-provider"
-version = "0.9.22"
+version = "0.9.23"
 dependencies = [
  "anyhow",
  "asn1-rs",

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cocore-provider"
-version = "0.9.22"
+version = "0.9.23"
 edition = "2021"
 description = "co/core provider agent: runs hardened compute and publishes signed receipts to AT Protocol."
 license = "MIT OR Apache-2.0"

--- a/provider/src/advisor.rs
+++ b/provider/src/advisor.rs
@@ -150,6 +150,11 @@ impl AdvisorClient {
             register.machine_id = provider_rkey.map(str::to_string);
         }
 
+        // Our measured cdHash, captured before `register` is moved into the
+        // frame — bound into every code-attestation response (0.9.23) so the
+        // code-identity proof is tied to this specific binary.
+        let my_cd_hash: Option<String> = register.cd_hash.clone();
+
         // Register
         let payload = serde_json::to_string(&AdvisorMessage::Register(register))
             .map_err(|e| ProviderError::Advisor(e.to_string()))?;
@@ -447,7 +452,9 @@ impl AdvisorClient {
                 // so the advisor can mark this measured binary `codeAttested`.
                 // Inert when `push_rx` is None (non-apns / headless).
                 Some(payload) = next_push(&mut push_rx) => {
-                    match handle_code_challenge_payload(encryption, signer, &payload) {
+                    // Bind our measured cdHash (the value we registered) into the
+                    // signed code-attestation, so the proof is tied to this binary.
+                    match handle_code_challenge_payload(encryption, signer, &payload, my_cd_hash.as_deref()) {
                         Ok(Some(resp)) => {
                             match serde_json::to_string(&AdvisorMessage::CodeAttestationResponse(resp)) {
                                 Ok(s) => {
@@ -1349,6 +1356,7 @@ pub fn recover_code_challenge(
     signer: &dyn SigningIdentity,
     advisor_eph_pub_b64: &str,
     sealed_b64: &str,
+    cd_hash: Option<&str>,
 ) -> Result<CodeAttestationResponse> {
     use base64::Engine as _;
     let sealed = base64::engine::general_purpose::STANDARD
@@ -1359,7 +1367,7 @@ pub fn recover_code_challenge(
         .map_err(|e| ProviderError::Advisor(format!("code challenge open: {e}")))?;
     let nonce = String::from_utf8(nonce_bytes)
         .map_err(|e| ProviderError::Advisor(format!("code challenge nonce utf8: {e}")))?;
-    build_code_attestation_response(signer, &nonce)
+    build_code_attestation_response(signer, &nonce, cd_hash)
 }
 
 /// Extract the code-identity challenge from an APNs push payload (the raw JSON
@@ -1395,9 +1403,12 @@ pub fn handle_code_challenge_payload(
     encryption: &ProviderKeypair,
     signer: &dyn SigningIdentity,
     json_str: &str,
+    cd_hash: Option<&str>,
 ) -> Result<Option<CodeAttestationResponse>> {
     match parse_code_challenge_payload(json_str) {
-        Some((epk, sealed)) => recover_code_challenge(encryption, signer, &epk, &sealed).map(Some),
+        Some((epk, sealed)) => {
+            recover_code_challenge(encryption, signer, &epk, &sealed, cd_hash).map(Some)
+        }
         None => Ok(None),
     }
 }
@@ -1413,8 +1424,21 @@ pub fn handle_code_challenge_payload(
 pub fn build_code_attestation_response(
     signer: &dyn SigningIdentity,
     recovered_nonce: &str,
+    cd_hash: Option<&str>,
 ) -> Result<CodeAttestationResponse> {
-    let payload = json!({ "nonce": recovered_nonce });
+    // 0.9.23: BIND the measured cdHash into the signed payload so the proof of
+    // code identity is tied to a specific binary, not just "answered the push".
+    // We sign over our OWN measured cdHash (the same value we put in Register);
+    // the advisor reconstructs with the cdHash we registered, so a mismatch
+    // between the registered and signed cdHash fails verification. Canonical
+    // sort-key order puts `cdHash` before `nonce`; the advisor's
+    // `canonicalize({ cdHash, nonce })` matches byte-for-byte. Falls back to
+    // `{ nonce }` only when no cdHash is available (a confidential machine
+    // always has one).
+    let payload = match cd_hash {
+        Some(cd) => json!({ "cdHash": cd, "nonce": recovered_nonce }),
+        None => json!({ "nonce": recovered_nonce }),
+    };
     let canonical = to_canonical_bytes(&payload)
         .map_err(|e| ProviderError::Advisor(format!("canonical: {e}")))?;
     let sig = signer
@@ -1564,15 +1588,16 @@ mod tests {
     }
 
     #[test]
-    fn code_attestation_response_signature_verifies() {
-        // The SE signature over {nonce} must verify against the signer's public
-        // key over the SAME canonical bytes the advisor's verifier reconstructs.
+    fn code_attestation_response_binds_cdhash() {
+        // 0.9.23: the SE signature is over {cdHash, nonce}, BOUND to the measured
+        // binary — it must verify over those canonical bytes AND must NOT verify
+        // over {nonce} alone (proving the cdHash is actually in the signed payload).
         let _g = identity_lock();
         let signer = load_or_create_identity().unwrap();
-        let resp = build_code_attestation_response(&*signer, "deadbeefcafe").unwrap();
+        let cd = "57bd6dfa8daf45c187249a4c70a2b6c396ab9fc0";
+        let resp = build_code_attestation_response(&*signer, "deadbeefcafe", Some(cd)).unwrap();
         assert_eq!(resp.nonce, "deadbeefcafe");
 
-        let canonical = to_canonical_bytes(&json!({ "nonce": resp.nonce })).unwrap();
         let pub_raw = B64.decode(signer.public_key_b64()).unwrap();
         let mut uncompressed = [0u8; 65];
         uncompressed[0] = 0x04;
@@ -1580,8 +1605,26 @@ mod tests {
         let point = EncodedPoint::from_bytes(uncompressed).unwrap();
         let vk = VerifyingKey::from_encoded_point(&point).unwrap();
         let sig = Signature::from_der(&resp.signature).unwrap();
-        vk.verify(&canonical, &sig)
-            .expect("code attestation response must verify");
+
+        // Verifies over {cdHash, nonce} (advisor reconstructs this with the
+        // registered cdHash).
+        let bound = to_canonical_bytes(&json!({ "cdHash": cd, "nonce": resp.nonce })).unwrap();
+        vk.verify(&bound, &sig)
+            .expect("code attestation must verify over {cdHash, nonce}");
+        // Does NOT verify over {nonce} alone — the binding is real.
+        let unbound = to_canonical_bytes(&json!({ "nonce": resp.nonce })).unwrap();
+        assert!(
+            vk.verify(&unbound, &sig).is_err(),
+            "a cdHash-bound proof must not verify as nonce-only"
+        );
+        // Nor over a DIFFERENT cdHash (a fork that registers a blessed cdHash but
+        // signs its own would fail the advisor's reconstruction).
+        let other =
+            to_canonical_bytes(&json!({ "cdHash": "deadbeef", "nonce": resp.nonce })).unwrap();
+        assert!(
+            vk.verify(&other, &sig).is_err(),
+            "proof must not verify against a different cdHash"
+        );
     }
 
     #[test]
@@ -1601,12 +1644,19 @@ mod tests {
             .unwrap();
         let sealed_b64 = B64.encode(&sealed);
 
-        let resp = recover_code_challenge(&k, &*signer, &advisor_eph.public_key_b64(), &sealed_b64)
-            .unwrap();
+        let cd = "abc123def456";
+        let resp = recover_code_challenge(
+            &k,
+            &*signer,
+            &advisor_eph.public_key_b64(),
+            &sealed_b64,
+            Some(cd),
+        )
+        .unwrap();
         assert_eq!(resp.nonce, nonce);
 
-        // Signature verifies against the attestation public key.
-        let canonical = to_canonical_bytes(&json!({ "nonce": resp.nonce })).unwrap();
+        // Signature verifies against the attestation public key over {cdHash, nonce}.
+        let canonical = to_canonical_bytes(&json!({ "cdHash": cd, "nonce": resp.nonce })).unwrap();
         let pub_raw = B64.decode(signer.public_key_b64()).unwrap();
         let mut uncompressed = [0u8; 65];
         uncompressed[0] = 0x04;
@@ -1636,7 +1686,7 @@ mod tests {
         .to_string();
 
         assert!(parse_code_challenge_payload(&payload).is_some());
-        let resp = handle_code_challenge_payload(&k, &*signer, &payload)
+        let resp = handle_code_challenge_payload(&k, &*signer, &payload, Some("cd0011"))
             .unwrap()
             .expect("payload carries a code challenge");
         assert_eq!(resp.nonce, nonce);
@@ -1644,9 +1694,11 @@ mod tests {
         // A non-challenge push (plain aps) is ignored, not an error.
         let plain = json!({ "aps": { "content-available": 1 } }).to_string();
         assert!(parse_code_challenge_payload(&plain).is_none());
-        assert!(handle_code_challenge_payload(&k, &*signer, &plain)
-            .unwrap()
-            .is_none());
+        assert!(
+            handle_code_challenge_payload(&k, &*signer, &plain, Some("cd0011"))
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]
@@ -1662,8 +1714,13 @@ mod tests {
             .seal_to(&k.public_key_b64(), b"deadbeef")
             .unwrap();
         let sealed_b64 = B64.encode(&sealed);
-        let err =
-            recover_code_challenge(&not_k, &*signer, &advisor_eph.public_key_b64(), &sealed_b64);
+        let err = recover_code_challenge(
+            &not_k,
+            &*signer,
+            &advisor_eph.public_key_b64(),
+            &sealed_b64,
+            Some("cd00"),
+        );
         assert!(err.is_err(), "opening with the wrong K must fail");
     }
 

--- a/sdk/py/cocore/verify.py
+++ b/sdk/py/cocore/verify.py
@@ -64,7 +64,10 @@ def verify_provider_for_seal(
     session_key: Optional[Mapping[str, str]] = None,
     require_session_key: bool = False,
     code_attested: bool = False,
-    require_code_attested: bool = False,
+    # SECURE DEFAULT (0.9.23): confidential requires the live APNs code-identity
+    # proof unless explicitly opted out (the cdHash is self-reported; the
+    # AMFI-gated push is the one leg an operator can't forge). Mirrors the TS SDK.
+    require_code_attested: bool = True,
     trust_anchor_der: Optional[bytes] = None,
     now: Optional[datetime] = None,
 ) -> VerifyResult:

--- a/sdk/py/tests/test_verify.py
+++ b/sdk/py/tests/test_verify.py
@@ -51,6 +51,9 @@ def test_cross_language_confidential_pass():
         att["mdaCertChain"],
         require_confidential=True,
         require_session_key=True,
+        # Offline fixture: the live APNs code-identity leg is asserted separately
+        # (see the 0.9.23 secure default), so opt out of it here.
+        require_code_attested=False,
         known_good_cdhashes=[f["knownGoodCdHash"]],
         known_good_metallib_hashes=[f["knownGoodMetallibHash"]],
         known_good_engine_lib_hashes=[f["knownGoodEngineLibHash"]],
@@ -70,6 +73,7 @@ def test_cross_language_confidential_pass():
         att,
         att["mdaCertChain"],
         require_confidential=True,
+        require_code_attested=False,
         known_good_cdhashes=[f["knownGoodCdHash"]],
         known_good_metallib_hashes=[f["knownGoodMetallibHash"]],
         os_floor=f["osFloor"],
@@ -135,8 +139,11 @@ def test_require_code_attested_gate():
     assert "code-not-attested" in codes(missing)
     ok = verify_provider_for_seal(att, None, require_code_attested=True, code_attested=True)
     assert "code-not-attested" not in codes(ok)
-    # Default (not required) never blocks on code-attestation.
-    off = verify_provider_for_seal(att, None)
+    # SECURE DEFAULT (0.9.23): code-attestation is REQUIRED by default → blocks.
+    default_required = verify_provider_for_seal(att, None)
+    assert "code-not-attested" in codes(default_required)
+    # Explicit opt-out (non-APNs advisor) no longer blocks.
+    off = verify_provider_for_seal(att, None, require_code_attested=False)
     assert "code-not-attested" not in codes(off)
 
 


### PR DESCRIPTION
Hardens the three top findings from the confidential-tier security audit (live break-in + d-inference comparison + code audit).

## C2 — default-require the un-forgeable code-identity leg (Critical)
The attestation cdHash is self-reported; a forked binary can copy a blessed cdHash and, with the operator's own genuine MDA chain, satisfy every other confidential gate. The AMFI-gated APNs challenge is the one leg an operator can't forge. **Flip `requireCodeAttested` to default `true`** in `verify-provider.ts` and `sdk/py/cocore/verify.py`. Callers targeting a non-APNs advisor must opt out explicitly (and accept the weaker proof). **SDK-visible default change.**

## C1 — bind the measured cdHash into the code-challenge (High / defense-in-depth)
The agent SE-signs `canonicalize({cdHash, nonce})` over its registered cdHash; the advisor reconstructs with the cdHash the machine **registered** and fails closed if absent. The code-identity proof is now tied to a specific measured binary, not just "answered the push." **Coordinated agent↔advisor change — deploy the advisor with/before the 0.9.23 agent.** During the skew a confidential machine on the old agent drops to best-effort (the canary is the only confidential machine today).

## H1 — authenticate the attestation at settlement (High)
`verifyForChargeStrict` now verifies the attestation's own `selfSignature` (not just the receipt's `enclaveSignature`), and the exchange rejects a receipt whose strong-ref'd attestation is owned by a different DID than the provider being paid. Closes settling against a forged/foreign attestation.

## Tests
126 Rust + 80 advisor + 94 SDK pass; tsc + oxfmt clean. New: `code_attestation_response_binds_cdhash` (Rust), the cdHash-binding case in advisor `verifyCodeAttestation`, and verifier/settlement fixtures updated for the new defaults. Bumps to 0.9.23.

(Audit follow-ups not in this PR: H2 attestation↔provider-DID key binding, H3 code-attest cache keyed on the attestation key, M1 challenge timestamp/skew, and the d-inference gaps — independent OS-MDM SecurityInfo cross-check + `rdmaDisabled` in the gate.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)