### PR TITLE
fix(secure-mode): add ServerCapabilities to MDM payload

### DIFF
--- a/packages/console/src/lib/mdm-coordinator.server.test.ts
+++ b/packages/console/src/lib/mdm-coordinator.server.test.ts
@@ -117,6 +117,8 @@ describe("buildEnrollmentProfile", () => {
     expect(p).toContain("com.apple.mdm");
     expect(p).toContain("<key>AccessRights</key><integer>3</integer>");
     expect(p).toContain("<key>SignMessage</key><true/>");
+    // Newer macOS requires the MDM payload to advertise the user channel.
+    expect(p).toContain("com.apple.mdm.per-user-connections");
     expect(p).toContain("https://mdm.example.test/mdm");
     expect(p).toContain("com.apple.mgmt.External.abc");
 

--- a/packages/console/src/lib/mdm-coordinator.server.ts
+++ b/packages/console/src/lib/mdm-coordinator.server.ts
@@ -305,6 +305,12 @@ function mdmPayload(
       <key>AccessRights</key><integer>3</integer>
       <key>SignMessage</key><true/>
       <key>CheckOutWhenRemoved</key><true/>
+      <!-- Newer macOS rejects an MDM payload that doesn't declare it supports
+           the per-user connection channel ("Profile installation failed: MDM
+           payload is missing ServerCapabilities key..."). NanoMDM serves the
+           user channel, so advertise it. -->
+      <key>ServerCapabilities</key>
+      <array><string>com.apple.mdm.per-user-connections</string></array>
     </dict>`;
 }
 


### PR DESCRIPTION
Newer macOS rejects the enrollment profile: *"MDM payload is missing ServerCapabilities key that indicates it supports a user channel."* Adds `ServerCapabilities=[com.apple.mdm.per-user-connections]` to the `com.apple.mdm` payload (NanoMDM serves the user channel). Unblocks Secure Mode profile install. Test updated; 9/9 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)