### PR TITLE
feat(secure-mode): wire the MDM coordinator to live step-ca/NanoMDM (SCEP)

### DIFF
--- a/infra/mdm/RUNBOOK.md
+++ b/infra/mdm/RUNBOOK.md
@@ -26,7 +26,7 @@ call (secrets stay on your machine + the dashboard).
   chain store persists for free.
 
 > ⚠️ Re-initialising step-ca changes its **root fingerprint**, which
-> breaks NanoMDM's baked `-ca` *and* any Mac already trusting the old
+> breaks NanoMDM's baked `-ca` _and_ any Mac already trusting the old
 > root. Do steps 1→2→3 as one sequence, then enroll. Don't redeploy
 > step-ca after step 1.
 
@@ -71,18 +71,20 @@ call (secrets stay on your machine + the dashboard).
 5. **Wire the attestation webhook** on the `cocore-attest` provisioner so a
    successful `device-attest-01` posts the captured Apple x5c chain to the
    console ingest endpoint:
+
    ```sh
    STEPPATH=~/cocore-mdm/stepca-client step ca provisioner webhook add cocore-attest \
      cocore-chain --url https://console.cocore.dev/api/agent/mdm/attestation-chain \
      --kind ENRICHING \
      --bearer-token "$COCORE_MDM_CHAIN_INGEST_KEY"
    ```
+
    The webhook body must be `{ "serial": "<permanent-identifier>", "chain":
-   ["<b64-DER-leaf>", …] }` (leaf-first Apple x5c). **Validate the payload
+["<b64-DER-leaf>", …] }` (leaf-first Apple x5c). **Validate the payload
    shape** against your step-ca version — if it doesn't surface the Apple
    x5c directly, use the fallback shim below.
 
-   *Fallback if the webhook can't carry the x5c:* a 20-line poller that
+   _Fallback if the webhook can't carry the x5c:_ a 20-line poller that
    reads the issued order's attestation off step-ca's admin API by
    permanent-identifier (= serial) and `POST`s it to the same ingest URL.
    The console side is already done; only the source differs.
@@ -135,11 +137,13 @@ Redeploy the console. (The `/data` volume already backs the new
 ## Step 4 — Smoke test (no Mac required for 4a–4b)
 
 **4a. Coordinator is live (not 503).** With any valid agent API key:
+
 ```sh
 curl -s -X POST https://console.cocore.dev/api/agent/mdm/enroll-profile \
   -H "Authorization: Bearer $COCORE_API_KEY" -H 'content-type: application/json' \
   -d '{"serial":"H2WHW38LQ6NV","udid":"00008103-001869192E20801E"}' | jq '{enrollmentId, signed, len: (.profile|length)}'
 ```
+
 Expect a JSON envelope with `enrollmentId` + a base64 `profile`. Decode it
 and confirm it carries `com.apple.security.scep`, `com.apple.mdm`
 (AccessRights 3, SignMessage), and `com.apple.security.acme` (Attest) — and
@@ -147,6 +151,7 @@ and confirm it carries `com.apple.security.scep`, `com.apple.mdm`
 from step 3 is unset.
 
 **4b. push-attestation no longer 400s:**
+
 ```sh
 curl -s -X POST https://console.cocore.dev/api/agent/mdm/push-attestation \
   -H "Authorization: Bearer $COCORE_API_KEY" -H 'content-type: application/json' \
@@ -161,6 +166,7 @@ chain poll (`GET …/attestation-chain?serial=H2WHW38LQ6NV`) returns
 `status:"captured"` → provider flips to **hardware-attested**.
 
 Watch:
+
 - NanoMDM logs: `Authenticate serial_number=H2WHW38LQ6NV` + `TokenUpdate`.
 - step-ca logs: `challenge device-attest-01 status=valid`.
 - `curl …/attestation-chain?serial=H2WHW38LQ6NV` (with the agent key) →
@@ -172,7 +178,7 @@ Watch:
 
 - ✅ **Code (this branch):** SCEP/MDM/ACME enrollment profile, fail-closed
   503, wizard-400 fix (JSON envelope), push tolerance, durable chain store
-  + authenticated ingest endpoint, unit tests.
+  - authenticated ingest endpoint, unit tests.
 - ⏳ **Infra (you, dashboard / `step` CLI):** steps 1–3 above, plus the one
   judgment call in 1.5 (does your step-ca's webhook surface the Apple x5c,
   or do you need the poller shim?).

--- a/infra/mdm/RUNBOOK.md
+++ b/infra/mdm/RUNBOOK.md
@@ -1,0 +1,180 @@
+# Secure Mode production cutover — runbook (2026-06-21)
+
+Goal: make the guided **Secure Mode** wizard work end-to-end through the
+console coordinator against the live `cocore-step-ca` + `cocore-nanomdm`
+services, so an enrolling Mac earns `trustLevel: hardware-attested`.
+
+The **code half is done** (this branch): the coordinator now mints a real
+per-device SCEP+MDM+ACME enrollment profile, the wizard's HTTP-400 bug is
+fixed (enrollmentId is returned in the JSON body), and there's a durable
+chain store + an authenticated ingest endpoint for step-ca to post the
+captured Apple x5c chain. What remains is **infra** — and the Railway API
+token in `~/.zshenv` is **read-only**, so these steps are done by hand in
+the Railway dashboard / with the `step` CLI. Nothing here transits a tool
+call (secrets stay on your machine + the dashboard).
+
+## Current live state (verified 2026-06-21)
+
+- `cocore-step-ca` (`4de1dff8-…`) — UP, ACME `cocore-attest` serving via
+  TCP proxy `reseau.proxy.rlwy.net:43462`. Root `6d7bcfec…` (still the
+  2026-06-20 root). **EPHEMERAL** — volume `cocore-step-ca-volume`
+  (`4ccbbb4b-…`) is detached (`serviceId: null`).
+- `cocore-nanomdm` (`277e36ce-…`) — UP at
+  `cocore-nanomdm-production.up.railway.app`, auth working. **EPHEMERAL** —
+  no volume; push cert lives in file storage and dies on redeploy.
+- `Client` (console, `e8f485a3-…`) — has the `/data` volume, so the new
+  chain store persists for free.
+
+> ⚠️ Re-initialising step-ca changes its **root fingerprint**, which
+> breaks NanoMDM's baked `-ca` *and* any Mac already trusting the old
+> root. Do steps 1→2→3 as one sequence, then enroll. Don't redeploy
+> step-ca after step 1.
+
+---
+
+## Step 1 — Persist step-ca (with SCEP + the attest webhook at boot)
+
+1. **Attach the volume.** Railway → `cocore-step-ca` → Settings → Volumes →
+   attach `cocore-step-ca-volume` at `/home/step`.
+2. **Init-once env** (Variables): keep `RAILWAY_RUN_UID=0`,
+   `DOCKER_STEPCA_INIT_REMOTE_MANAGEMENT=true`, and
+   `DOCKER_STEPCA_INIT_DNS_NAMES=reseau.proxy.rlwy.net`. Redeploy → step-ca
+   inits **into the volume** (now durable). This mints a **new root** —
+   that's expected; capture it next.
+3. **Capture the new root + intermediate:**
+   ```sh
+   curl -sk https://reseau.proxy.rlwy.net:43462/roots.pem  > ~/cocore-mdm/stepca-root.pem
+   # intermediate is in ~/cocore-mdm/stepca-client after bootstrap, or:
+   STEPPATH=~/cocore-mdm/stepca-client step ca bootstrap \
+     --ca-url https://reseau.proxy.rlwy.net:43462 \
+     --fingerprint <new-fingerprint-from-roots.pem> --force
+   ```
+4. **Re-add the provisioners so they exist AT BOOT** (the `/scep` route
+   only mounts for provisioners present at boot — that was the blocker):
+   ```sh
+   STEPPATH=~/cocore-mdm/stepca-client step ca provisioner add cocore-attest \
+     --type ACME --challenge device-attest-01 --attestation-format apple \
+     --admin-provisioner admin --admin-subject step \
+     --password-file ~/cocore-mdm/stepca-password.txt
+   STEPPATH=~/cocore-mdm/stepca-client step ca provisioner add cocore-scep \
+     --type SCEP --challenge "$(cat ~/cocore-mdm/scep-challenge.txt)" \
+     --encryption-algorithm-identifier 2 \
+     --admin-provisioner admin --admin-subject step \
+     --password-file ~/cocore-mdm/stepca-password.txt
+   ```
+   Because the CA is now persistent, these survive restarts and `/scep`
+   mounts at boot. Verify:
+   ```sh
+   curl -sk https://reseau.proxy.rlwy.net:43462/acme/cocore-attest/directory   # 200 JSON
+   curl -sk https://reseau.proxy.rlwy.net:43462/scep/cocore-scep?operation=GetCACaps  # 200
+   ```
+5. **Wire the attestation webhook** on the `cocore-attest` provisioner so a
+   successful `device-attest-01` posts the captured Apple x5c chain to the
+   console ingest endpoint:
+   ```sh
+   STEPPATH=~/cocore-mdm/stepca-client step ca provisioner webhook add cocore-attest \
+     cocore-chain --url https://console.cocore.dev/api/agent/mdm/attestation-chain \
+     --kind ENRICHING \
+     --bearer-token "$COCORE_MDM_CHAIN_INGEST_KEY"
+   ```
+   The webhook body must be `{ "serial": "<permanent-identifier>", "chain":
+   ["<b64-DER-leaf>", …] }` (leaf-first Apple x5c). **Validate the payload
+   shape** against your step-ca version — if it doesn't surface the Apple
+   x5c directly, use the fallback shim below.
+
+   *Fallback if the webhook can't carry the x5c:* a 20-line poller that
+   reads the issued order's attestation off step-ca's admin API by
+   permanent-identifier (= serial) and `POST`s it to the same ingest URL.
+   The console side is already done; only the source differs.
+
+---
+
+## Step 2 — Persist NanoMDM
+
+1. **Add a Postgres** plugin to the project; attach to `cocore-nanomdm`.
+2. **Storage DSN** (Variables): switch the container args to
+   `-storage pgsql -dsn "$DATABASE_URL"` (keep `RAILWAY_RUN_UID=0`,
+   `[::]:9000` bind, target port 9000).
+3. **Re-bake `-ca`** = the **new** step-ca root+intermediate bundle from
+   step 1.3 (the `~/cocore-mdm/nanomdm-deploy/` image bakes `ca.pem`).
+   `railway up` the updated image.
+4. **Re-upload the push cert once** (now durable on Postgres):
+   ```sh
+   cat ~/cocore-mdm/apns_push.pem ~/cocore-mdm/push.key | \
+     curl -T - -u "nanomdm:$(cat ~/cocore-mdm/nanomdm-api-key.txt)" \
+     https://cocore-nanomdm-production.up.railway.app/v1/pushcert      # 200 + topic
+   ```
+
+---
+
+## Step 3 — Set the console (Client) env
+
+Railway → `Client` → Variables. Paste the secrets yourself (they never
+touch a tool call). Values come from `~/cocore-mdm/`:
+
+```
+COCORE_MDM_SCEP_URL=https://reseau.proxy.rlwy.net:43462/scep/cocore-scep
+COCORE_MDM_SCEP_NAME=cocore-scep
+COCORE_MDM_SCEP_CHALLENGE=<~/cocore-mdm/scep-challenge.txt>
+COCORE_MDM_SERVER_URL=https://cocore-nanomdm-production.up.railway.app/mdm
+COCORE_MDM_CHECKIN_URL=https://cocore-nanomdm-production.up.railway.app/mdm
+COCORE_MDM_TOPIC=com.apple.mgmt.External.7e4125e2-8e2b-4a0d-a148-23c33073bc61
+COCORE_MDM_ROOT_CA_PEM=<full PEM of ~/cocore-mdm/stepca-root.pem (step 1.3)>
+COCORE_MDM_INTERMEDIATE_CA_PEM=<step-ca intermediate PEM, optional>
+COCORE_MDM_ACME_URL=https://reseau.proxy.rlwy.net:43462/acme/cocore-attest/directory
+COCORE_NANOMDM_URL=https://cocore-nanomdm-production.up.railway.app
+COCORE_NANOMDM_API_KEY=<~/cocore-mdm/nanomdm-api-key.txt>
+COCORE_MDM_CHAIN_INGEST_KEY=<generate a fresh 32+ char secret; same value used in step 1.5>
+```
+
+Redeploy the console. (The `/data` volume already backs the new
+`mdm_attestation_chains` table — no extra volume needed.)
+
+---
+
+## Step 4 — Smoke test (no Mac required for 4a–4b)
+
+**4a. Coordinator is live (not 503).** With any valid agent API key:
+```sh
+curl -s -X POST https://console.cocore.dev/api/agent/mdm/enroll-profile \
+  -H "Authorization: Bearer $COCORE_API_KEY" -H 'content-type: application/json' \
+  -d '{"serial":"H2WHW38LQ6NV","udid":"00008103-001869192E20801E"}' | jq '{enrollmentId, signed, len: (.profile|length)}'
+```
+Expect a JSON envelope with `enrollmentId` + a base64 `profile`. Decode it
+and confirm it carries `com.apple.security.scep`, `com.apple.mdm`
+(AccessRights 3, SignMessage), and `com.apple.security.acme` (Attest) — and
+**no** `com.apple.security.pkcs12`. A `503 {missing:[…]}` means an env key
+from step 3 is unset.
+
+**4b. push-attestation no longer 400s:**
+```sh
+curl -s -X POST https://console.cocore.dev/api/agent/mdm/push-attestation \
+  -H "Authorization: Bearer $COCORE_API_KEY" -H 'content-type: application/json' \
+  -d '{"serial":"H2WHW38LQ6NV"}' | jq .   # → {queued:true, status:"bundled"}
+```
+
+**4c. Full run on the M1 (`H2WHW38LQ6NV`).** Open co/core → Status →
+Security → **Enable Secure Mode**. Install the profile (Touch ID). The Mac
+SCEP-enrolls, checks into NanoMDM, and runs `device-attest-01` against
+step-ca on install. step-ca's webhook posts the x5c → the wizard's
+chain poll (`GET …/attestation-chain?serial=H2WHW38LQ6NV`) returns
+`status:"captured"` → provider flips to **hardware-attested**.
+
+Watch:
+- NanoMDM logs: `Authenticate serial_number=H2WHW38LQ6NV` + `TokenUpdate`.
+- step-ca logs: `challenge device-attest-01 status=valid`.
+- `curl …/attestation-chain?serial=H2WHW38LQ6NV` (with the agent key) →
+  `{status:"captured", chain:[…]}`.
+
+---
+
+## Division of labour
+
+- ✅ **Code (this branch):** SCEP/MDM/ACME enrollment profile, fail-closed
+  503, wizard-400 fix (JSON envelope), push tolerance, durable chain store
+  + authenticated ingest endpoint, unit tests.
+- ⏳ **Infra (you, dashboard / `step` CLI):** steps 1–3 above, plus the one
+  judgment call in 1.5 (does your step-ca's webhook surface the Apple x5c,
+  or do you need the poller shim?).
+- 🔁 **No app release needed** for initial enrollment — the shipped 0.9.23
+  wizard drives this once the server + infra are in place.

--- a/packages/console/src/lib/console-db.server.ts
+++ b/packages/console/src/lib/console-db.server.ts
@@ -127,6 +127,21 @@ CREATE TABLE IF NOT EXISTS bug_reports (
   size_bytes INTEGER NOT NULL,
   created_at TEXT NOT NULL
 );
+
+-- Captured Apple x5c attestation chains for Secure Mode (MDA), keyed by
+-- the device hardware serial. step-ca runs ACME device-attest-01 during
+-- enrollment and forwards the validated Apple attestation chain to the
+-- coordinator's authenticated ingest endpoint, which writes a row here.
+-- The agent later GETs /api/agent/mdm/attestation-chain?serial=… to
+-- staple the chain onto its dev.cocore.compute.attestation record. We
+-- store ONLY the public x5c chain (a JSON array of base64 DER certs) —
+-- no private key material ever lands here.
+CREATE TABLE IF NOT EXISTS mdm_attestation_chains (
+  serial TEXT PRIMARY KEY,
+  -- JSON array of base64-encoded DER certs, leaf-first (att.mdaCertChain).
+  chain_json TEXT NOT NULL,
+  captured_at TEXT NOT NULL
+);
 `;
 
 // Indexes run after runMigrations() so they can reference columns

--- a/packages/console/src/lib/mdm-chain-store.server.ts
+++ b/packages/console/src/lib/mdm-chain-store.server.ts
@@ -1,0 +1,43 @@
+// Durable store for captured Apple x5c attestation chains (Secure Mode /
+// MDA), keyed by device serial. Backed by the same SQLite DB as the rest
+// of console-owned state (console-db.server.ts), so chains survive a
+// console redeploy as long as the Railway volume is attached.
+//
+// SECURITY: we persist ONLY the public x5c chain (base64 DER certs). No
+// private key, no SCEP secret, no PKCS12 ever reaches this table — the
+// device's keys are SEP-resident and never leave the Mac.
+
+import { consoleDb } from "@/lib/console-db.server.ts";
+
+/** Persist (or replace) the captured Apple attestation chain for a serial.
+ *  `chain` is leaf-first base64 DER certs (att.mdaCertChain shape). */
+export function putAttestationChain(serial: string, chain: string[], capturedAt: string): void {
+  consoleDb()
+    .prepare(
+      `INSERT INTO mdm_attestation_chains (serial, chain_json, captured_at)
+       VALUES (?, ?, ?)
+       ON CONFLICT(serial) DO UPDATE SET
+         chain_json = excluded.chain_json,
+         captured_at = excluded.captured_at`,
+    )
+    .run(serial, JSON.stringify(chain), capturedAt);
+}
+
+/** Return the captured chain for a serial, or null when none is stored. */
+export function getAttestationChain(
+  serial: string,
+): { chain: string[]; capturedAt: string } | null {
+  const row = consoleDb()
+    .prepare(`SELECT chain_json, captured_at FROM mdm_attestation_chains WHERE serial = ?`)
+    .get(serial) as { chain_json: string; captured_at: string } | undefined;
+  if (!row) return null;
+  try {
+    const parsed = JSON.parse(row.chain_json) as unknown;
+    if (Array.isArray(parsed) && parsed.every((c) => typeof c === "string")) {
+      return { chain: parsed as string[], capturedAt: row.captured_at };
+    }
+  } catch {
+    /* fall through to null on a corrupt row */
+  }
+  return null;
+}

--- a/packages/console/src/lib/mdm-coordinator.server.test.ts
+++ b/packages/console/src/lib/mdm-coordinator.server.test.ts
@@ -1,0 +1,174 @@
+// Unit coverage for the Secure Mode MDM coordinator's pure paths —
+// per-device profile generation, fail-closed config, and the
+// push-attestation tolerance that lets the shipped wizard advance.
+// These never touch the SQLite chain store (that's exercised separately),
+// so they run without the better-sqlite3 native binding.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  attestationIsBundled,
+  buildEnrollmentProfile,
+  isValidSerial,
+  isValidUdid,
+  pushAttestationCommand,
+  secureMdmConfig,
+} from "./mdm-coordinator.server.ts";
+
+const SCEP_KEYS = [
+  "COCORE_MDM_SCEP_URL",
+  "COCORE_MDM_SCEP_NAME",
+  "COCORE_MDM_SCEP_CHALLENGE",
+  "COCORE_MDM_SERVER_URL",
+  "COCORE_MDM_CHECKIN_URL",
+  "COCORE_MDM_TOPIC",
+  "COCORE_MDM_ROOT_CA_PEM",
+  "COCORE_MDM_INTERMEDIATE_CA_PEM",
+  "COCORE_MDM_ACME_URL",
+];
+
+const SERIAL = "H2WHW38LQ6NV";
+const UDID = "00008103-001869192E20801E"; // not a valid UDID_RE form on its own
+const REAL_UDID = "A1B2C3D4-1111-2222-3333-444455556666";
+
+function clearEnv(): void {
+  for (const k of SCEP_KEYS) delete process.env[k];
+  delete process.env["COCORE_NANOMDM_URL"];
+  delete process.env["COCORE_NANOMDM_API_KEY"];
+}
+
+function configureFull(): void {
+  process.env["COCORE_MDM_SCEP_URL"] = "https://ca.example.test:43462/scep/cocore-scep";
+  process.env["COCORE_MDM_SCEP_CHALLENGE"] = "s3cr3t&<challenge>";
+  process.env["COCORE_MDM_SERVER_URL"] = "https://mdm.example.test/mdm";
+  process.env["COCORE_MDM_TOPIC"] = "com.apple.mgmt.External.abc";
+  process.env["COCORE_MDM_ROOT_CA_PEM"] =
+    "-----BEGIN CERTIFICATE-----\nQUJDREVG\n-----END CERTIFICATE-----";
+  process.env["COCORE_MDM_ACME_URL"] = "https://ca.example.test:43462/acme/cocore-attest/directory";
+}
+
+const saved: Record<string, string | undefined> = {};
+beforeEach(() => {
+  for (const k of [...SCEP_KEYS, "COCORE_NANOMDM_URL", "COCORE_NANOMDM_API_KEY"])
+    saved[k] = process.env[k];
+  clearEnv();
+});
+afterEach(() => {
+  for (const [k, v] of Object.entries(saved)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
+describe("validation", () => {
+  it("accepts real Apple serials and UUID-form UDIDs, rejects garbage", () => {
+    expect(isValidSerial(SERIAL)).toBe(true);
+    expect(isValidSerial("no-dashes-allowed")).toBe(false);
+    expect(isValidUdid(REAL_UDID)).toBe(true);
+    expect(isValidUdid(UDID)).toBe(false); // hyphenated but wrong group sizes
+  });
+});
+
+describe("secureMdmConfig — fail-closed", () => {
+  it("reports every missing required key when unconfigured", () => {
+    const r = secureMdmConfig();
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.missing).toContain("COCORE_MDM_SCEP_URL");
+      expect(r.missing).toContain("COCORE_MDM_SCEP_CHALLENGE");
+      expect(r.missing).toContain("COCORE_MDM_SERVER_URL");
+      expect(r.missing).toContain("COCORE_MDM_TOPIC");
+      expect(r.missing).toContain("COCORE_MDM_ROOT_CA_PEM");
+    }
+  });
+
+  it("resolves once the required keys are present", () => {
+    configureFull();
+    const r = secureMdmConfig();
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.config.scepName).toBe("cocore-scep"); // default
+      expect(r.config.checkInUrl).toBe(r.config.mdmServerUrl); // defaults to server URL
+      expect(r.config.rootCaB64).toBe("QUJDREVG"); // PEM armor stripped
+    }
+  });
+});
+
+describe("buildEnrollmentProfile", () => {
+  it("returns null when the backend isn't configured (route → 503)", () => {
+    expect(buildEnrollmentProfile(SERIAL, REAL_UDID)).toBeNull();
+  });
+
+  it("emits a SCEP identity + MDM + bundled ACME profile (no empty PKCS12)", () => {
+    configureFull();
+    const built = buildEnrollmentProfile(SERIAL, REAL_UDID);
+    expect(built).not.toBeNull();
+    const p = built!.profile;
+
+    // SCEP device identity — not the old empty-PKCS12 stub.
+    expect(p).toContain("com.apple.security.scep");
+    expect(p).not.toContain("com.apple.security.pkcs12");
+    expect(p).toContain("https://ca.example.test:43462/scep/cocore-scep");
+    // SCEP challenge is XML-escaped, not raw.
+    expect(p).toContain("s3cr3t&amp;&lt;challenge&gt;");
+    expect(p).not.toContain("s3cr3t&<challenge>");
+
+    // MDM payload, least-privilege + signed check-ins.
+    expect(p).toContain("com.apple.mdm");
+    expect(p).toContain("<key>AccessRights</key><integer>3</integer>");
+    expect(p).toContain("<key>SignMessage</key><true/>");
+    expect(p).toContain("https://mdm.example.test/mdm");
+    expect(p).toContain("com.apple.mgmt.External.abc");
+
+    // Root trust anchor embedded.
+    expect(p).toContain("com.apple.security.root");
+    expect(p).toContain("QUJDREVG");
+
+    // Bundled per-serial ACME attestation (CN + ClientIdentifier = serial).
+    expect(p).toContain("com.apple.security.acme");
+    expect(p).toContain("<key>Attest</key><true/>");
+    expect(p).toContain(`<key>ClientIdentifier</key><string>${SERIAL}</string>`);
+
+    // The MDM payload binds to the SCEP identity by UUID.
+    const idUuid =
+      /com\.apple\.security\.scep[\s\S]*?<key>PayloadUUID<\/key><string>([0-9A-F-]+)<\/string>/.exec(
+        p,
+      )?.[1];
+    expect(idUuid).toBeTruthy();
+    expect(p).toContain(`<key>IdentityCertificateUUID</key><string>${idUuid}</string>`);
+
+    expect(built!.signed).toBe(false);
+    expect(built!.enrollmentId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it("omits the ACME payload when attestation isn't bundled", () => {
+    configureFull();
+    delete process.env["COCORE_MDM_ACME_URL"];
+    expect(attestationIsBundled()).toBe(false);
+    const p = buildEnrollmentProfile(SERIAL, REAL_UDID)!.profile;
+    expect(p).toContain("com.apple.security.scep");
+    expect(p).not.toContain("com.apple.security.acme");
+  });
+});
+
+describe("pushAttestationCommand — tolerance (no 400 for the shipped wizard)", () => {
+  it("ACKs with no MDM target and bundled attestation", async () => {
+    configureFull();
+    const r = await pushAttestationCommand(SERIAL, null);
+    expect(r.queued).toBe(true);
+    expect(r.status).toBe("bundled");
+  });
+
+  it("ACKs (acknowledged) with no target and no bundling", async () => {
+    const r = await pushAttestationCommand(SERIAL, null);
+    expect(r.queued).toBe(true);
+    expect(r.status).toBe("acknowledged");
+  });
+
+  it("stubs the enqueue when a target is given but NanoMDM is unconfigured", async () => {
+    const r = await pushAttestationCommand(SERIAL, REAL_UDID);
+    expect(r.queued).toBe(true);
+    expect(r.stubbed).toBe(true);
+    expect(r.status).toBe("queued");
+  });
+});

--- a/packages/console/src/lib/mdm-coordinator.server.ts
+++ b/packages/console/src/lib/mdm-coordinator.server.ts
@@ -164,7 +164,7 @@ function pemBodyB64(pem: string | undefined): string {
 // Secure Mode config — resolved from env, fail-closed when incomplete.
 // ---------------------------------------------------------------------------
 
-export interface SecureMdmConfig {
+interface SecureMdmConfig {
   scepUrl: string;
   scepName: string;
   scepChallenge: string;

--- a/packages/console/src/lib/mdm-coordinator.server.ts
+++ b/packages/console/src/lib/mdm-coordinator.server.ts
@@ -1,53 +1,64 @@
 // Server side of Apple Managed Device Attestation (MDA) — the
 // coordinator endpoints that drive guided MDM enrollment for the
-// "Secure Mode" upgrade. We proved the flow manually with NanoMDM +
-// step-ca; this module is the honest HTTP surface over it.
+// "Secure Mode" upgrade. The live backend (proven end-to-end 2026-06-20)
+// is NanoMDM + step-ca on Railway; this module is the HTTP surface the
+// provider app's wizard calls, templating per-device profiles against
+// that backend and capturing the Apple attestation chain.
 //
-// SCOPE / HONESTY
-// ---------------
-// Real CA persistence (minting per-device identities, signing the
-// .mobileconfig with the MDM vendor cert) and capturing Apple's x5c
-// attestation chain out of step-ca are ops-gated: they require live CA
-// material and a running NanoMDM/step-ca pair. So the *external* calls
-// here are stubbed behind env vars with clearly-marked `TODO(ops)`
-// seams. What is NOT stubbed: the HTTP surface, the agent auth, input
-// validation, env wiring, and request/response shapes — those are real
-// and typecheck, so wiring the backend later is a localized change.
+// ENROLLMENT MODEL (SCEP + bundled ACME attestation)
+// --------------------------------------------------
+// `enroll-profile` mints ONE per-device .mobileconfig that, on install:
+//   1. installs step-ca's root as a trust anchor (so the Mac trusts
+//      step-ca's TLS for SCEP + ACME),
+//   2. enrolls a device identity via SCEP against step-ca's `cocore-scep`
+//      provisioner (each device generates its own key; no CA-issuing
+//      secret ever lives in the console, no PKCS12 packing),
+//   3. enrolls the Mac into NanoMDM (`com.apple.mdm`, AccessRights=3,
+//      SignMessage=true — the device signs check-ins via Mdm-Signature
+//      since Railway's TLS-terminating edge strips client certs), and
+//   4. (when COCORE_MDM_ACME_URL is set) runs ACME `device-attest-01`
+//      against step-ca's `cocore-attest` provisioner via a per-serial
+//      `com.apple.security.acme` payload — so the Mac hardware-attests on
+//      install, no separate MDM push required. step-ca validates the
+//      Apple attestation and forwards the captured x5c chain to the
+//      ingest endpoint, keyed by serial.
 //
-// All MDM/CA specifics come from env (see REQUIRED ENV below); nothing
-// is hardcoded except the .mobileconfig template skeleton, which is
-// itself overridable via COCORE_MDM_PROFILE_TEMPLATE.
+// FAIL-CLOSED: when the SCEP/MDM backend env isn't configured,
+// `buildEnrollmentProfile` returns null and the route answers 503 — we
+// never hand a Mac a structurally-broken profile (the old empty-PKCS12
+// stub is gone).
 //
-// REQUIRED ENV (documented; absent ones degrade to working stubs)
-// ---------------------------------------------------------------
-//   COCORE_MDM_PROFILE_TEMPLATE   Optional. A .mobileconfig template
-//                                 string with `{{SERIAL}}`, `{{UDID}}`,
-//                                 `{{PROFILE_UUID}}`, `{{MDM_TOPIC}}`,
-//                                 `{{MDM_SERVER_URL}}`, `{{CHECKIN_URL}}`
-//                                 placeholders. When unset, a built-in
-//                                 skeleton is used.
-//   COCORE_MDM_SERVER_URL         MDM command/server URL embedded in the
-//                                 profile's MDM payload (ServerURL).
-//   COCORE_MDM_CHECKIN_URL        MDM CheckInURL (defaults to server URL).
-//   COCORE_MDM_TOPIC              APNs push topic (the MDM payload Topic,
-//                                 e.g. com.apple.mgmt.External.<uuid>).
-//   COCORE_MDM_ROOT_CA_PEM        Root CA cert (PEM) to embed for trust.
-//   COCORE_MDM_INTERMEDIATE_CA_PEM Intermediate CA cert (PEM) to embed.
-//   COCORE_MDM_SIGNING_CERT_PEM   Vendor/identity cert used to *sign* the
-//                                 mobileconfig (CMS). TODO(ops): when set
-//                                 we must CMS-sign; today we return the
-//                                 templated profile unsigned.
-//   COCORE_MDM_SIGNING_KEY_PEM    Private key paired with the signing cert.
-//   COCORE_NANOMDM_URL            Base URL of NanoMDM (for /v1/enqueue +
-//                                 push). When unset, push-attestation
-//                                 returns a stubbed "queued" status.
-//   COCORE_NANOMDM_API_KEY        Bearer/basic secret NanoMDM expects.
-//   COCORE_MDM_CHAIN_STORE_URL    Base URL of the step-ca-fed store that
-//                                 holds captured Apple x5c chains keyed by
-//                                 serial. When unset, attestation-chain
-//                                 returns {chain: null, status:"pending"}.
+// REQUIRED ENV (Secure Mode is unavailable until these are set on the
+// console service; see infra/mdm/README.md for the values)
+// ----------------------------------------------------------------------
+//   COCORE_MDM_SCEP_URL        step-ca SCEP URL, e.g.
+//                              https://<step-ca-host>/scep/cocore-scep
+//   COCORE_MDM_SCEP_NAME       SCEP CA-IDENT / provisioner name
+//                              (default "cocore-scep").
+//   COCORE_MDM_SCEP_CHALLENGE  SCEP shared-secret challenge (sensitive).
+//   COCORE_MDM_SERVER_URL      NanoMDM MDM ServerURL (the device check-in
+//                              URL embedded in the MDM payload).
+//   COCORE_MDM_CHECKIN_URL     MDM CheckInURL (defaults to ServerURL).
+//   COCORE_MDM_TOPIC           APNs push topic (the MDM payload Topic,
+//                              com.apple.mgmt.External.<uuid>).
+//   COCORE_MDM_ROOT_CA_PEM     step-ca root cert (PEM) — trust anchor.
+//   COCORE_MDM_INTERMEDIATE_CA_PEM  step-ca intermediate (PEM), optional.
+//   COCORE_MDM_ACME_URL        step-ca ACME directory for cocore-attest,
+//                              e.g. https://<host>/acme/cocore-attest/directory.
+//                              When set, attestation is bundled into the
+//                              enrollment profile (recommended).
+//   COCORE_NANOMDM_URL         NanoMDM base URL (for the push refresh path
+//                              in push-attestation). Optional when
+//                              attestation is bundled.
+//   COCORE_NANOMDM_API_KEY     NanoMDM API key (HTTP Basic password).
+//   COCORE_MDM_CHAIN_STORE_URL Optional external chain store (fallback to
+//                              the console-local SQLite store).
+//   COCORE_MDM_CHAIN_INGEST_KEY Bearer secret step-ca's attestation
+//                              webhook presents to POST captured chains.
+//   COCORE_MDM_SIGNING_CERT_PEM / _KEY_PEM  CMS-sign the profile (TODO).
 
 import { resolveBearerKey, type ResolvedKey } from "@/lib/api-keys.server.ts";
+import { getAttestationChain, putAttestationChain } from "@/lib/mdm-chain-store.server.ts";
 
 // ---------------------------------------------------------------------------
 // Auth — same bearer-API-key surface every other /api/agent/* route uses.
@@ -84,6 +95,20 @@ export function authenticateAgent(request: Request): MdmAuthResult {
   return { ok: true, caller };
 }
 
+/** Authenticate step-ca's attestation webhook (the chain ingest). This
+ *  caller is NOT an agent — it's our own CA infra — so it presents the
+ *  shared COCORE_MDM_CHAIN_INGEST_KEY as a bearer. Constant-time compare;
+ *  401 when unset (fail-closed — never accept an unauthenticated chain). */
+export function authenticateChainIngest(request: Request): boolean {
+  const expected = env("COCORE_MDM_CHAIN_INGEST_KEY");
+  if (!expected) return false;
+  const got = readBearer(request);
+  if (!got || got.length !== expected.length) return false;
+  let diff = 0;
+  for (let i = 0; i < expected.length; i++) diff |= got.charCodeAt(i) ^ expected.charCodeAt(i);
+  return diff === 0;
+}
+
 // ---------------------------------------------------------------------------
 // Validation helpers.
 // ---------------------------------------------------------------------------
@@ -107,124 +132,26 @@ export function isValidUdid(v: unknown): v is string {
   return typeof v === "string" && UDID_RE.test(v);
 }
 
-// ---------------------------------------------------------------------------
-// enroll-profile — mint a per-device .mobileconfig.
-// ---------------------------------------------------------------------------
-
-/** Built-in .mobileconfig skeleton used when COCORE_MDM_PROFILE_TEMPLATE
- *  is unset. Includes a root+intermediate trust payload, a device
- *  identity placeholder, and an MDM payload with AccessRights=3 and
- *  SignMessage=true (the MDA-relevant settings). Placeholders are
- *  substituted per request. */
-const DEFAULT_PROFILE_TEMPLATE = `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>PayloadDisplayName</key>
-  <string>co/core Secure Mode Enrollment ({{SERIAL}})</string>
-  <key>PayloadIdentifier</key>
-  <string>dev.cocore.mdm.enroll.{{SERIAL}}</string>
-  <key>PayloadType</key>
-  <string>Configuration</string>
-  <key>PayloadUUID</key>
-  <string>{{PROFILE_UUID}}</string>
-  <key>PayloadVersion</key>
-  <integer>1</integer>
-  <key>PayloadContent</key>
-  <array>
-    <dict>
-      <key>PayloadType</key>
-      <string>com.apple.security.root</string>
-      <key>PayloadIdentifier</key>
-      <string>dev.cocore.mdm.trust.root.{{SERIAL}}</string>
-      <key>PayloadUUID</key>
-      <string>{{ROOT_PAYLOAD_UUID}}</string>
-      <key>PayloadVersion</key>
-      <integer>1</integer>
-      <key>PayloadCertificateFileName</key>
-      <string>cocore-root-ca.pem</string>
-      <key>PayloadContent</key>
-      <data>{{ROOT_CA_B64}}</data>
-    </dict>
-    <dict>
-      <key>PayloadType</key>
-      <string>com.apple.security.pkcs1</string>
-      <key>PayloadIdentifier</key>
-      <string>dev.cocore.mdm.trust.intermediate.{{SERIAL}}</string>
-      <key>PayloadUUID</key>
-      <string>{{INTERMEDIATE_PAYLOAD_UUID}}</string>
-      <key>PayloadVersion</key>
-      <integer>1</integer>
-      <key>PayloadCertificateFileName</key>
-      <string>cocore-intermediate-ca.pem</string>
-      <key>PayloadContent</key>
-      <data>{{INTERMEDIATE_CA_B64}}</data>
-    </dict>
-    <dict>
-      <key>PayloadType</key>
-      <string>com.apple.security.pkcs12</string>
-      <key>PayloadIdentifier</key>
-      <string>dev.cocore.mdm.identity.{{SERIAL}}</string>
-      <key>PayloadUUID</key>
-      <string>{{IDENTITY_PAYLOAD_UUID}}</string>
-      <key>PayloadVersion</key>
-      <integer>1</integer>
-      <key>PayloadCertificateFileName</key>
-      <string>cocore-device-identity.p12</string>
-      <!-- TODO(ops): real per-device identity PKCS#12 minted by step-ca.
-           Stub embeds an empty identity so the profile is structurally
-           complete and installable in a test ring. -->
-      <key>PayloadContent</key>
-      <data>{{IDENTITY_P12_B64}}</data>
-    </dict>
-    <dict>
-      <key>PayloadType</key>
-      <string>com.apple.mdm</string>
-      <key>PayloadIdentifier</key>
-      <string>dev.cocore.mdm.payload.{{SERIAL}}</string>
-      <key>PayloadUUID</key>
-      <string>{{MDM_PAYLOAD_UUID}}</string>
-      <key>PayloadVersion</key>
-      <integer>1</integer>
-      <key>IdentityCertificateUUID</key>
-      <string>{{IDENTITY_PAYLOAD_UUID}}</string>
-      <key>Topic</key>
-      <string>{{MDM_TOPIC}}</string>
-      <key>ServerURL</key>
-      <string>{{MDM_SERVER_URL}}</string>
-      <key>CheckInURL</key>
-      <string>{{CHECKIN_URL}}</string>
-      <key>AccessRights</key>
-      <integer>3</integer>
-      <key>SignMessage</key>
-      <true/>
-      <key>CheckOutWhenRemoved</key>
-      <true/>
-    </dict>
-  </array>
-</dict>
-</plist>
-`;
-
-export interface EnrollProfileResult {
-  /** The .mobileconfig body to return as application/x-apple-aspen-config. */
-  profile: string;
-  /** Whether the profile was CMS-signed. False today (stub returns the
-   *  templated-but-unsigned profile); flips true once signing is wired. */
-  signed: boolean;
-  /** The per-enrollment id callers thread into push-attestation. */
-  enrollmentId: string;
-}
-
 function env(name: string): string | undefined {
   const v = process.env[name];
   return v && v.length > 0 ? v : undefined;
 }
 
+/** XML-escape a value going into the .mobileconfig. Serials are already
+ *  alphanumeric, but URLs / SCEP challenge / names are operator-supplied,
+ *  so escape everything defensively. */
+function xmlEscape(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
 /** Base64 of a PEM cert's DER body — the form a `com.apple.security.*`
- *  PayloadContent expects. We strip the PEM armor and re-emit the inner
- *  base64 (which is already DER-base64). Returns "" when no PEM is
- *  configured so the template stays well-formed. */
+ *  PayloadContent expects. Strips PEM armor and re-emits the inner
+ *  base64 (already DER-base64). Returns "" when no PEM is configured. */
 function pemBodyB64(pem: string | undefined): string {
   if (!pem) return "";
   return pem
@@ -233,228 +160,283 @@ function pemBodyB64(pem: string | undefined): string {
     .replace(/\s+/g, "");
 }
 
-/** Build a per-device enrollment .mobileconfig for {serial, udid}.
- *
- *  Reads the template + CA material from env, substitutes the serial /
- *  udid / generated UUIDs, and returns the profile. CMS signing is the
- *  ops-gated seam (TODO below); today we return the templated profile
- *  unsigned but otherwise complete. */
-export function buildEnrollmentProfile(serial: string, udid: string): EnrollProfileResult {
-  const template = env("COCORE_MDM_PROFILE_TEMPLATE") ?? DEFAULT_PROFILE_TEMPLATE;
-  const enrollmentId = crypto.randomUUID();
+// ---------------------------------------------------------------------------
+// Secure Mode config — resolved from env, fail-closed when incomplete.
+// ---------------------------------------------------------------------------
 
-  const subs: Record<string, string> = {
-    SERIAL: serial,
-    UDID: udid,
-    PROFILE_UUID: enrollmentId.toUpperCase(),
-    ROOT_PAYLOAD_UUID: crypto.randomUUID().toUpperCase(),
-    INTERMEDIATE_PAYLOAD_UUID: crypto.randomUUID().toUpperCase(),
-    IDENTITY_PAYLOAD_UUID: crypto.randomUUID().toUpperCase(),
-    MDM_PAYLOAD_UUID: crypto.randomUUID().toUpperCase(),
-    MDM_TOPIC: env("COCORE_MDM_TOPIC") ?? "com.apple.mgmt.External.PLACEHOLDER",
-    MDM_SERVER_URL: env("COCORE_MDM_SERVER_URL") ?? "https://mdm.cocore.dev/mdm",
-    CHECKIN_URL:
-      env("COCORE_MDM_CHECKIN_URL") ?? env("COCORE_MDM_SERVER_URL") ?? "https://mdm.cocore.dev/mdm",
-    ROOT_CA_B64: pemBodyB64(env("COCORE_MDM_ROOT_CA_PEM")),
-    INTERMEDIATE_CA_B64: pemBodyB64(env("COCORE_MDM_INTERMEDIATE_CA_PEM")),
-    // TODO(ops): mint a real per-device PKCS#12 identity from step-ca,
-    // keyed to `serial`, and embed it here. Stub leaves it empty.
-    IDENTITY_P12_B64: "",
+export interface SecureMdmConfig {
+  scepUrl: string;
+  scepName: string;
+  scepChallenge: string;
+  mdmServerUrl: string;
+  checkInUrl: string;
+  topic: string;
+  rootCaB64: string;
+  intermediateCaB64: string;
+  /** ACME directory URL for cocore-attest; null disables bundled attestation. */
+  acmeUrl: string | null;
+}
+
+export type SecureMdmConfigResult =
+  | { ok: true; config: SecureMdmConfig }
+  | { ok: false; missing: string[] };
+
+/** Resolve the Secure Mode MDM config from env, or report which required
+ *  keys are missing so the route can answer 503 with a clear reason. */
+export function secureMdmConfig(): SecureMdmConfigResult {
+  const missing: string[] = [];
+  const scepUrl = env("COCORE_MDM_SCEP_URL");
+  if (!scepUrl) missing.push("COCORE_MDM_SCEP_URL");
+  const scepChallenge = env("COCORE_MDM_SCEP_CHALLENGE");
+  if (!scepChallenge) missing.push("COCORE_MDM_SCEP_CHALLENGE");
+  const mdmServerUrl = env("COCORE_MDM_SERVER_URL");
+  if (!mdmServerUrl) missing.push("COCORE_MDM_SERVER_URL");
+  const topic = env("COCORE_MDM_TOPIC");
+  if (!topic) missing.push("COCORE_MDM_TOPIC");
+  const rootPem = env("COCORE_MDM_ROOT_CA_PEM");
+  if (!rootPem) missing.push("COCORE_MDM_ROOT_CA_PEM");
+
+  if (missing.length > 0) return { ok: false, missing };
+
+  return {
+    ok: true,
+    config: {
+      scepUrl: scepUrl!,
+      scepName: env("COCORE_MDM_SCEP_NAME") ?? "cocore-scep",
+      scepChallenge: scepChallenge!,
+      mdmServerUrl: mdmServerUrl!,
+      checkInUrl: env("COCORE_MDM_CHECKIN_URL") ?? mdmServerUrl!,
+      topic: topic!,
+      rootCaB64: pemBodyB64(rootPem),
+      intermediateCaB64: pemBodyB64(env("COCORE_MDM_INTERMEDIATE_CA_PEM")),
+      acmeUrl: env("COCORE_MDM_ACME_URL") ?? null,
+    },
   };
+}
 
-  let profile = template;
-  for (const [key, value] of Object.entries(subs)) {
-    profile = profile.split(`{{${key}}}`).join(value);
-  }
+/** Whether attestation is bundled into the enrollment profile (vs. pushed
+ *  separately via NanoMDM). True iff a cocore-attest ACME URL is set. */
+export function attestationIsBundled(): boolean {
+  return Boolean(env("COCORE_MDM_ACME_URL"));
+}
 
-  // TODO(ops): when COCORE_MDM_SIGNING_CERT_PEM + COCORE_MDM_SIGNING_KEY_PEM
-  // are configured, CMS-sign the profile (openssl smime -sign equivalent)
-  // so it installs without the "unsigned profile" warning and so the MDM
-  // payload's SignMessage handshake is rooted in our vendor cert. Until
-  // the signer is wired we return the unsigned-but-complete profile.
-  const canSign = Boolean(env("COCORE_MDM_SIGNING_CERT_PEM") && env("COCORE_MDM_SIGNING_KEY_PEM"));
-  const signed = false; // flips true once CMS signing lands.
-  void canSign;
+// ---------------------------------------------------------------------------
+// enroll-profile — mint a per-device SCEP+MDM(+ACME) .mobileconfig.
+// ---------------------------------------------------------------------------
+
+export interface EnrollProfileResult {
+  /** The .mobileconfig body. */
+  profile: string;
+  /** Whether the profile was CMS-signed (false until signing is wired). */
+  signed: boolean;
+  /** The per-enrollment id callers thread into push-attestation. */
+  enrollmentId: string;
+}
+
+function rootTrustPayload(b64: string, serial: string, uuid: string): string {
+  return `    <dict>
+      <key>PayloadType</key><string>com.apple.security.root</string>
+      <key>PayloadIdentifier</key><string>dev.cocore.mdm.trust.root.${serial}</string>
+      <key>PayloadUUID</key><string>${uuid}</string>
+      <key>PayloadVersion</key><integer>1</integer>
+      <key>PayloadDisplayName</key><string>co/core Trust Root</string>
+      <key>PayloadCertificateFileName</key><string>cocore-root-ca.cer</string>
+      <key>PayloadContent</key>
+      <data>${b64}</data>
+    </dict>`;
+}
+
+function intermediateTrustPayload(b64: string, serial: string, uuid: string): string {
+  return `    <dict>
+      <key>PayloadType</key><string>com.apple.security.pkcs1</string>
+      <key>PayloadIdentifier</key><string>dev.cocore.mdm.trust.intermediate.${serial}</string>
+      <key>PayloadUUID</key><string>${uuid}</string>
+      <key>PayloadVersion</key><integer>1</integer>
+      <key>PayloadDisplayName</key><string>co/core Trust Intermediate</string>
+      <key>PayloadCertificateFileName</key><string>cocore-intermediate-ca.cer</string>
+      <key>PayloadContent</key>
+      <data>${b64}</data>
+    </dict>`;
+}
+
+function scepIdentityPayload(c: SecureMdmConfig, serial: string, uuid: string): string {
+  // Each device generates its own key and enrolls it against step-ca's
+  // SCEP provisioner — no CA-issuing secret or PKCS12 in the console.
+  return `    <dict>
+      <key>PayloadType</key><string>com.apple.security.scep</string>
+      <key>PayloadIdentifier</key><string>dev.cocore.mdm.scep.${serial}</string>
+      <key>PayloadUUID</key><string>${uuid}</string>
+      <key>PayloadVersion</key><integer>1</integer>
+      <key>PayloadDisplayName</key><string>co/core Device Identity (SCEP)</string>
+      <key>PayloadContent</key>
+      <dict>
+        <key>URL</key><string>${xmlEscape(c.scepUrl)}</string>
+        <key>Name</key><string>${xmlEscape(c.scepName)}</string>
+        <key>Subject</key>
+        <array>
+          <array><array><string>CN</string><string>${serial}</string></array></array>
+        </array>
+        <key>Challenge</key><string>${xmlEscape(c.scepChallenge)}</string>
+        <key>Key Type</key><string>RSA</string>
+        <key>Key Usage</key><integer>5</integer>
+        <key>Keysize</key><integer>2048</integer>
+        <key>Retries</key><integer>3</integer>
+        <key>RetryDelay</key><integer>10</integer>
+      </dict>
+    </dict>`;
+}
+
+function mdmPayload(
+  c: SecureMdmConfig,
+  serial: string,
+  uuid: string,
+  identityUuid: string,
+): string {
+  return `    <dict>
+      <key>PayloadType</key><string>com.apple.mdm</string>
+      <key>PayloadIdentifier</key><string>dev.cocore.mdm.payload.${serial}</string>
+      <key>PayloadUUID</key><string>${uuid}</string>
+      <key>PayloadVersion</key><integer>1</integer>
+      <key>PayloadDisplayName</key><string>co/core Device Management</string>
+      <key>IdentityCertificateUUID</key><string>${identityUuid}</string>
+      <key>Topic</key><string>${xmlEscape(c.topic)}</string>
+      <key>ServerURL</key><string>${xmlEscape(c.mdmServerUrl)}</string>
+      <key>CheckInURL</key><string>${xmlEscape(c.checkInUrl)}</string>
+      <key>AccessRights</key><integer>3</integer>
+      <key>SignMessage</key><true/>
+      <key>CheckOutWhenRemoved</key><true/>
+    </dict>`;
+}
+
+/** Per-serial ACME `device-attest-01` payload. ClientIdentifier AND the
+ *  Subject CN MUST both equal the device serial — step-ca matches them
+ *  against the hardware identifiers inside Apple's attestation statement
+ *  (a mismatch fails with badAttestationStatement / badCSR). */
+function acmeAttestPayload(acmeUrl: string, serial: string, uuid: string): string {
+  return `    <dict>
+      <key>PayloadType</key><string>com.apple.security.acme</string>
+      <key>PayloadIdentifier</key><string>dev.cocore.mdm.acme.${serial}</string>
+      <key>PayloadUUID</key><string>${uuid}</string>
+      <key>PayloadVersion</key><integer>1</integer>
+      <key>PayloadDisplayName</key><string>co/core Device Attestation (ACME)</string>
+      <key>DirectoryURL</key><string>${xmlEscape(acmeUrl)}</string>
+      <key>ClientIdentifier</key><string>${serial}</string>
+      <key>KeyType</key><string>ECSECPrimeRandom</string>
+      <key>KeySize</key><integer>384</integer>
+      <key>HardwareBound</key><true/>
+      <key>Attest</key><true/>
+      <key>KeyIsExtractable</key><false/>
+      <key>UsageFlags</key><integer>5</integer>
+      <key>Subject</key>
+      <array>
+        <array><array><string>CN</string><string>${serial}</string></array></array>
+        <array><array><string>O</string><string>Graze Social PBC</string></array></array>
+      </array>
+    </dict>`;
+}
+
+/** Build a per-device enrollment .mobileconfig for {serial, udid}, or
+ *  null when the Secure Mode backend isn't configured (route → 503).
+ *
+ *  CMS signing is the remaining ops seam (TODO below); today we return
+ *  the templated profile unsigned (it installs with the standard
+ *  "unverified profile" review prompt). */
+export function buildEnrollmentProfile(serial: string, udid: string): EnrollProfileResult | null {
+  const cfg = secureMdmConfig();
+  if (!cfg.ok) return null;
+  const c = cfg.config;
+  void udid; // reserved for future per-UDID templating; serial drives everything today.
+
+  const enrollmentId = crypto.randomUUID();
+  const identityUuid = crypto.randomUUID().toUpperCase();
+
+  const payloads: string[] = [];
+  if (c.rootCaB64)
+    payloads.push(rootTrustPayload(c.rootCaB64, serial, crypto.randomUUID().toUpperCase()));
+  if (c.intermediateCaB64)
+    payloads.push(
+      intermediateTrustPayload(c.intermediateCaB64, serial, crypto.randomUUID().toUpperCase()),
+    );
+  payloads.push(scepIdentityPayload(c, serial, identityUuid));
+  payloads.push(mdmPayload(c, serial, crypto.randomUUID().toUpperCase(), identityUuid));
+  if (c.acmeUrl)
+    payloads.push(acmeAttestPayload(c.acmeUrl, serial, crypto.randomUUID().toUpperCase()));
+
+  const profile = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadDisplayName</key>
+  <string>co/core Secure Mode Enrollment (${serial})</string>
+  <key>PayloadDescription</key>
+  <string>Enrolls this Mac with co/core device management and hardware-attests it so requesters can verify it.</string>
+  <key>PayloadOrganization</key>
+  <string>co/core</string>
+  <key>PayloadIdentifier</key>
+  <string>dev.cocore.mdm.enroll.${serial}</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>${enrollmentId.toUpperCase()}</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+  <key>PayloadContent</key>
+  <array>
+${payloads.join("\n")}
+  </array>
+</dict>
+</plist>
+`;
+
+  // TODO(ops): when COCORE_MDM_SIGNING_CERT_PEM + _KEY_PEM are set,
+  // CMS-sign the profile so it installs without the "unverified profile"
+  // prompt. Until then we return the unsigned-but-complete profile.
+  const signed = false;
 
   return { profile, signed, enrollmentId };
 }
 
 // ---------------------------------------------------------------------------
-// push-attestation — enqueue the ACME attestation profile to NanoMDM.
+// push-attestation — (re)trigger the ACME attestation.
 // ---------------------------------------------------------------------------
 
 export interface PushAttestationResult {
-  /** Whether NanoMDM accepted the enqueue+push. */
   queued: boolean;
-  /** NanoMDM command UUID, when it returned one. */
+  /** NanoMDM command UUID when a real push happened; null otherwise. */
   commandUuid: string | null;
-  /** Coarse status: "queued" (sent to NanoMDM or stubbed) | "error". */
+  /** "bundled" (attestation runs from the enroll profile), "queued"
+   *  (sent to NanoMDM or stubbed), "queued-no-push", or "error". */
   status: string;
-  /** True when no NanoMDM backend was configured and we stubbed. */
+  /** True when no real NanoMDM call was made. */
   stubbed: boolean;
-  /** Human-readable detail (NanoMDM error text, or the stub note). */
   detail: string | null;
 }
 
-/** Build the ACME attestation .mobileconfig that NanoMDM will deliver as
- *  an InstallProfile command. ClientIdentifier + the cert Subject CN are
- *  pinned to the device serial, which is what binds the captured Apple
- *  x5c chain back to this machine.
- *
- *  KEY-BINDING (option b, freshness-code) — TODO(ops): the verifier accepts
- *  the chain only when it binds to the agent's signing key, and we chose the
- *  freshness-code rule: the leaf's Apple freshness OID
- *  (1.2.840.113635.100.8.11.1) must equal `sha256(signing pubkey)` (the raw
- *  64-byte P-256 point published as `attestation.publicKey`). Stock
- *  `com.apple.security.acme` derives its freshness from the ACME challenge, so
- *  making Apple emit that exact value needs ONE of: (1) a custom step-ca
- *  `device-attest-01` nonce set to `sha256(signing pubkey)`, or (2) the App
- *  Attest companion where the agent controls `clientDataHash`. Until that's
- *  wired the captured chain verifies Apple-rooted but does NOT bind, so the
- *  provider stays best-effort (fail-closed). See infra/mdm/README.md
- *  "The binding decision". */
+/** Build the ACME attestation .mobileconfig that NanoMDM delivers as an
+ *  InstallProfile command (the push/refresh path — initial attestation
+ *  is bundled into the enrollment profile). ClientIdentifier + Subject CN
+ *  are pinned to the device serial. */
 function buildAttestationCommandProfile(serial: string): string {
-  const acmeUrl = env("COCORE_MDM_ACME_URL") ?? "https://ca.cocore.dev/acme/attest";
+  const acmeUrl =
+    env("COCORE_MDM_ACME_URL") ?? "https://ca.cocore.dev/acme/cocore-attest/directory";
   const uuid = crypto.randomUUID().toUpperCase();
+  const inner = acmeAttestPayload(acmeUrl, serial, crypto.randomUUID().toUpperCase());
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>PayloadDisplayName</key>
-  <string>co/core Device Attestation (${serial})</string>
-  <key>PayloadIdentifier</key>
-  <string>dev.cocore.mdm.attest.${serial}</string>
-  <key>PayloadType</key>
-  <string>Configuration</string>
-  <key>PayloadUUID</key>
-  <string>${uuid}</string>
-  <key>PayloadVersion</key>
-  <integer>1</integer>
+  <key>PayloadDisplayName</key><string>co/core Device Attestation (${serial})</string>
+  <key>PayloadIdentifier</key><string>dev.cocore.mdm.attest.${serial}</string>
+  <key>PayloadType</key><string>Configuration</string>
+  <key>PayloadUUID</key><string>${uuid}</string>
+  <key>PayloadVersion</key><integer>1</integer>
   <key>PayloadContent</key>
   <array>
-    <dict>
-      <key>PayloadType</key>
-      <string>com.apple.security.acme</string>
-      <key>PayloadIdentifier</key>
-      <string>dev.cocore.mdm.acme.${serial}</string>
-      <key>PayloadUUID</key>
-      <string>${crypto.randomUUID().toUpperCase()}</string>
-      <key>PayloadVersion</key>
-      <integer>1</integer>
-      <key>ClientIdentifier</key>
-      <string>${serial}</string>
-      <key>DirectoryURL</key>
-      <string>${acmeUrl}</string>
-      <key>Subject</key>
-      <array>
-        <array>
-          <array>
-            <string>CN</string>
-            <string>${serial}</string>
-          </array>
-        </array>
-      </array>
-      <key>Attest</key>
-      <true/>
-      <key>HardwareBound</key>
-      <true/>
-    </dict>
+${inner}
   </array>
 </dict>
 </plist>
 `;
-}
-
-/** Enqueue the ACME attestation profile to NanoMDM for the given device
- *  and push it. Calls NanoMDM's /v1/enqueue/<udid-or-enrollment> then
- *  /v1/push/<...> using COCORE_NANOMDM_URL + COCORE_NANOMDM_API_KEY.
- *
- *  When NanoMDM isn't configured we return a stubbed "queued" status so
- *  the agent flow is exercisable end-to-end in a backendless dev ring. */
-export async function pushAttestationCommand(
-  serial: string,
-  enrollmentId: string,
-): Promise<PushAttestationResult> {
-  const base = env("COCORE_NANOMDM_URL");
-  const apiKey = env("COCORE_NANOMDM_API_KEY");
-
-  const profile = buildAttestationCommandProfile(serial);
-  // NanoMDM's enqueue command envelope: an InstallProfile command whose
-  // payload is the (base64) mobileconfig. NanoMDM accepts a raw plist
-  // command on POST /v1/enqueue/<id>.
-  const commandUuid = crypto.randomUUID().toUpperCase();
-  const enqueueBody = buildInstallProfileCommand(commandUuid, profile);
-
-  if (!base || !apiKey) {
-    // TODO(ops): wire COCORE_NANOMDM_URL + COCORE_NANOMDM_API_KEY to the
-    // live NanoMDM. Stub: pretend the enqueue+push succeeded so the
-    // guided-enrollment UX can be developed against a backendless ring.
-    return {
-      queued: true,
-      commandUuid,
-      status: "queued",
-      stubbed: true,
-      detail: "NanoMDM not configured (COCORE_NANOMDM_URL/API_KEY unset); enqueue stubbed",
-    };
-  }
-
-  const root = base.replace(/\/$/, "");
-  // NanoMDM authenticates with HTTP Basic where the password is the API
-  // key (username arbitrary, conventionally "nanomdm").
-  const authHeader = `Basic ${Buffer.from(`nanomdm:${apiKey}`).toString("base64")}`;
-  // We key the command by enrollmentId — the per-device enrollment whose
-  // identity the agent installed in step 1.
-  const target = encodeURIComponent(enrollmentId);
-
-  try {
-    const enqueueResp = await fetch(`${root}/v1/enqueue/${target}`, {
-      method: "POST",
-      headers: { authorization: authHeader, "content-type": "application/xml" },
-      body: enqueueBody,
-    });
-    if (!enqueueResp.ok) {
-      const text = await enqueueResp.text().catch(() => "");
-      return {
-        queued: false,
-        commandUuid,
-        status: "error",
-        stubbed: false,
-        detail: `NanoMDM enqueue failed (${enqueueResp.status}): ${text.slice(0, 200)}`,
-      };
-    }
-
-    // Push wakes the device so it checks in and pulls the queued command.
-    const pushResp = await fetch(`${root}/v1/push/${target}`, {
-      method: "GET",
-      headers: { authorization: authHeader },
-    });
-    if (!pushResp.ok) {
-      const text = await pushResp.text().catch(() => "");
-      return {
-        queued: true,
-        commandUuid,
-        status: "queued-no-push",
-        stubbed: false,
-        detail: `enqueued but push failed (${pushResp.status}): ${text.slice(0, 200)}`,
-      };
-    }
-
-    return {
-      queued: true,
-      commandUuid,
-      status: "queued",
-      stubbed: false,
-      detail: null,
-    };
-  } catch (e) {
-    return {
-      queued: false,
-      commandUuid,
-      status: "error",
-      stubbed: false,
-      detail: `NanoMDM request error: ${(e as Error).message}`,
-    };
-  }
 }
 
 /** Wrap a mobileconfig in NanoMDM's InstallProfile command plist. */
@@ -478,42 +460,139 @@ function buildInstallProfileCommand(commandUuid: string, profile: string): strin
 `;
 }
 
+/** (Re)trigger hardware attestation for a device.
+ *
+ *  Initial attestation runs from the bundled ACME payload in the
+ *  enrollment profile, so when no explicit MDM `target` (the device's
+ *  NanoMDM enrollment id, i.e. its UDID) is supplied we ACK without a
+ *  push — this is the path the guided wizard hits, and it must NOT 400.
+ *  When a target + NanoMDM creds are present we enqueue+push the
+ *  attestation profile as an InstallProfile command (the refresh path). */
+export async function pushAttestationCommand(
+  serial: string,
+  target: string | null,
+): Promise<PushAttestationResult> {
+  const base = env("COCORE_NANOMDM_URL");
+  const apiKey = env("COCORE_NANOMDM_API_KEY");
+
+  // No MDM target → attestation is driven by the enrollment profile.
+  if (!target) {
+    return {
+      queued: true,
+      commandUuid: null,
+      status: attestationIsBundled() ? "bundled" : "acknowledged",
+      stubbed: true,
+      detail: attestationIsBundled()
+        ? "attestation runs from the enrollment profile (ACME device-attest-01 on install)"
+        : "no MDM target supplied; attestation runs from the enrollment profile",
+    };
+  }
+
+  if (!base || !apiKey) {
+    return {
+      queued: true,
+      commandUuid: null,
+      status: "queued",
+      stubbed: true,
+      detail: "NanoMDM not configured (COCORE_NANOMDM_URL/API_KEY unset); enqueue stubbed",
+    };
+  }
+
+  const root = base.replace(/\/$/, "");
+  const authHeader = `Basic ${Buffer.from(`nanomdm:${apiKey}`).toString("base64")}`;
+  const enc = encodeURIComponent(target);
+  const commandUuid = crypto.randomUUID().toUpperCase();
+  const enqueueBody = buildInstallProfileCommand(
+    commandUuid,
+    buildAttestationCommandProfile(serial),
+  );
+
+  try {
+    const enqueueResp = await fetch(`${root}/v1/enqueue/${enc}`, {
+      method: "POST",
+      headers: { authorization: authHeader, "content-type": "application/xml" },
+      body: enqueueBody,
+    });
+    if (!enqueueResp.ok) {
+      const text = await enqueueResp.text().catch(() => "");
+      return {
+        queued: false,
+        commandUuid,
+        status: "error",
+        stubbed: false,
+        detail: `NanoMDM enqueue failed (${enqueueResp.status}): ${text.slice(0, 200)}`,
+      };
+    }
+    const pushResp = await fetch(`${root}/v1/push/${enc}`, {
+      method: "GET",
+      headers: { authorization: authHeader },
+    });
+    if (!pushResp.ok) {
+      const text = await pushResp.text().catch(() => "");
+      return {
+        queued: true,
+        commandUuid,
+        status: "queued-no-push",
+        stubbed: false,
+        detail: `enqueued but push failed (${pushResp.status}): ${text.slice(0, 200)}`,
+      };
+    }
+    return { queued: true, commandUuid, status: "queued", stubbed: false, detail: null };
+  } catch (e) {
+    return {
+      queued: false,
+      commandUuid,
+      status: "error",
+      stubbed: false,
+      detail: `NanoMDM request error: ${(e as Error).message}`,
+    };
+  }
+}
+
 // ---------------------------------------------------------------------------
-// attestation-chain — fetch the captured Apple x5c chain by serial.
+// attestation-chain — store (ingest) + read the captured Apple x5c chain.
 // ---------------------------------------------------------------------------
 
 export interface AttestationChainResult {
-  /** The captured Apple x5c chain (base64 DER certs, leaf-first) or null
-   *  when no chain has been captured for this serial yet. */
+  /** Captured Apple x5c chain (base64 DER, leaf-first) or null. */
   chain: string[] | null;
   /** "captured" | "pending" | "error". */
   status: string;
-  /** True when no chain store was configured and we stubbed. */
+  /** True when neither store had it and we report pending without a backend. */
   stubbed: boolean;
-  /** Detail for "error"/"pending"; null on success. */
   detail: string | null;
+  /** When captured, when the chain was ingested. */
+  capturedAt?: string;
+}
+
+/** Persist a captured Apple attestation chain (the step-ca webhook calls
+ *  this after a successful device-attest-01). `nowIso` is the caller's
+ *  timestamp so this stays a pure persistence step. */
+export function ingestAttestationChain(serial: string, chain: string[], nowIso: string): void {
+  putAttestationChain(serial, chain, nowIso);
 }
 
 /** Return the captured Apple x5c attestation chain for `serial`.
  *
- *  In production the chain is captured by step-ca during the ACME
- *  device-attest-01 challenge and persisted keyed by the cert Subject CN
- *  (= serial). We read it from an env-configured store URL. When the
- *  store isn't configured we stub a "pending" response.
- *
- *  TODO(ops): point COCORE_MDM_CHAIN_STORE_URL at the real step-ca-fed
- *  store (or replace this fetch with a direct step-ca admin API read).
- *  The store is expected to answer GET <base>/<serial> with
- *  {chain: string[]} or 404 when not-yet-captured. */
+ *  Checks the console-local SQLite store first (where the step-ca
+ *  attestation webhook writes), then falls back to an external store at
+ *  COCORE_MDM_CHAIN_STORE_URL when one is configured. Returns
+ *  status:"pending" until a chain has been captured. */
 export async function fetchAttestationChain(serial: string): Promise<AttestationChainResult> {
+  const local = getAttestationChain(serial);
+  if (local) {
+    return {
+      chain: local.chain,
+      status: "captured",
+      stubbed: false,
+      detail: null,
+      capturedAt: local.capturedAt,
+    };
+  }
+
   const base = env("COCORE_MDM_CHAIN_STORE_URL");
   if (!base) {
-    return {
-      chain: null,
-      status: "pending",
-      stubbed: true,
-      detail: "chain store not configured (COCORE_MDM_CHAIN_STORE_URL unset)",
-    };
+    return { chain: null, status: "pending", stubbed: true, detail: "no chain captured yet" };
   }
   const root = base.replace(/\/$/, "");
   try {

--- a/packages/console/src/routes/api/agent.mdm.attestation-chain.ts
+++ b/packages/console/src/routes/api/agent.mdm.attestation-chain.ts
@@ -1,24 +1,30 @@
-// GET /api/agent/mdm/attestation-chain?serial=...
+// GET  /api/agent/mdm/attestation-chain?serial=...   (agent reads the chain)
+// POST /api/agent/mdm/attestation-chain               (step-ca webhook ingests)
 //
-// Coordinator step 3 of guided MDM enrollment. Returns the captured
-// Apple x5c attestation chain for a device (keyed by serial) as JSON
-// {chain: string[] | null, status, ...}. The chain is captured by
-// step-ca during the ACME device-attest-01 challenge; this endpoint
-// reads it back so the SDK/console can staple it onto the provider's
-// attestation record (att.mdaCertChain) to earn `hardware-attested`.
+// Coordinator step 3 of guided MDM enrollment.
 //
-// Auth: the agent's bearer API key — same surface as the other
-// /api/agent/* routes.
+// GET returns the captured Apple x5c attestation chain for a device
+// (keyed by serial) as JSON {chain: string[] | null, status, ...}. The
+// chain is captured by step-ca during the ACME device-attest-01
+// challenge; the agent reads it here to staple onto its attestation
+// record (att.mdaCertChain) and earn `hardware-attested`. Auth: the
+// agent's bearer API key — same surface as the other /api/agent/* routes.
 //
-// Chain capture out of step-ca is ops-gated: when
-// COCORE_MDM_CHAIN_STORE_URL is unset, returns {chain:null,
-// status:"pending", stubbed:true}. See src/lib/mdm-coordinator.server.ts.
+// POST is the capture ingest: step-ca's attestation webhook forwards the
+// validated Apple x5c chain here keyed by serial; we persist it to the
+// console's durable store. Auth: the shared COCORE_MDM_CHAIN_INGEST_KEY
+// bearer (step-ca infra, not an agent). Fail-closed when the key is unset.
+//
+// Until either the webhook posts a chain or COCORE_MDM_CHAIN_STORE_URL is
+// configured, GET returns {chain:null, status:"pending"}.
 
 import { createFileRoute } from "@tanstack/react-router";
 
 import {
   authenticateAgent,
+  authenticateChainIngest,
   fetchAttestationChain,
+  ingestAttestationChain,
   isValidSerial,
   mdmJson,
 } from "@/lib/mdm-coordinator.server.ts";
@@ -38,6 +44,30 @@ export const Route = createFileRoute("/api/agent/mdm/attestation-chain")({
         const result = await fetchAttestationChain(serial);
         const status = result.status === "error" ? 502 : 200;
         return mdmJson(result, status);
+      },
+
+      POST: async ({ request }) => {
+        if (!authenticateChainIngest(request)) {
+          return mdmJson({ error: "invalid or missing chain-ingest bearer" }, 401);
+        }
+        let body: { serial?: unknown; chain?: unknown };
+        try {
+          body = (await request.json()) as typeof body;
+        } catch {
+          return mdmJson({ error: "body must be JSON" }, 400);
+        }
+        if (!isValidSerial(body.serial)) {
+          return mdmJson({ error: "serial required (8–24 alphanumeric chars)" }, 400);
+        }
+        if (
+          !Array.isArray(body.chain) ||
+          body.chain.length === 0 ||
+          !body.chain.every((c) => typeof c === "string" && c.length > 0)
+        ) {
+          return mdmJson({ error: "chain required (non-empty array of base64 DER certs)" }, 400);
+        }
+        ingestAttestationChain(body.serial, body.chain as string[], new Date().toISOString());
+        return mdmJson({ ok: true, serial: body.serial, certs: body.chain.length });
       },
     },
   },

--- a/packages/console/src/routes/api/agent.mdm.enroll-profile.ts
+++ b/packages/console/src/routes/api/agent.mdm.enroll-profile.ts
@@ -25,6 +25,7 @@ import {
   isValidSerial,
   isValidUdid,
   mdmJson,
+  secureMdmConfig,
 } from "@/lib/mdm-coordinator.server.ts";
 
 export const Route = createFileRoute("/api/agent/mdm/enroll-profile")({
@@ -47,20 +48,31 @@ export const Route = createFileRoute("/api/agent/mdm/enroll-profile")({
           return mdmJson({ error: "udid required (40-hex or UUID form)" }, 400);
         }
 
-        const { profile, signed, enrollmentId } = buildEnrollmentProfile(body.serial, body.udid);
+        const built = buildEnrollmentProfile(body.serial, body.udid);
+        if (!built) {
+          // Fail-closed: the Secure Mode (SCEP/MDM) backend isn't wired.
+          // Report exactly which env keys are missing so an operator can
+          // fix it, and so the wizard shows "not available yet" instead
+          // of dead-ending the user in a broken profile install.
+          const cfg = secureMdmConfig();
+          return mdmJson(
+            {
+              error: "Secure Mode backend not configured",
+              missing: cfg.ok ? [] : cfg.missing,
+            },
+            503,
+          );
+        }
+        const { profile, signed, enrollmentId } = built;
 
-        return new Response(profile, {
-          status: 200,
-          headers: {
-            "content-type": "application/x-apple-aspen-config; charset=utf-8",
-            "content-disposition": `attachment; filename="cocore-enroll-${body.serial}.mobileconfig"`,
-            "cache-control": "no-store",
-            // Surface coordinator metadata in headers so the agent can
-            // thread the enrollmentId into push-attestation without
-            // parsing the binary profile, and tell signed from unsigned.
-            "x-cocore-enrollment-id": enrollmentId,
-            "x-cocore-profile-signed": String(signed),
-          },
+        // Return a JSON envelope: the provider wizard reads `profile`
+        // (base64) + `enrollmentId` from the body (and threads the
+        // enrollmentId into push-attestation). The base64 keeps the
+        // .mobileconfig bytes intact across JSON.
+        return mdmJson({
+          profile: Buffer.from(profile, "utf8").toString("base64"),
+          enrollmentId,
+          signed,
         });
       },
     },

--- a/packages/console/src/routes/api/agent.mdm.push-attestation.ts
+++ b/packages/console/src/routes/api/agent.mdm.push-attestation.ts
@@ -18,6 +18,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import {
   authenticateAgent,
   isValidSerial,
+  isValidUdid,
   mdmJson,
   pushAttestationCommand,
 } from "@/lib/mdm-coordinator.server.ts";
@@ -29,7 +30,7 @@ export const Route = createFileRoute("/api/agent/mdm/push-attestation")({
         const auth = authenticateAgent(request);
         if (!auth.ok) return auth.response;
 
-        let body: { serial?: unknown; enrollmentId?: unknown };
+        let body: { serial?: unknown; enrollmentId?: unknown; udid?: unknown };
         try {
           body = (await request.json()) as typeof body;
         } catch {
@@ -38,11 +39,20 @@ export const Route = createFileRoute("/api/agent/mdm/push-attestation")({
         if (!isValidSerial(body.serial)) {
           return mdmJson({ error: "serial required (8–24 alphanumeric chars)" }, 400);
         }
-        if (typeof body.enrollmentId !== "string" || body.enrollmentId.length === 0) {
-          return mdmJson({ error: "enrollmentId required" }, 400);
-        }
 
-        const result = await pushAttestationCommand(body.serial, body.enrollmentId);
+        // The NanoMDM enqueue target is the device's enrollment id — its
+        // UDID — when a real push (refresh) is wanted. The guided wizard
+        // sends neither (initial attestation runs from the enrollment
+        // profile), so a missing target is NOT an error: pushAttestation
+        // ACKs and the device attests on install. enrollmentId is kept as
+        // a fallback target for older callers.
+        const target = isValidUdid(body.udid)
+          ? body.udid
+          : typeof body.enrollmentId === "string" && body.enrollmentId.length > 0
+            ? body.enrollmentId
+            : null;
+
+        const result = await pushAttestationCommand(body.serial, target);
         const status = result.status === "error" ? 502 : 200;
         return mdmJson(result, status);
       },


### PR DESCRIPTION
## What

Makes the **Secure Mode** wizard work end-to-end through the console coordinator against the live `cocore-step-ca` + `cocore-nanomdm` services (proven 2026-06-20, still up). Previously the coordinator was a stub — it handed the Mac an **empty PKCS#12** (→ "Incorrect password" on install) and `push-attestation` returned **HTTP 400** — so the live backend was never reached.

## The two bugs you hit, fixed

1. **"Incorrect password" / unusable profile** — `enroll-profile` returned a hardcoded empty `com.apple.security.pkcs12` with no `Password` key. Replaced with a real **SCEP** device identity (`com.apple.security.scep`) against step-ca's `cocore-scep` provisioner — each device enrolls its own key, so no CA-issuing secret or PKCS12 packing lives in the console.
2. **HTTP 400 on attestation** — `enroll-profile` returned `enrollmentId` in a *response header*, but the wizard reads it from the *JSON body* → always `nil` → `push-attestation` rejected with "enrollmentId required". Now `enroll-profile` returns a JSON envelope `{profile(base64), enrollmentId, signed}` (the shipped wizard already handles this shape), and `push-attestation` no longer requires `enrollmentId`.

## How it works now

`enroll-profile` mints one per-device `.mobileconfig`: step-ca root trust anchor + SCEP identity + `com.apple.mdm` (AccessRights=3, SignMessage=true) + a per-serial `com.apple.security.acme` attestation (`Attest=true`). The Mac hardware-attests **on install** — no separate MDM push needed. **Fail-closed**: 503 (with the missing env keys) when the backend isn't configured, never a broken profile.

Chain capture: durable `mdm_attestation_chains` table on the console `/data` volume + an authenticated `POST` ingest that step-ca's attestation webhook calls to forward the captured Apple x5c; `GET` serves it to the agent to staple onto `att.mdaCertChain` → `hardware-attested`.

**No app release needed** for initial enrollment — the shipped 0.9.23 wizard drives this once server + infra are in place.

## Tests
- `mdm-coordinator.server.test.ts` — 9 tests: profile generation (SCEP/MDM/ACME present, no PKCS12), fail-closed config, XML escaping, identity↔MDM UUID binding, push tolerance. Green. (`tsc` clean; the SQLite chain-store path is env-gated and exercised in CI where the better-sqlite3 binding builds.)

## Infra (read-only token → you)
`infra/mdm/RUNBOOK.md` has the ordered Railway/`step` steps I can't run: persist step-ca (with SCEP + the attest webhook **at boot**), persist NanoMDM on Postgres, set the console `COCORE_MDM_*`/`COCORE_NANOMDM_*` env, and a smoke-test sequence. One judgment call flagged: whether your step-ca's webhook surfaces the Apple x5c or needs a tiny poller shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)