### PR TITLE
fix(tray): killStrayAgents reaps only launchd orphans (ppid==1) — 0.9.24

### DIFF
--- a/provider-shell/Sources/CoCoreShell/AgentSupervisor.swift
+++ b/provider-shell/Sources/CoCoreShell/AgentSupervisor.swift
@@ -363,18 +363,30 @@ final class AgentSupervisor {
         }
     }
 
-    /// SIGTERM any `cocore agent serve` process owned by this user that we
-    /// aren't currently tracking. Best-effort and synchronous (it runs
-    /// before a spawn, where a ~half-second wait is acceptable). Uses
-    /// `pgrep`/`kill` rather than `pkill` so we can exclude our own PID and
-    /// log what we reaped.
+    /// SIGTERM any launchd-orphaned `cocore agent serve` process — one whose
+    /// parent is pid 1, i.e. a previous app session's agent that was
+    /// reparented to launchd when its shell quit without reaping it. Scoped
+    /// to ppid==1 deliberately: a worker parented to a LIVE supervisor is
+    /// that supervisor's to manage, never ours to kill. Without the `-P 1`
+    /// scope, two coexisting tray instances (a botched relaunch, or an
+    /// in-place update where the old instance hadn't quit yet) each reaped
+    /// the OTHER's live worker on every pre-spawn pass — the worker
+    /// respawned and ~30s later got reaped again, the "⚠ the agent keeps
+    /// crashing N×" war that hit the confidential nested worker most
+    /// visibly. `pgrep -P 1 -f <pattern>` is AND semantics on macOS, so we
+    /// catch genuine orphans while leaving live supervised workers alone.
+    /// Best-effort and synchronous (it runs before a spawn, where a
+    /// ~half-second wait is acceptable). Uses `pgrep`/`kill` rather than
+    /// `pkill` so we can exclude our own PID and log what we reaped.
     private static func killStrayAgents() {
         let pgrep = Process()
         pgrep.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
         // Match both the default CLI (`cocore agent serve`) and the nested
         // confidential worker (`cocore-provider agent serve`) — a confidential
         // machine runs the latter, and an orphan of either kind must be reaped.
-        pgrep.arguments = ["-f", "cocore(-provider)? agent serve"]
+        // `-P 1` restricts to launchd orphans (ppid==1); a worker parented to
+        // a running supervisor is left alone.
+        pgrep.arguments = ["-P", "1", "-f", "cocore(-provider)? agent serve"]
         let pipe = Pipe()
         pgrep.standardOutput = pipe
         pgrep.standardError = FileHandle.nullDevice
@@ -388,7 +400,7 @@ final class AgentSupervisor {
                 .compactMap { Int32($0.trimmingCharacters(in: .whitespaces)) }
                 .filter { $0 != mine }
             guard !pids.isEmpty else { return }
-            NSLog("cocore: reaping %d stray agent process(es) before spawn: %@",
+            NSLog("cocore: reaping %d orphaned agent process(es) before spawn: %@",
                   pids.count, pids.map(String.init).joined(separator: ","))
             for pid in pids { kill(pid, SIGTERM) }
             // Give them a moment to unwind (their Drop SIGTERMs the Python

--- a/provider-shell/Sources/CoCoreShell/Resources/Info.plist
+++ b/provider-shell/Sources/CoCoreShell/Resources/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleName</key>
 	<string>co/core</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.23</string>
+	<string>0.9.24</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -22,7 +22,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>923</string>
+	<string>924</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/provider/Cargo.lock
+++ b/provider/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "cocore-provider"
-version = "0.9.23"
+version = "0.9.24"
 dependencies = [
  "anyhow",
  "asn1-rs",

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cocore-provider"
-version = "0.9.23"
+version = "0.9.24"
 edition = "2021"
 description = "co/core provider agent: runs hardened compute and publishes signed receipts to AT Protocol."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## 0.9.24 — confidential restart-loop stability fix

Self-contained release. The fix is **one functional line** (`-P 1` on the `pgrep` invocation) plus a doc/log update and the 0.9.23 → 0.9.24 version bump. This is **not** bundled with the in-progress App Attest work.

### The bug
The confidential tier crash-loop ("⚠ the agent keeps crashing N×") is a **two-supervisor war** in the macOS tray. `AgentSupervisor.killStrayAgents()` reaped every `cocore(-provider)? agent serve` process except the app's own PID. So when two `CoCoreShell` (tray) instances are alive at once — a botched relaunch, or an in-place update where the old instance hadn't quit yet — each one's pre-spawn reaper SIGTERMs the *other's* live worker, which respawns, and ~30s later gets reaped again. It hits the confidential nested worker (`cocore-provider`) most visibly.

### The fix
Scope the reaper to genuine **launchd orphans only** by adding `-P 1` to the `pgrep` args (parent pid == 1) — which is exactly what the function's doc comment always claimed it did. `pgrep -P 1 -f <pattern>` is AND semantics on macOS. A worker parented to a live supervisor is now left alone; two live supervisors coexist harmlessly instead of warring. A previous session's launchd-reparented orphan is still caught.

### Why this is trusted (reproduced, not guessed)
Reproduced deterministically on an M1: a stable single-tray baseline (0 shutdowns) churned the worker within ~30s of forcing a second tray via `open -n` (4 graceful shutdowns), and returned to stability when the second tray was killed. Confirmed `pgrep -P 1 -f "cocore-provider agent serve"` returns empty while the supervised worker is alive (it's parented to the tray, not launchd) — so the new reaper leaves live workers alone but still catches a genuine orphan.

Competing theories were disproven against the code: the serve-loop `select!` only logs graceful shutdown on a real external SIGTERM/SIGINT; `stop()`/`stopSynchronously()` set `intentionalStop=true` (no respawn); `spawnChild` guards `process == nil` (no self-kill); `reconcileServeSwitch` reads `active = "serving"` (stops nothing). The only surviving mechanism producing external SIGTERM + auto-respawn is two supervisors reaping each other.

### Version bump (all three required)
- `provider/Cargo.toml`: `0.9.23` → `0.9.24`
- `provider/Cargo.lock`: `cocore-provider` entry → `0.9.24`
- `provider-shell/.../Info.plist`: `CFBundleShortVersionString` `0.9.24`, `CFBundleVersion` `924`

(`build/` Info.plists are regenerated by the build script and intentionally untouched.)

### CI note
`build-mac-arm64` is the real compile check for the Swift change — `static-analysis` (rustfmt + oxfmt + tsc) doesn't build Swift.

### Out of scope (not done here)
Per the handoff, the cut/notarize/publish/tag steps and the advisor cdHash blessing are **not** performed in this cloud environment — this PR is the code + version bump only, ready for review against `main`. The optional single-instance guard for `CoCoreShell` was also left out of 0.9.24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSVg9cB4K9PgsdqsKHm2yx)_