### PR TITLE
secure-mode: hardware-attested on macOS via MDA option-B (key-bound freshness)

### DIFF
--- a/infra/mdm/RUNBOOK.md
+++ b/infra/mdm/RUNBOOK.md
@@ -216,9 +216,11 @@ publishes while the signing key is stable.
 ### Wire-up (code is done; these are the config/ops steps)
 
 1. **NanoMDM → console webhook.** Run NanoMDM with
-   `-webhook-url https://console.cocore.dev/api/agent/mdm/nanomdm-webhook` and set
-   the console env `COCORE_NANOMDM_WEBHOOK_KEY` (a fresh 32+ char secret; NanoMDM
-   presents it as the bearer). The webhook captures the device's
+   `-webhook-url 'https://console.cocore.dev/api/agent/mdm/nanomdm-webhook?key=<SECRET>'`
+   and set the console env `COCORE_NANOMDM_WEBHOOK_KEY=<SECRET>` to the same
+   value (NanoMDM doesn't send an Authorization header, so the secret rides in
+   the URL `?key=`; a Bearer header is also accepted). The webhook captures the
+   device's
    `DevicePropertiesAttestation` result and stores the chain keyed by serial —
    the same store the agent polls.
 2. **Agent env** (set by the Secure Mode wizard / installer next to the existing

--- a/infra/mdm/RUNBOOK.md
+++ b/infra/mdm/RUNBOOK.md
@@ -184,3 +184,83 @@ Watch:
   or do you need the poller shim?).
 - 🔁 **No app release needed** for initial enrollment — the shipped 0.9.23
   wizard drives this once the server + infra are in place.
+
+---
+
+## Option-B: key-bound hardware-attested (DeviceInformation + DeviceAttestationNonce)
+
+The ACME flow above proves *genuine Apple hardware* but its attestation can't
+**bind to the receipt-signing key**: the ACME path attests an OS-managed P-384
+key (not our P-256 signer), and its freshness = `sha256(challenge token)` (step-ca
+chosen). App Attest — which lets an app bind an arbitrary key via clientDataHash —
+is **iOS-only** (`DCAppAttestService.isSupported` is false on macOS, confirmed on
+M1/macOS 26.4.1). So neither earns `hardware-attested` for the P-256 receipt key
+on a Mac.
+
+**The fix (no App Attest, no forked step-ca): MDM `DeviceInformation`
+attestation with a key-bound nonce.** Apple's security guide: for
+DeviceInformation attestation, *the leaf's freshness code = the
+`DeviceAttestationNonce` the MDM sends*. Set
+
+```
+DeviceAttestationNonce = sha256(agent P-256 publicKey)
+```
+
+→ the leaf's freshness OID (1.2.840.113635.100.8.11.1) commits to the signing
+key → the shipped verifiers' option-B check (`freshness == sha256(publicKey)`,
+in mda.rs / verify-provider.ts / verify.py, and AppView verifyReceipt) bind it →
+`hardware-attested`. Apple rate-limits this to **~1 attestation/device/7 days**,
+so it's a weekly re-bind; the captured chain is reused across the 24h attestation
+publishes while the signing key is stable.
+
+### Wire-up (code is done; these are the config/ops steps)
+
+1. **NanoMDM → console webhook.** Run NanoMDM with
+   `-webhook-url https://console.cocore.dev/api/agent/mdm/nanomdm-webhook` and set
+   the console env `COCORE_NANOMDM_WEBHOOK_KEY` (a fresh 32+ char secret; NanoMDM
+   presents it as the bearer). The webhook captures the device's
+   `DevicePropertiesAttestation` result and stores the chain keyed by serial —
+   the same store the agent polls.
+2. **Agent env** (set by the Secure Mode wizard / installer next to the existing
+   chain-URL wiring):
+   ```
+   COCORE_MDA_REQUEST_URL=https://console.cocore.dev/api/agent/mdm/request-attestation
+   COCORE_MDA_DEVICE_SERIAL=<device serial>
+   COCORE_MDA_DEVICE_UDID=<NanoMDM enrollment UDID>
+   COCORE_MDA_CHAIN_URL=https://console.cocore.dev/api/agent/mdm/attestation-chain?serial=<serial>
+   COCORE_API_KEY=<agent bearer>            # already set
+   ```
+   On serve the agent POSTs its pubkey to `request-attestation` (best-effort,
+   weekly), then polls `attestation-chain` as today.
+3. **Flow:** agent → `request-attestation {serial, udid, publicKey}` → coordinator
+   enqueues a `DeviceInformation` command (Queries: `DevicePropertiesAttestation`,
+   `DeviceAttestationNonce = sha256(pubkey)`) via NanoMDM → device returns the
+   Apple x5c → NanoMDM webhook → stored by serial → agent reads it →
+   `attestation::build` binds via freshness (option B) → `hardware-attested`.
+
+### ⚠️ Confirm the freshness bytes on the FIRST live capture
+
+We carry the nonce as a base64 `<string>` and the verifiers expect the freshness
+OID to contain the raw 32 bytes of `sha256(pubkey)`. Apple's exact storage of the
+nonce→freshness bytes is the one unconfirmed detail. On the first captured leaf:
+
+```sh
+# leaf.pem = the captured Apple attestation leaf; pubkey = `cocore agent pubkey`
+scripts/inspect-mda-freshness.sh leaf.pem "$(cocore agent pubkey)"
+```
+
+- **MATCH** → done, the shipped verifiers accept it as-is.
+- **NO MATCH** → the script prints the actual freshness bytes vs `sha256(pubkey)`;
+  adjust the single freshness normalizer (`provider/src/mda.rs::freshness_binds`,
+  mirrored in `packages/sdk/src/verify-provider.ts::freshnessBindsKey` and
+  `sdk/py/cocore/verify.py::_freshness_binds_key`) to fit, and re-run the
+  cross-language fixtures.
+
+### Division of labour (option-B)
+
+- ✅ **Code (this branch):** `request-attestation` + `nanomdm-webhook` endpoints,
+  the DeviceInformation command builder + nonce + webhook result parser
+  (unit-tested), the agent's `request_attestation` trigger, the freshness-binding
+  verifiers (all 4), and `inspect-mda-freshness.sh`.
+- ⏳ **Infra/ops (you):** NanoMDM `-webhook-url` + `COCORE_NANOMDM_WEBHOOK_KEY`,
+  the agent env wiring, and the one-capture freshness-bytes confirmation above.

--- a/infra/mdm/RUNBOOK.md
+++ b/infra/mdm/RUNBOOK.md
@@ -74,7 +74,7 @@ call (secrets stay on your machine + the dashboard).
 
    ```sh
    STEPPATH=~/cocore-mdm/stepca-client step ca provisioner webhook add cocore-attest \
-     cocore-chain --url https://console.cocore.dev/api/agent/mdm/attestation-chain \
+     cocore-chain --url https://cocore.dev/api/agent/mdm/attestation-chain \
      --kind ENRICHING \
      --bearer-token "$COCORE_MDM_CHAIN_INGEST_KEY"
    ```
@@ -139,7 +139,7 @@ Redeploy the console. (The `/data` volume already backs the new
 **4a. Coordinator is live (not 503).** With any valid agent API key:
 
 ```sh
-curl -s -X POST https://console.cocore.dev/api/agent/mdm/enroll-profile \
+curl -s -X POST https://cocore.dev/api/agent/mdm/enroll-profile \
   -H "Authorization: Bearer $COCORE_API_KEY" -H 'content-type: application/json' \
   -d '{"serial":"H2WHW38LQ6NV","udid":"00008103-001869192E20801E"}' | jq '{enrollmentId, signed, len: (.profile|length)}'
 ```
@@ -153,7 +153,7 @@ from step 3 is unset.
 **4b. push-attestation no longer 400s:**
 
 ```sh
-curl -s -X POST https://console.cocore.dev/api/agent/mdm/push-attestation \
+curl -s -X POST https://cocore.dev/api/agent/mdm/push-attestation \
   -H "Authorization: Bearer $COCORE_API_KEY" -H 'content-type: application/json' \
   -d '{"serial":"H2WHW38LQ6NV"}' | jq .   # → {queued:true, status:"bundled"}
 ```
@@ -189,7 +189,7 @@ Watch:
 
 ## Option-B: key-bound hardware-attested (DeviceInformation + DeviceAttestationNonce)
 
-The ACME flow above proves *genuine Apple hardware* but its attestation can't
+The ACME flow above proves _genuine Apple hardware_ but its attestation can't
 **bind to the receipt-signing key**: the ACME path attests an OS-managed P-384
 key (not our P-256 signer), and its freshness = `sha256(challenge token)` (step-ca
 chosen). App Attest — which lets an app bind an arbitrary key via clientDataHash —
@@ -199,8 +199,8 @@ on a Mac.
 
 **The fix (no App Attest, no forked step-ca): MDM `DeviceInformation`
 attestation with a key-bound nonce.** Apple's security guide: for
-DeviceInformation attestation, *the leaf's freshness code = the
-`DeviceAttestationNonce` the MDM sends*. Set
+DeviceInformation attestation, _the leaf's freshness code = the
+`DeviceAttestationNonce` the MDM sends_. Set
 
 ```
 DeviceAttestationNonce = sha256(agent P-256 publicKey)
@@ -216,7 +216,7 @@ publishes while the signing key is stable.
 ### Wire-up (code is done; these are the config/ops steps)
 
 1. **NanoMDM → console webhook.** Run NanoMDM with
-   `-webhook-url 'https://console.cocore.dev/api/agent/mdm/nanomdm-webhook?key=<SECRET>'`
+   `-webhook-url 'https://cocore.dev/api/agent/mdm/nanomdm-webhook?key=<SECRET>'`
    and set the console env `COCORE_NANOMDM_WEBHOOK_KEY=<SECRET>` to the same
    value (NanoMDM doesn't send an Authorization header, so the secret rides in
    the URL `?key=`; a Bearer header is also accepted). The webhook captures the
@@ -226,10 +226,10 @@ publishes while the signing key is stable.
 2. **Agent env** (set by the Secure Mode wizard / installer next to the existing
    chain-URL wiring):
    ```
-   COCORE_MDA_REQUEST_URL=https://console.cocore.dev/api/agent/mdm/request-attestation
+   COCORE_MDA_REQUEST_URL=https://cocore.dev/api/agent/mdm/request-attestation
    COCORE_MDA_DEVICE_SERIAL=<device serial>
    COCORE_MDA_DEVICE_UDID=<NanoMDM enrollment UDID>
-   COCORE_MDA_CHAIN_URL=https://console.cocore.dev/api/agent/mdm/attestation-chain?serial=<serial>
+   COCORE_MDA_CHAIN_URL=https://cocore.dev/api/agent/mdm/attestation-chain?serial=<serial>
    COCORE_API_KEY=<agent bearer>            # already set
    ```
    On serve the agent POSTs its pubkey to `request-attestation` (best-effort,

--- a/lexicons/dev/cocore/compute/attestation.json
+++ b/lexicons/dev/cocore/compute/attestation.json
@@ -114,7 +114,24 @@
             "type": "array",
             "items": { "type": "bytes", "maxLength": 8192 },
             "maxLength": 8,
-            "description": "Optional Apple Managed Device Attestation certificate chain (DER), leaf first. Present when trustLevel is 'hardware-attested'. Verifiers MUST: (1) verify every adjacent link to the embedded Apple Enterprise Attestation Root CA, enforcing BasicConstraints (non-leaf certs are CAs, the leaf is an end-entity); and (2) require the leaf's P-256 public key to EQUAL this record's `publicKey` — i.e. the chain is BOUND to the receipt-signing key. Without (2) a valid Apple chain for one device could be stapled onto an unrelated signing key, so a chain that verifies but isn't bound MUST NOT earn 'hardware-attested'. Producers (the MDA provisioning tool) MUST therefore attest the signing key itself."
+            "description": "Optional Apple Managed Device Attestation certificate chain (DER), leaf first. One of two paths to trustLevel 'hardware-attested' (the other is `appAttest`). Verifiers MUST: (1) verify every adjacent link to the embedded Apple Enterprise Attestation Root CA, enforcing BasicConstraints (non-leaf certs are CAs, the leaf is an end-entity); and (2) BIND the chain to this record's `publicKey` by EITHER the leaf's P-256 public key EQUALLING `publicKey`, OR the Apple freshness extension (OID 1.2.840.113635.100.8.11.1) committing to it as `freshnessCode == sha256(publicKey)`. Without a binding a valid Apple chain for one device could be stapled onto an unrelated signing key, so a chain that verifies but isn't bound MUST NOT earn 'hardware-attested'."
+          },
+          "appAttest": {
+            "type": "object",
+            "description": "Optional Apple App Attest evidence — the second, MDM-free path to trustLevel 'hardware-attested'. The provider's signed helper calls DCAppAttestService with `clientDataHash = sha256(publicKey)` (this record's receipt-signing key), so Apple's attestation commits to the signing key by construction. Verifiers MUST, offline: (1) CBOR-decode `object`, requiring fmt 'apple-appattest'; (2) verify the attStmt x5c chain to the embedded Apple App Attest Root CA; (3) recompute `nonce = sha256(authData || sha256(publicKey))` and require it to equal the credential certificate's nonce extension (OID 1.2.840.113635.100.8.2) — THIS is the binding to the signing key; (4) check authData's rpIdHash == sha256(App ID 'TEAMID.dev.cocore.provider'), the AAGUID is the genuine-hardware appattest value, and credentialId == sha256(attested public key) == `keyId`. A bound, valid App Attest object earns 'hardware-attested' exactly as a bound mdaCertChain does. It proves genuine, un-tampered Apple hardware holds a Secure-Enclave key bound to the signing key; it does NOT by itself prove the signing key is SE-resident nor that the running binary is honest (those are carried by the SE-backed signing identity + hardened-runtime + cdHash known-good gate, same self-measurement ceiling as the MDA path).",
+            "required": ["object", "keyId"],
+            "properties": {
+              "object": {
+                "type": "bytes",
+                "maxLength": 16384,
+                "description": "The CBOR App Attest attestation object returned by DCAppAttestService.attestKey, as produced for `clientDataHash = sha256(publicKey)`. Contains fmt, attStmt (x5c + receipt), and authData."
+              },
+              "keyId": {
+                "type": "bytes",
+                "maxLength": 64,
+                "description": "The App Attest key identifier (the SHA-256 of the attested public key) DCAppAttestService.generateKey returned. Verifiers cross-check this equals the credentialId in authData."
+              }
+            }
           },
           "selfSignature": {
             "type": "bytes",

--- a/packages/appview/src/api/read-router.ts
+++ b/packages/appview/src/api/read-router.ts
@@ -333,13 +333,17 @@ export function buildReadRouter(store: Store): HttpRouter.HttpRouter<never, neve
         const aa = att.appAttest;
         let appAttestBound = false;
         if (aa && aa.object && aa.keyId) {
-          appAttestBound = verifyAppAttestB64(aa.object, aa.keyId, att.publicKey, APP_ATTEST_APP_ID);
+          appAttestBound = verifyAppAttestB64(
+            aa.object,
+            aa.keyId,
+            att.publicKey,
+            APP_ATTEST_APP_ID,
+          );
           if (!appAttestBound) {
             findings.push({
               severity: "error",
               code: "appattest-not-bound",
-              message:
-                "App Attest object did not verify or is not bound to attestation.publicKey",
+              message: "App Attest object did not verify or is not bound to attestation.publicKey",
             });
           }
         }

--- a/packages/appview/src/api/read-router.ts
+++ b/packages/appview/src/api/read-router.ts
@@ -15,6 +15,8 @@ import { HttpRouter } from "@effect/platform";
 import { Effect } from "effect";
 
 import { MdaError, verifyChain } from "@cocore/sdk/mda";
+import { verifyAppAttestB64, APP_ATTEST_APP_ID } from "@cocore/sdk/appattest";
+import { freshnessBindsKey } from "@cocore/sdk/verify-provider";
 import { verifyReceiptSignature } from "@cocore/sdk/p256";
 import { ids, lexicons } from "@cocore/sdk/lex";
 import type {
@@ -324,7 +326,27 @@ export function buildReadRouter(store: Store): HttpRouter.HttpRouter<never, neve
           });
         }
         let trustLevel: "self-attested" | "hardware-attested" = "self-attested";
-        if (att.mdaCertChain && att.mdaCertChain.length > 0) {
+
+        // Hardware attestation via App Attest (the MDM-free path): present AND
+        // bound to attestation.publicKey by construction (clientDataHash =
+        // sha256(publicKey), checked through the credCert nonce extension).
+        const aa = att.appAttest;
+        let appAttestBound = false;
+        if (aa && aa.object && aa.keyId) {
+          appAttestBound = verifyAppAttestB64(aa.object, aa.keyId, att.publicKey, APP_ATTEST_APP_ID);
+          if (!appAttestBound) {
+            findings.push({
+              severity: "error",
+              code: "appattest-not-bound",
+              message:
+                "App Attest object did not verify or is not bound to attestation.publicKey",
+            });
+          }
+        }
+
+        if (appAttestBound) {
+          trustLevel = "hardware-attested";
+        } else if (att.mdaCertChain && att.mdaCertChain.length > 0) {
           try {
             const chain = att.mdaCertChain.map((b64: string) =>
               Uint8Array.from(Buffer.from(b64, "base64")),
@@ -336,16 +358,27 @@ export function buildReadRouter(store: Store): HttpRouter.HttpRouter<never, neve
                 code: "mda-invalid",
                 message: mda.error ?? "MDA chain validation failed",
               });
-            } else if (mda.leafPublicKey !== att.publicKey) {
-              findings.push({
-                severity: "error",
-                code: "mda-not-bound",
-                message:
-                  "MDA leaf does not certify attestation.publicKey " +
-                  "(chain not bound to the receipt-signing key)",
-              });
             } else {
-              trustLevel = "hardware-attested";
+              // Bind by EITHER the leaf key being the signing key (option A) OR
+              // the freshness-code commitment sha256(publicKey) (option B) —
+              // matching the SDK verifier (verify-provider.ts) and mda.rs.
+              // Previously only option A was checked, so an option-B (freshness)
+              // chain was wrongly reported self-attested here.
+              const leafBinds = mda.leafPublicKey === att.publicKey;
+              const freshBinds = yield* Effect.promise(() =>
+                freshnessBindsKey(mda.freshnessCode, att.publicKey),
+              );
+              if (!leafBinds && !freshBinds) {
+                findings.push({
+                  severity: "error",
+                  code: "mda-not-bound",
+                  message:
+                    "MDA chain is not bound to attestation.publicKey " +
+                    "(neither leaf-key nor freshness-code binding holds)",
+                });
+              } else {
+                trustLevel = "hardware-attested";
+              }
             }
           } catch (e) {
             const code = e instanceof MdaError ? `mda-${e.code}` : "mda-error";
@@ -357,6 +390,7 @@ export function buildReadRouter(store: Store): HttpRouter.HttpRouter<never, neve
             structural.ok &&
             sigOk &&
             !findings.some((f) => f.code.startsWith("mda-")) &&
+            !findings.some((f) => f.code.startsWith("appattest-")) &&
             !findings.some((f) => f.code === "lexicon-invalid"),
           trustLevel,
           findings,

--- a/packages/console/src/lib/mdm-coordinator.server.test.ts
+++ b/packages/console/src/lib/mdm-coordinator.server.test.ts
@@ -10,6 +10,7 @@ import { createHash } from "node:crypto";
 import {
   attestationIsBundled,
   attestationNonceBytes,
+  authenticateNanomdmWebhook,
   buildDeviceInformationAttestationCommand,
   buildEnrollmentProfile,
   isValidSerial,
@@ -248,5 +249,45 @@ describe("option-B DeviceInformation attestation (freshness binding)", () => {
     expect(parseNanomdmAttestationWebhook({ topic: "mdm.TokenUpdate", serial: "H2WHW38LQ6NV" })).toBeNull();
     expect(parseNanomdmAttestationWebhook(null)).toBeNull();
     expect(parseNanomdmAttestationWebhook("nope")).toBeNull();
+  });
+
+  it("parses a NanoMDM acknowledge_event.raw_payload (the live webhook shape)", () => {
+    const responsePlist = `<?xml version="1.0"?>
+<plist version="1.0"><dict>
+  <key>SerialNumber</key><string>H2WHW38LQ6NV</string>
+  <key>QueryResponses</key><dict>
+    <key>DevicePropertiesAttestation</key>
+    <array><data>bGVhZg==</data><data>aW50ZXI=</data></array>
+  </dict>
+</dict></plist>`;
+    const payload = {
+      topic: "mdm.Connect",
+      acknowledge_event: {
+        udid: "00008103-001869192E20801E",
+        status: "Acknowledged",
+        raw_payload: Buffer.from(responsePlist, "utf8").toString("base64"),
+      },
+    };
+    const parsed = parseNanomdmAttestationWebhook(payload);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.serial).toBe("H2WHW38LQ6NV");
+    expect(parsed!.chain).toEqual(["bGVhZg==", "aW50ZXI="]);
+  });
+
+  it("authenticateNanomdmWebhook accepts the ?key= URL secret and a bearer; rejects wrong/unset", () => {
+    process.env["COCORE_NANOMDM_WEBHOOK_KEY"] = "s3cr3t-webhook-key-value";
+    const viaQuery = new Request("https://c.test/api/agent/mdm/nanomdm-webhook?key=s3cr3t-webhook-key-value", {
+      method: "POST",
+    });
+    const viaBearer = new Request("https://c.test/api/agent/mdm/nanomdm-webhook", {
+      method: "POST",
+      headers: { authorization: "Bearer s3cr3t-webhook-key-value" },
+    });
+    const wrong = new Request("https://c.test/api/agent/mdm/nanomdm-webhook?key=nope", { method: "POST" });
+    expect(authenticateNanomdmWebhook(viaQuery)).toBe(true);
+    expect(authenticateNanomdmWebhook(viaBearer)).toBe(true);
+    expect(authenticateNanomdmWebhook(wrong)).toBe(false);
+    delete process.env["COCORE_NANOMDM_WEBHOOK_KEY"];
+    expect(authenticateNanomdmWebhook(viaQuery)).toBe(false); // fail-closed when unset
   });
 });

--- a/packages/console/src/lib/mdm-coordinator.server.test.ts
+++ b/packages/console/src/lib/mdm-coordinator.server.test.ts
@@ -5,13 +5,18 @@
 // so they run without the better-sqlite3 native binding.
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createHash } from "node:crypto";
 
 import {
   attestationIsBundled,
+  attestationNonceBytes,
+  buildDeviceInformationAttestationCommand,
   buildEnrollmentProfile,
   isValidSerial,
   isValidUdid,
+  parseNanomdmAttestationWebhook,
   pushAttestationCommand,
+  requestDeviceInformationAttestation,
   secureMdmConfig,
 } from "./mdm-coordinator.server.ts";
 
@@ -172,5 +177,76 @@ describe("pushAttestationCommand — tolerance (no 400 for the shipped wizard)",
     expect(r.queued).toBe(true);
     expect(r.stubbed).toBe(true);
     expect(r.status).toBe("queued");
+  });
+});
+
+describe("option-B DeviceInformation attestation (freshness binding)", () => {
+  // A representative raw 64-byte P-256 X‖Y public key (base64).
+  const PUBKEY_B64 = Buffer.alloc(64, 7).toString("base64");
+
+  it("nonce is sha256 of the raw pubkey bytes (32 bytes)", () => {
+    const nonce = attestationNonceBytes(PUBKEY_B64);
+    expect(nonce.length).toBe(32);
+    const expected = createHash("sha256").update(Buffer.from(PUBKEY_B64, "base64")).digest();
+    expect(nonce.equals(expected)).toBe(true);
+  });
+
+  it("builds a DeviceInformation command carrying DevicePropertiesAttestation + the nonce", () => {
+    const nonce = attestationNonceBytes(PUBKEY_B64);
+    const cmd = buildDeviceInformationAttestationCommand("ABCDEF01-2345-6789-ABCD-EF0123456789", nonce);
+    expect(cmd).toContain("<string>DeviceInformation</string>");
+    expect(cmd).toContain("<string>DevicePropertiesAttestation</string>");
+    expect(cmd).toContain("<key>DeviceAttestationNonce</key>");
+    // The nonce rides as base64 in the command.
+    expect(cmd).toContain(nonce.toString("base64"));
+  });
+
+  it("requestDeviceInformationAttestation errors without an MDM target", async () => {
+    const r = await requestDeviceInformationAttestation("H2WHW38LQ6NV", null, PUBKEY_B64);
+    expect(r.status).toBe("error");
+    expect(r.queued).toBe(false);
+  });
+
+  it("requestDeviceInformationAttestation stubs when NanoMDM is unconfigured", async () => {
+    delete process.env["COCORE_NANOMDM_URL"];
+    delete process.env["COCORE_NANOMDM_API_KEY"];
+    const r = await requestDeviceInformationAttestation(
+      "H2WHW38LQ6NV",
+      "A1B2C3D4-1111-2222-3333-444455556666",
+      PUBKEY_B64,
+    );
+    expect(r.stubbed).toBe(true);
+    expect(r.status).toBe("queued");
+  });
+
+  it("parses a NanoMDM webhook carrying a DevicePropertiesAttestation chain", () => {
+    // The device's DeviceInformation response plist (leaf-first base64 DER certs).
+    const responsePlist = `<?xml version="1.0"?>
+<plist version="1.0"><dict>
+  <key>Status</key><string>Acknowledged</string>
+  <key>SerialNumber</key><string>H2WHW38LQ6NV</string>
+  <key>QueryResponses</key><dict>
+    <key>DevicePropertiesAttestation</key>
+    <array>
+      <data>bGVhZi1kZXItYnl0ZXM=</data>
+      <data>aW50ZXJtZWRpYXRlLWRlcg==</data>
+    </array>
+  </dict>
+</dict></plist>`;
+    const payload = {
+      topic: "mdm.Connect",
+      serial: "H2WHW38LQ6NV",
+      raw_command_response: Buffer.from(responsePlist, "utf8").toString("base64"),
+    };
+    const parsed = parseNanomdmAttestationWebhook(payload);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.serial).toBe("H2WHW38LQ6NV");
+    expect(parsed!.chain).toEqual(["bGVhZi1kZXItYnl0ZXM=", "aW50ZXJtZWRpYXRlLWRlcg=="]);
+  });
+
+  it("returns null for a webhook with no attestation (e.g. a TokenUpdate)", () => {
+    expect(parseNanomdmAttestationWebhook({ topic: "mdm.TokenUpdate", serial: "H2WHW38LQ6NV" })).toBeNull();
+    expect(parseNanomdmAttestationWebhook(null)).toBeNull();
+    expect(parseNanomdmAttestationWebhook("nope")).toBeNull();
   });
 });

--- a/packages/console/src/lib/mdm-coordinator.server.test.ts
+++ b/packages/console/src/lib/mdm-coordinator.server.test.ts
@@ -194,7 +194,10 @@ describe("option-B DeviceInformation attestation (freshness binding)", () => {
 
   it("builds a DeviceInformation command carrying DevicePropertiesAttestation + the nonce", () => {
     const nonce = attestationNonceBytes(PUBKEY_B64);
-    const cmd = buildDeviceInformationAttestationCommand("ABCDEF01-2345-6789-ABCD-EF0123456789", nonce);
+    const cmd = buildDeviceInformationAttestationCommand(
+      "ABCDEF01-2345-6789-ABCD-EF0123456789",
+      nonce,
+    );
     expect(cmd).toContain("<string>DeviceInformation</string>");
     expect(cmd).toContain("<string>DevicePropertiesAttestation</string>");
     expect(cmd).toContain("<key>DeviceAttestationNonce</key>");
@@ -246,7 +249,9 @@ describe("option-B DeviceInformation attestation (freshness binding)", () => {
   });
 
   it("returns null for a webhook with no attestation (e.g. a TokenUpdate)", () => {
-    expect(parseNanomdmAttestationWebhook({ topic: "mdm.TokenUpdate", serial: "H2WHW38LQ6NV" })).toBeNull();
+    expect(
+      parseNanomdmAttestationWebhook({ topic: "mdm.TokenUpdate", serial: "H2WHW38LQ6NV" }),
+    ).toBeNull();
     expect(parseNanomdmAttestationWebhook(null)).toBeNull();
     expect(parseNanomdmAttestationWebhook("nope")).toBeNull();
   });
@@ -276,14 +281,19 @@ describe("option-B DeviceInformation attestation (freshness binding)", () => {
 
   it("authenticateNanomdmWebhook accepts the ?key= URL secret and a bearer; rejects wrong/unset", () => {
     process.env["COCORE_NANOMDM_WEBHOOK_KEY"] = "s3cr3t-webhook-key-value";
-    const viaQuery = new Request("https://c.test/api/agent/mdm/nanomdm-webhook?key=s3cr3t-webhook-key-value", {
-      method: "POST",
-    });
+    const viaQuery = new Request(
+      "https://c.test/api/agent/mdm/nanomdm-webhook?key=s3cr3t-webhook-key-value",
+      {
+        method: "POST",
+      },
+    );
     const viaBearer = new Request("https://c.test/api/agent/mdm/nanomdm-webhook", {
       method: "POST",
       headers: { authorization: "Bearer s3cr3t-webhook-key-value" },
     });
-    const wrong = new Request("https://c.test/api/agent/mdm/nanomdm-webhook?key=nope", { method: "POST" });
+    const wrong = new Request("https://c.test/api/agent/mdm/nanomdm-webhook?key=nope", {
+      method: "POST",
+    });
     expect(authenticateNanomdmWebhook(viaQuery)).toBe(true);
     expect(authenticateNanomdmWebhook(viaBearer)).toBe(true);
     expect(authenticateNanomdmWebhook(wrong)).toBe(false);

--- a/packages/console/src/lib/mdm-coordinator.server.ts
+++ b/packages/console/src/lib/mdm-coordinator.server.ts
@@ -793,12 +793,24 @@ export async function requestDeviceInformationAttestation(
   }
 }
 
-/** Authenticate a NanoMDM webhook POST (the device's command results). Bearer
- *  COCORE_NANOMDM_WEBHOOK_KEY, constant-time, fail-closed when unset. */
+/** Authenticate a NanoMDM webhook POST (the device's command results).
+ *
+ *  Secret = COCORE_NANOMDM_WEBHOOK_KEY, constant-time, fail-closed when unset.
+ *  NanoMDM's `-webhook-url` does NOT send an Authorization header, so the
+ *  operator embeds the secret in the URL as `?key=<secret>` — that's the
+ *  primary check. A Bearer header is also accepted (e.g. for manual posts /
+ *  a future webhook proxy that adds one). */
 export function authenticateNanomdmWebhook(request: Request): boolean {
   const expected = env("COCORE_NANOMDM_WEBHOOK_KEY");
   if (!expected) return false;
-  const got = readBearer(request);
+  const fromQuery = (() => {
+    try {
+      return new URL(request.url).searchParams.get("key");
+    } catch {
+      return null;
+    }
+  })();
+  const got = fromQuery ?? readBearer(request);
   if (!got || got.length !== expected.length) return false;
   let diff = 0;
   for (let i = 0; i < expected.length; i++) diff |= got.charCodeAt(i) ^ expected.charCodeAt(i);

--- a/packages/console/src/lib/mdm-coordinator.server.ts
+++ b/packages/console/src/lib/mdm-coordinator.server.ts
@@ -57,6 +57,8 @@
 //                              webhook presents to POST captured chains.
 //   COCORE_MDM_SIGNING_CERT_PEM / _KEY_PEM  CMS-sign the profile (TODO).
 
+import { createHash } from "node:crypto";
+
 import { resolveBearerKey, type ResolvedKey } from "@/lib/api-keys.server.ts";
 import { getAttestationChain, putAttestationChain } from "@/lib/mdm-chain-store.server.ts";
 
@@ -638,4 +640,240 @@ export async function fetchAttestationChain(serial: string): Promise<Attestation
       detail: `chain store request error: ${(e as Error).message}`,
     };
   }
+}
+
+// ---------------------------------------------------------------------------
+// Option-B (freshness-code) hardware attestation via MDM DeviceInformation.
+//
+// The ACME path above attests an OS-managed P-384 key whose leaf can't bind to
+// the agent's P-256 receipt key (see the option-A analysis in
+// infra/mdm/RUNBOOK.md). The DeviceInformation path lets US choose the
+// attestation's freshness: Apple sets the leaf's freshness OID
+// (1.2.840.113635.100.8.11.1) to the `DeviceAttestationNonce` the MDM sends
+// (Apple security guide: "the freshness code is the value of the
+// DeviceAttestationNonce specified in the request"). Setting
+//
+//     DeviceAttestationNonce = sha256(agent P-256 pubkey)
+//
+// makes the freshness commit to the receipt-signing key — exactly the option-B
+// binding the verifiers (mda.rs `freshness_binds`, verify-provider
+// `freshnessBindsKey`, py `_freshness_binds_key`) already check. No App Attest,
+// no forked step-ca.
+//
+// Apple rate-limits DeviceInformation attestation to ~1 per device / 7 days, so
+// this is a weekly (re)bind, not per-refresh; the captured chain is reused
+// across the 24h attestation publishes while the signing key is stable.
+//
+// ⚠️ ENCODING TO CONFIRM ON FIRST LIVE CAPTURE: we carry the 32-byte nonce as a
+// base64 <string> (the MDM-compatible form). The verifier expects the freshness
+// OID to contain the raw 32 bytes of sha256(pubkey). If Apple stores the nonce
+// string verbatim (rather than its decoded bytes), the freshness normalizer is
+// the single one-line place to adjust — use scripts/inspect-mda-freshness.sh on
+// the first captured leaf to confirm. See infra/mdm/RUNBOOK.md "Option-B".
+// ---------------------------------------------------------------------------
+
+/** The `DeviceAttestationNonce` that binds an attestation to `publicKeyB64`
+ *  (the agent's raw 64-byte P-256 X‖Y key, base64). The bytes are
+ *  `sha256(pubkey)` — what the leaf's freshness OID must equal for the
+ *  verifiers' `freshness == sha256(publicKey)` check to hold. */
+export function attestationNonceBytes(publicKeyB64: string): Buffer {
+  const raw = Buffer.from(publicKeyB64, "base64");
+  return createHash("sha256").update(raw).digest(); // 32 bytes
+}
+
+/** Build the MDM `DeviceInformation` command that requests a fresh hardware
+ *  attestation bound to `nonceBytes`. `Queries: [DevicePropertiesAttestation]`
+ *  asks for the attestation; `DeviceAttestationNonce` forces a fresh one whose
+ *  freshness OID equals the nonce. */
+export function buildDeviceInformationAttestationCommand(
+  commandUuid: string,
+  nonceBytes: Buffer,
+): string {
+  const nonceB64 = nonceBytes.toString("base64");
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CommandUUID</key>
+  <string>${commandUuid}</string>
+  <key>Command</key>
+  <dict>
+    <key>RequestType</key>
+    <string>DeviceInformation</string>
+    <key>Queries</key>
+    <array>
+      <string>DevicePropertiesAttestation</string>
+    </array>
+    <key>DeviceAttestationNonce</key>
+    <string>${nonceB64}</string>
+  </dict>
+</dict>
+</plist>
+`;
+}
+
+/** Enqueue + push a DeviceInformation attestation command, binding the
+ *  resulting Apple attestation to `publicKeyB64` via the nonce. `target` is the
+ *  device's NanoMDM enrollment id (UDID). Mirrors `pushAttestationCommand`. */
+export async function requestDeviceInformationAttestation(
+  serial: string,
+  target: string | null,
+  publicKeyB64: string,
+): Promise<PushAttestationResult> {
+  const base = env("COCORE_NANOMDM_URL");
+  const apiKey = env("COCORE_NANOMDM_API_KEY");
+
+  if (!target) {
+    return {
+      queued: false,
+      commandUuid: null,
+      status: "error",
+      stubbed: true,
+      detail: "DeviceInformation attestation requires an MDM target (device UDID)",
+    };
+  }
+  if (!base || !apiKey) {
+    return {
+      queued: true,
+      commandUuid: null,
+      status: "queued",
+      stubbed: true,
+      detail: "NanoMDM not configured (COCORE_NANOMDM_URL/API_KEY unset); enqueue stubbed",
+    };
+  }
+
+  const root = base.replace(/\/$/, "");
+  const authHeader = `Basic ${Buffer.from(`nanomdm:${apiKey}`).toString("base64")}`;
+  const enc = encodeURIComponent(target);
+  const commandUuid = crypto.randomUUID().toUpperCase();
+  const enqueueBody = buildDeviceInformationAttestationCommand(
+    commandUuid,
+    attestationNonceBytes(publicKeyB64),
+  );
+
+  try {
+    const enqueueResp = await fetch(`${root}/v1/enqueue/${enc}`, {
+      method: "POST",
+      headers: { authorization: authHeader, "content-type": "application/xml" },
+      body: enqueueBody,
+    });
+    if (!enqueueResp.ok) {
+      const text = await enqueueResp.text().catch(() => "");
+      return {
+        queued: false,
+        commandUuid,
+        status: "error",
+        stubbed: false,
+        detail: `NanoMDM enqueue failed (${enqueueResp.status}): ${text.slice(0, 200)}`,
+      };
+    }
+    const pushResp = await fetch(`${root}/v1/push/${enc}`, {
+      method: "GET",
+      headers: { authorization: authHeader },
+    });
+    if (!pushResp.ok) {
+      const text = await pushResp.text().catch(() => "");
+      return {
+        queued: true,
+        commandUuid,
+        status: "queued-no-push",
+        stubbed: false,
+        detail: `enqueued but push failed (${pushResp.status}): ${text.slice(0, 200)}`,
+      };
+    }
+    return { queued: true, commandUuid, status: "queued", stubbed: false, detail: null };
+  } catch (e) {
+    return {
+      queued: false,
+      commandUuid,
+      status: "error",
+      stubbed: false,
+      detail: `NanoMDM request error: ${(e as Error).message}`,
+    };
+  }
+}
+
+/** Authenticate a NanoMDM webhook POST (the device's command results). Bearer
+ *  COCORE_NANOMDM_WEBHOOK_KEY, constant-time, fail-closed when unset. */
+export function authenticateNanomdmWebhook(request: Request): boolean {
+  const expected = env("COCORE_NANOMDM_WEBHOOK_KEY");
+  if (!expected) return false;
+  const got = readBearer(request);
+  if (!got || got.length !== expected.length) return false;
+  let diff = 0;
+  for (let i = 0; i < expected.length; i++) diff |= got.charCodeAt(i) ^ expected.charCodeAt(i);
+  return diff === 0;
+}
+
+/** Parse a NanoMDM webhook payload for a DeviceInformation attestation result.
+ *
+ *  NanoMDM posts MDM events as JSON; a command-result event carries the
+ *  device's raw response plist (base64) under `command_results` / `raw_command`
+ *  (field names vary by NanoMDM webhook version, so we scan defensively). The
+ *  device's DeviceInformation response contains a `DevicePropertiesAttestation`
+ *  array of base64-DER certs (leaf-first) — the Apple x5c chain we persist.
+ *
+ *  Returns `{ serial, chain }` when an attestation chain is present, else null.
+ *  Pure (no I/O) so it's unit-tested against a sample payload; the exact NanoMDM
+ *  field layout is confirmed on first live capture (see RUNBOOK "Option-B"). */
+export function parseNanomdmAttestationWebhook(
+  payload: unknown,
+): { serial: string | null; chain: string[] } | null {
+  if (!payload || typeof payload !== "object") return null;
+  const obj = payload as Record<string, unknown>;
+
+  // Pull a candidate raw command-result plist (base64 or inline XML) from the
+  // common NanoMDM webhook shapes.
+  const rawCandidates: string[] = [];
+  const pushStr = (v: unknown) => {
+    if (typeof v === "string" && v.length > 0) rawCandidates.push(v);
+  };
+  pushStr(obj["raw_command_response"]);
+  pushStr(obj["command_response"]);
+  if (obj["command_results"] && typeof obj["command_results"] === "object") {
+    const cr = obj["command_results"] as Record<string, unknown>;
+    pushStr(cr["raw"]);
+    pushStr(cr["payload"]);
+  }
+  // Some webhook configs nest the device plist under `checkin`/`acknowledge`.
+  pushStr((obj["acknowledge_event"] as Record<string, unknown> | undefined)?.["raw_payload"] as unknown);
+
+  const serial = typeof obj["serial"] === "string" ? (obj["serial"] as string) : null;
+
+  for (const raw of rawCandidates) {
+    // raw may be base64 of a plist, or a plist string directly.
+    let xml = raw;
+    if (!/[<]plist/i.test(raw)) {
+      try {
+        xml = Buffer.from(raw, "base64").toString("utf8");
+      } catch {
+        continue;
+      }
+    }
+    const chain = extractDevicePropertiesAttestation(xml);
+    if (chain && chain.length > 0) {
+      return { serial: serial ?? extractSerialFromPlist(xml), chain };
+    }
+  }
+  return null;
+}
+
+/** Extract the `DevicePropertiesAttestation` cert array (base64 DER, leaf-first)
+ *  from a device's DeviceInformation response plist. Minimal, dependency-free:
+ *  finds the keyed <array> of <data> entries. */
+function extractDevicePropertiesAttestation(plistXml: string): string[] | null {
+  const keyIdx = plistXml.search(/<key>\s*DevicePropertiesAttestation\s*<\/key>/i);
+  if (keyIdx < 0) return null;
+  const after = plistXml.slice(keyIdx);
+  const arrMatch = after.match(/<array>([\s\S]*?)<\/array>/i);
+  if (!arrMatch) return null;
+  const datas = [...arrMatch[1]!.matchAll(/<data>([\s\S]*?)<\/data>/gi)].map((m) =>
+    m[1]!.replace(/\s+/g, ""),
+  );
+  return datas.length > 0 ? datas : null;
+}
+
+function extractSerialFromPlist(plistXml: string): string | null {
+  const m = plistXml.match(/<key>\s*SerialNumber\s*<\/key>\s*<string>([^<]+)<\/string>/i);
+  return m ? m[1]!.trim() : null;
 }

--- a/packages/console/src/lib/mdm-coordinator.server.ts
+++ b/packages/console/src/lib/mdm-coordinator.server.ts
@@ -848,7 +848,9 @@ export function parseNanomdmAttestationWebhook(
     pushStr(cr["payload"]);
   }
   // Some webhook configs nest the device plist under `checkin`/`acknowledge`.
-  pushStr((obj["acknowledge_event"] as Record<string, unknown> | undefined)?.["raw_payload"] as unknown);
+  pushStr(
+    (obj["acknowledge_event"] as Record<string, unknown> | undefined)?.["raw_payload"] as unknown,
+  );
 
   const serial = typeof obj["serial"] === "string" ? (obj["serial"] as string) : null;
 

--- a/packages/console/src/routeTree.gen.ts
+++ b/packages/console/src/routeTree.gen.ts
@@ -89,7 +89,9 @@ import { Route as ApiAuthAtprotoMetadataDotjsonRouteImport } from './routes/api.
 import { Route as ApiAuthAtprotoJwksDotjsonRouteImport } from './routes/api.auth.atproto.jwks[.]json'
 import { Route as ApiAuthAtprotoCallbackRouteImport } from './routes/api.auth.atproto.callback'
 import { Route as ApiAuthAtprotoAuthorizeRouteImport } from './routes/api.auth.atproto.authorize'
+import { Route as ApiAgentMdmRequestAttestationRouteImport } from './routes/api/agent.mdm.request-attestation'
 import { Route as ApiAgentMdmPushAttestationRouteImport } from './routes/api/agent.mdm.push-attestation'
+import { Route as ApiAgentMdmNanomdmWebhookRouteImport } from './routes/api/agent.mdm.nanomdm-webhook'
 import { Route as ApiAgentMdmEnrollProfileRouteImport } from './routes/api/agent.mdm.enroll-profile'
 import { Route as ApiAgentMdmAttestationChainRouteImport } from './routes/api/agent.mdm.attestation-chain'
 import { Route as DocsHeaderLayoutDocsInferenceAuthenticationRouteImport } from './routes/_docs-header-layout.docs.inference.authentication'
@@ -524,10 +526,22 @@ const ApiAuthAtprotoAuthorizeRoute = ApiAuthAtprotoAuthorizeRouteImport.update({
   path: '/api/auth/atproto/authorize',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiAgentMdmRequestAttestationRoute =
+  ApiAgentMdmRequestAttestationRouteImport.update({
+    id: '/api/agent/mdm/request-attestation',
+    path: '/api/agent/mdm/request-attestation',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiAgentMdmPushAttestationRoute =
   ApiAgentMdmPushAttestationRouteImport.update({
     id: '/api/agent/mdm/push-attestation',
     path: '/api/agent/mdm/push-attestation',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiAgentMdmNanomdmWebhookRoute =
+  ApiAgentMdmNanomdmWebhookRouteImport.update({
+    id: '/api/agent/mdm/nanomdm-webhook',
+    path: '/api/agent/mdm/nanomdm-webhook',
     getParentRoute: () => rootRouteImport,
   } as any)
 const ApiAgentMdmEnrollProfileRoute =
@@ -635,7 +649,9 @@ export interface FileRoutesByFullPath {
   '/docs/inference/authentication': typeof DocsHeaderLayoutDocsInferenceAuthenticationRoute
   '/api/agent/mdm/attestation-chain': typeof ApiAgentMdmAttestationChainRoute
   '/api/agent/mdm/enroll-profile': typeof ApiAgentMdmEnrollProfileRoute
+  '/api/agent/mdm/nanomdm-webhook': typeof ApiAgentMdmNanomdmWebhookRoute
   '/api/agent/mdm/push-attestation': typeof ApiAgentMdmPushAttestationRoute
+  '/api/agent/mdm/request-attestation': typeof ApiAgentMdmRequestAttestationRoute
   '/api/auth/atproto/authorize': typeof ApiAuthAtprotoAuthorizeRoute
   '/api/auth/atproto/callback': typeof ApiAuthAtprotoCallbackRoute
   '/api/auth/atproto/jwks.json': typeof ApiAuthAtprotoJwksDotjsonRoute
@@ -720,7 +736,9 @@ export interface FileRoutesByTo {
   '/docs/inference/authentication': typeof DocsHeaderLayoutDocsInferenceAuthenticationRoute
   '/api/agent/mdm/attestation-chain': typeof ApiAgentMdmAttestationChainRoute
   '/api/agent/mdm/enroll-profile': typeof ApiAgentMdmEnrollProfileRoute
+  '/api/agent/mdm/nanomdm-webhook': typeof ApiAgentMdmNanomdmWebhookRoute
   '/api/agent/mdm/push-attestation': typeof ApiAgentMdmPushAttestationRoute
+  '/api/agent/mdm/request-attestation': typeof ApiAgentMdmRequestAttestationRoute
   '/api/auth/atproto/authorize': typeof ApiAuthAtprotoAuthorizeRoute
   '/api/auth/atproto/callback': typeof ApiAuthAtprotoCallbackRoute
   '/api/auth/atproto/jwks.json': typeof ApiAuthAtprotoJwksDotjsonRoute
@@ -809,7 +827,9 @@ export interface FileRoutesById {
   '/_docs-header-layout/docs/inference/authentication': typeof DocsHeaderLayoutDocsInferenceAuthenticationRoute
   '/api/agent/mdm/attestation-chain': typeof ApiAgentMdmAttestationChainRoute
   '/api/agent/mdm/enroll-profile': typeof ApiAgentMdmEnrollProfileRoute
+  '/api/agent/mdm/nanomdm-webhook': typeof ApiAgentMdmNanomdmWebhookRoute
   '/api/agent/mdm/push-attestation': typeof ApiAgentMdmPushAttestationRoute
+  '/api/agent/mdm/request-attestation': typeof ApiAgentMdmRequestAttestationRoute
   '/api/auth/atproto/authorize': typeof ApiAuthAtprotoAuthorizeRoute
   '/api/auth/atproto/callback': typeof ApiAuthAtprotoCallbackRoute
   '/api/auth/atproto/jwks.json': typeof ApiAuthAtprotoJwksDotjsonRoute
@@ -897,7 +917,9 @@ export interface FileRouteTypes {
     | '/docs/inference/authentication'
     | '/api/agent/mdm/attestation-chain'
     | '/api/agent/mdm/enroll-profile'
+    | '/api/agent/mdm/nanomdm-webhook'
     | '/api/agent/mdm/push-attestation'
+    | '/api/agent/mdm/request-attestation'
     | '/api/auth/atproto/authorize'
     | '/api/auth/atproto/callback'
     | '/api/auth/atproto/jwks.json'
@@ -982,7 +1004,9 @@ export interface FileRouteTypes {
     | '/docs/inference/authentication'
     | '/api/agent/mdm/attestation-chain'
     | '/api/agent/mdm/enroll-profile'
+    | '/api/agent/mdm/nanomdm-webhook'
     | '/api/agent/mdm/push-attestation'
+    | '/api/agent/mdm/request-attestation'
     | '/api/auth/atproto/authorize'
     | '/api/auth/atproto/callback'
     | '/api/auth/atproto/jwks.json'
@@ -1070,7 +1094,9 @@ export interface FileRouteTypes {
     | '/_docs-header-layout/docs/inference/authentication'
     | '/api/agent/mdm/attestation-chain'
     | '/api/agent/mdm/enroll-profile'
+    | '/api/agent/mdm/nanomdm-webhook'
     | '/api/agent/mdm/push-attestation'
+    | '/api/agent/mdm/request-attestation'
     | '/api/auth/atproto/authorize'
     | '/api/auth/atproto/callback'
     | '/api/auth/atproto/jwks.json'
@@ -1124,7 +1150,9 @@ export interface RootRouteChildren {
   V1ChatCompletionsRoute: typeof V1ChatCompletionsRoute
   ApiAgentMdmAttestationChainRoute: typeof ApiAgentMdmAttestationChainRoute
   ApiAgentMdmEnrollProfileRoute: typeof ApiAgentMdmEnrollProfileRoute
+  ApiAgentMdmNanomdmWebhookRoute: typeof ApiAgentMdmNanomdmWebhookRoute
   ApiAgentMdmPushAttestationRoute: typeof ApiAgentMdmPushAttestationRoute
+  ApiAgentMdmRequestAttestationRoute: typeof ApiAgentMdmRequestAttestationRoute
   ApiAuthAtprotoAuthorizeRoute: typeof ApiAuthAtprotoAuthorizeRoute
   ApiAuthAtprotoCallbackRoute: typeof ApiAuthAtprotoCallbackRoute
   ApiAuthAtprotoJwksDotjsonRoute: typeof ApiAuthAtprotoJwksDotjsonRoute
@@ -1698,11 +1726,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiAuthAtprotoAuthorizeRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/agent/mdm/request-attestation': {
+      id: '/api/agent/mdm/request-attestation'
+      path: '/api/agent/mdm/request-attestation'
+      fullPath: '/api/agent/mdm/request-attestation'
+      preLoaderRoute: typeof ApiAgentMdmRequestAttestationRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/agent/mdm/push-attestation': {
       id: '/api/agent/mdm/push-attestation'
       path: '/api/agent/mdm/push-attestation'
       fullPath: '/api/agent/mdm/push-attestation'
       preLoaderRoute: typeof ApiAgentMdmPushAttestationRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/agent/mdm/nanomdm-webhook': {
+      id: '/api/agent/mdm/nanomdm-webhook'
+      path: '/api/agent/mdm/nanomdm-webhook'
+      fullPath: '/api/agent/mdm/nanomdm-webhook'
+      preLoaderRoute: typeof ApiAgentMdmNanomdmWebhookRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/agent/mdm/enroll-profile': {
@@ -1916,7 +1958,9 @@ const rootRouteChildren: RootRouteChildren = {
   V1ChatCompletionsRoute: V1ChatCompletionsRoute,
   ApiAgentMdmAttestationChainRoute: ApiAgentMdmAttestationChainRoute,
   ApiAgentMdmEnrollProfileRoute: ApiAgentMdmEnrollProfileRoute,
+  ApiAgentMdmNanomdmWebhookRoute: ApiAgentMdmNanomdmWebhookRoute,
   ApiAgentMdmPushAttestationRoute: ApiAgentMdmPushAttestationRoute,
+  ApiAgentMdmRequestAttestationRoute: ApiAgentMdmRequestAttestationRoute,
   ApiAuthAtprotoAuthorizeRoute: ApiAuthAtprotoAuthorizeRoute,
   ApiAuthAtprotoCallbackRoute: ApiAuthAtprotoCallbackRoute,
   ApiAuthAtprotoJwksDotjsonRoute: ApiAuthAtprotoJwksDotjsonRoute,

--- a/packages/console/src/routes/api/agent.mdm.nanomdm-webhook.ts
+++ b/packages/console/src/routes/api/agent.mdm.nanomdm-webhook.ts
@@ -1,0 +1,59 @@
+// POST /api/agent/mdm/nanomdm-webhook
+//
+// Capture sink for the option-B DeviceInformation attestation flow. NanoMDM is
+// configured (`-webhook-url`) to POST MDM events here; when a device's
+// DeviceInformation command result carries a `DevicePropertiesAttestation`
+// chain (the Apple x5c we requested with a key-bound nonce in
+// agent.mdm.request-attestation), we persist it keyed by serial — the same
+// store the agent polls via agent.mdm.attestation-chain.
+//
+// Non-attestation events (Authenticate, TokenUpdate, other command results) are
+// acknowledged and ignored. Auth: COCORE_NANOMDM_WEBHOOK_KEY bearer
+// (constant-time, fail-closed when unset) — NanoMDM infra, not an agent.
+//
+// This mirrors the step-ca attestation webhook (agent.mdm.attestation-chain
+// POST) for the ACME flow; the DeviceInformation flow's chain comes back over
+// MDM instead of out-of-band from the CA.
+
+import { createFileRoute } from "@tanstack/react-router";
+
+import {
+  authenticateNanomdmWebhook,
+  ingestAttestationChain,
+  isValidSerial,
+  mdmJson,
+  parseNanomdmAttestationWebhook,
+} from "@/lib/mdm-coordinator.server.ts";
+
+export const Route = createFileRoute("/api/agent/mdm/nanomdm-webhook")({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        if (!authenticateNanomdmWebhook(request)) {
+          return mdmJson({ error: "invalid or missing nanomdm-webhook bearer" }, 401);
+        }
+        let body: unknown;
+        try {
+          body = await request.json();
+        } catch {
+          return mdmJson({ error: "body must be JSON" }, 400);
+        }
+
+        const parsed = parseNanomdmAttestationWebhook(body);
+        // Not an attestation result → ACK so NanoMDM doesn't retry.
+        if (!parsed) return mdmJson({ ok: true, captured: false });
+
+        if (!isValidSerial(parsed.serial)) {
+          // We got a chain but couldn't tie it to a serial — don't store
+          // unkeyed; report so the operator can inspect the webhook shape.
+          return mdmJson(
+            { ok: false, captured: false, detail: "attestation chain present but no valid serial" },
+            422,
+          );
+        }
+        ingestAttestationChain(parsed.serial, parsed.chain, new Date().toISOString());
+        return mdmJson({ ok: true, captured: true, serial: parsed.serial, certs: parsed.chain.length });
+      },
+    },
+  },
+});

--- a/packages/console/src/routes/api/agent.mdm.nanomdm-webhook.ts
+++ b/packages/console/src/routes/api/agent.mdm.nanomdm-webhook.ts
@@ -52,7 +52,12 @@ export const Route = createFileRoute("/api/agent/mdm/nanomdm-webhook")({
           );
         }
         ingestAttestationChain(parsed.serial, parsed.chain, new Date().toISOString());
-        return mdmJson({ ok: true, captured: true, serial: parsed.serial, certs: parsed.chain.length });
+        return mdmJson({
+          ok: true,
+          captured: true,
+          serial: parsed.serial,
+          certs: parsed.chain.length,
+        });
       },
     },
   },

--- a/packages/console/src/routes/api/agent.mdm.request-attestation.ts
+++ b/packages/console/src/routes/api/agent.mdm.request-attestation.ts
@@ -1,0 +1,74 @@
+// POST /api/agent/mdm/request-attestation
+//
+// Option-B (freshness-code) hardware attestation. The agent supplies its
+// receipt-signing public key; the coordinator sends an MDM `DeviceInformation`
+// attestation command (via NanoMDM) with `DeviceAttestationNonce =
+// sha256(publicKey)`, so the Apple attestation Apple returns has its freshness
+// OID committed to the signing key. The captured chain arrives via the NanoMDM
+// webhook (agent.mdm.nanomdm-webhook), is stored keyed by serial, and the agent
+// reads it from agent.mdm.attestation-chain — where the freshness binding earns
+// `hardware-attested`.
+//
+// This is the MDM-free-of-App-Attest path: it needs no step-ca challenge
+// control, unlike the bundled ACME flow whose freshness = sha256(challenge
+// token). Apple rate-limits DeviceInformation attestation to ~1/device/7 days,
+// so the agent calls this at most weekly (the bound chain is reused across the
+// 24h attestation publishes).
+//
+// Auth: the agent's bearer API key (same surface as the other /api/agent/*).
+
+import { createFileRoute } from "@tanstack/react-router";
+
+import {
+  authenticateAgent,
+  isValidSerial,
+  isValidUdid,
+  mdmJson,
+  requestDeviceInformationAttestation,
+} from "@/lib/mdm-coordinator.server.ts";
+
+/** Accept a base64 raw 64-byte P-256 X‖Y public key (the value the agent
+ *  publishes as attestation.publicKey). */
+function isValidPublicKey(v: unknown): v is string {
+  if (typeof v !== "string" || v.length === 0) return false;
+  try {
+    return Buffer.from(v, "base64").length === 64;
+  } catch {
+    return false;
+  }
+}
+
+export const Route = createFileRoute("/api/agent/mdm/request-attestation")({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        const auth = authenticateAgent(request);
+        if (!auth.ok) return auth.response;
+
+        let body: { serial?: unknown; udid?: unknown; publicKey?: unknown };
+        try {
+          body = (await request.json()) as typeof body;
+        } catch {
+          return mdmJson({ error: "body must be JSON" }, 400);
+        }
+        if (!isValidSerial(body.serial)) {
+          return mdmJson({ error: "serial required (8–24 alphanumeric chars)" }, 400);
+        }
+        if (!isValidUdid(body.udid)) {
+          return mdmJson({ error: "udid required (40-hex or UUID form; the NanoMDM target)" }, 400);
+        }
+        if (!isValidPublicKey(body.publicKey)) {
+          return mdmJson({ error: "publicKey required (base64 of a raw 64-byte P-256 key)" }, 400);
+        }
+
+        const result = await requestDeviceInformationAttestation(
+          body.serial,
+          body.udid,
+          body.publicKey,
+        );
+        const status = result.status === "error" ? 502 : 200;
+        return mdmJson(result, status);
+      },
+    },
+  },
+});

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -11,6 +11,8 @@
     "./firehose": "./src/firehose.ts",
     "./lex": "./src/lex-runtime.ts",
     "./mda": "./src/mda.ts",
+    "./appattest": "./src/appattest.ts",
+    "./verify-provider": "./src/verify-provider.ts",
     "./oauth-scope": "./src/oauth-scope.ts",
     "./p256": "./src/p256.ts",
     "./publish": "./src/publish.ts",

--- a/packages/sdk/src/appattest.test.ts
+++ b/packages/sdk/src/appattest.test.ts
@@ -1,0 +1,118 @@
+import { test } from "vitest";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  APPLE_APP_ATTEST_ROOT_CA_PEM,
+  AppAttestError,
+  verifyAppAttest,
+  verifyAppAttestB64,
+} from "./appattest.ts";
+
+interface Fixture {
+  objectB64: string;
+  keyIdB64: string;
+  publicKeyB64: string;
+  appId: string;
+  rootDerB64: string;
+  appleRootPem: string;
+}
+
+function loadFixture(): Fixture {
+  const here = new URL(".", import.meta.url).pathname;
+  const path = join(here, "..", "..", "..", "target", "appattest-cross-lang-fixture.json");
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+function b64(s: string): Uint8Array {
+  return Uint8Array.from(Buffer.from(s, "base64"));
+}
+
+test("cross-language App Attest fixture: TS verifies an object produced by Rust", () => {
+  const f = loadFixture();
+  const res = verifyAppAttest(
+    b64(f.objectB64),
+    b64(f.keyIdB64),
+    b64(f.publicKeyB64),
+    f.appId,
+    { trustAnchorDer: b64(f.rootDerB64) },
+  );
+  assert.equal(res.valid, true);
+  assert.equal(res.bindsSigningKey, true);
+  // keyId is sha256(attested pubkey) → 32 bytes; equals the fixture's keyId.
+  assert.equal(Buffer.from(res.keyId, "base64").length, 32);
+  assert.equal(res.keyId, f.keyIdB64);
+});
+
+test("App Attest bound to a different signing key is rejected (nonce mismatch)", () => {
+  const f = loadFixture();
+  const otherKey = Buffer.alloc(64, 9).toString("base64");
+  assert.throws(
+    () =>
+      verifyAppAttest(b64(f.objectB64), b64(f.keyIdB64), b64(otherKey), f.appId, {
+        trustAnchorDer: b64(f.rootDerB64),
+      }),
+    (e: unknown) => e instanceof AppAttestError && e.code === "nonce-mismatch",
+  );
+});
+
+test("synthetic App Attest object rejected against the real Apple App Attest root", () => {
+  const f = loadFixture();
+  assert.throws(
+    () =>
+      verifyAppAttest(b64(f.objectB64), b64(f.keyIdB64), b64(f.publicKeyB64), f.appId, {
+        // pull the Apple PEM from the fixture (the exact Rust-embedded bytes)
+        trustAnchorDer: pemToDer(f.appleRootPem),
+      }),
+    (e: unknown) => e instanceof AppAttestError && e.code === "bad-signature",
+  );
+});
+
+test("wrong appId is rejected (rpIdHash mismatch)", () => {
+  const f = loadFixture();
+  assert.throws(
+    () =>
+      verifyAppAttest(
+        b64(f.objectB64),
+        b64(f.keyIdB64),
+        b64(f.publicKeyB64),
+        "4L45P7CP9M.com.evil.fork",
+        { trustAnchorDer: b64(f.rootDerB64) },
+      ),
+    (e: unknown) => e instanceof AppAttestError && e.code === "shape",
+  );
+});
+
+test("verifyAppAttestB64 returns true for the bound fixture, false for a bad object", () => {
+  const f = loadFixture();
+  assert.equal(
+    verifyAppAttestB64(f.objectB64, f.keyIdB64, f.publicKeyB64, f.appId, {
+      trustAnchorDer: b64(f.rootDerB64),
+    }),
+    true,
+  );
+  // Garbage object → false, never throws.
+  assert.equal(
+    verifyAppAttestB64(
+      Buffer.from("not-cbor").toString("base64"),
+      f.keyIdB64,
+      f.publicKeyB64,
+      f.appId,
+      { trustAnchorDer: b64(f.rootDerB64) },
+    ),
+    false,
+  );
+});
+
+test("embedded Apple App Attest root PEM is byte-identical to the Rust embed", () => {
+  const f = loadFixture();
+  assert.equal(APPLE_APP_ATTEST_ROOT_CA_PEM, f.appleRootPem);
+});
+
+function pemToDer(pem: string): Uint8Array {
+  const stripped = pem
+    .replace(/-----BEGIN [^-]+-----/, "")
+    .replace(/-----END [^-]+-----/, "")
+    .replace(/\s+/g, "");
+  return Uint8Array.from(Buffer.from(stripped, "base64"));
+}

--- a/packages/sdk/src/appattest.test.ts
+++ b/packages/sdk/src/appattest.test.ts
@@ -30,13 +30,9 @@ function b64(s: string): Uint8Array {
 
 test("cross-language App Attest fixture: TS verifies an object produced by Rust", () => {
   const f = loadFixture();
-  const res = verifyAppAttest(
-    b64(f.objectB64),
-    b64(f.keyIdB64),
-    b64(f.publicKeyB64),
-    f.appId,
-    { trustAnchorDer: b64(f.rootDerB64) },
-  );
+  const res = verifyAppAttest(b64(f.objectB64), b64(f.keyIdB64), b64(f.publicKeyB64), f.appId, {
+    trustAnchorDer: b64(f.rootDerB64),
+  });
   assert.equal(res.valid, true);
   assert.equal(res.bindsSigningKey, true);
   // keyId is sha256(attested pubkey) → 32 bytes; equals the fixture's keyId.

--- a/packages/sdk/src/appattest.ts
+++ b/packages/sdk/src/appattest.ts
@@ -1,0 +1,490 @@
+// Apple App Attest attestation verification.
+//
+// Mirror of provider/src/appattest.rs in TypeScript so AppViews and requesters
+// can verify the MDM-free "hardware-attested" path without re-implementing it.
+// Parallel to mda.ts (which verifies an MDA x509 chain): this verifies an Apple
+// App Attest *attestation object* (CBOR/WebAuthn-shaped) and confirms it is
+// BOUND to the provider's receipt-signing key via the credential certificate's
+// nonce extension.
+//
+// Binding (by construction in the helper): clientDataHash = sha256(signingPubKey),
+// so here:
+//   nonce == sha256(authData ‖ sha256(signingPubKey))  ==  credCert ext 1.2.840.113635.100.8.2
+//
+// Verification steps (Apple "Validating Apps That Connect to Your Server"),
+// kept byte-for-byte aligned with the Rust verifier:
+//   1. CBOR-decode; require fmt == "apple-appattest".
+//   2. Verify the x5c chain (credCert → intermediate) to the embedded Apple App
+//      Attest Root CA: signatures, validity, BasicConstraints.
+//   3. nonce = sha256(authData ‖ sha256(signingPubKey)) == credCert nonce ext.
+//   4. credentialId (authData) == sha256(credCert uncompressed pubkey) == keyId.
+//   5. authData rpIdHash == sha256(appId), AAGUID is genuine, AT flag set.
+
+import { X509Certificate, createHash } from "node:crypto";
+import { parseExtensions } from "./mda.ts";
+
+/// Apple App Attest Root CA, P-384, valid 2020 → 2045.
+/// Identical bytes to the Rust embed in provider/src/appattest.rs.
+export const APPLE_APP_ATTEST_ROOT_CA_PEM =
+  "-----BEGIN CERTIFICATE-----\n" +
+  "MIICITCCAaegAwIBAgIQC/O+DvHN0uD7jG5yH2IXmDAKBggqhkjOPQQDAzBSMSYw\n" +
+  "JAYDVQQDDB1BcHBsZSBBcHAgQXR0ZXN0YXRpb24gUm9vdCBDQTETMBEGA1UECgwK\n" +
+  "QXBwbGUgSW5jLjETMBEGA1UECAwKQ2FsaWZvcm5pYTAeFw0yMDAzMTgxODMyNTNa\n" +
+  "Fw00NTAzMTUwMDAwMDBaMFIxJjAkBgNVBAMMHUFwcGxlIEFwcCBBdHRlc3RhdGlv\n" +
+  "biBSb290IENBMRMwEQYDVQQKDApBcHBsZSBJbmMuMRMwEQYDVQQIDApDYWxpZm9y\n" +
+  "bmlhMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAERTHhmLW07ATaFQIEVwTtT4dyctdh\n" +
+  "NbJhFs/Ii2FdCgAHGbpphY3+d8qjuDngIN3WVhQUBHAoMeQ/cLiP1sOUtgjqK9au\n" +
+  "Yen1mMEvRq9Sk3Jm5X8U62H+xTD3FE9TgS41o0IwQDAPBgNVHRMBAf8EBTADAQH/\n" +
+  "MB0GA1UdDgQWBBSskRBTM72+aEH/pwyp5frq5eWKoTAOBgNVHQ8BAf8EBAMCAQYw\n" +
+  "CgYIKoZIzj0EAwMDaAAwZQIwQgFGnByvsiVbpTKwSga0kP0e8EeDS4+sQmTvb7vn\n" +
+  "53O5+FRXgeLhpJ06ysC5PrOyAjEAp5U4xDgEgllF7En3VcE3iexZZtKeYnpqtijV\n" +
+  "oyFraWVIyd/dganmrduC1bmTBGwD\n" +
+  "-----END CERTIFICATE-----\n";
+
+/// Apple's App Attest nonce extension OID (dotted-int; Node-style).
+const OID_APP_ATTEST_NONCE = "1.2.840.113635.100.8.2";
+
+/// AAGUID for genuine production App Attest: ASCII "appattest" + 7 zero bytes.
+export const AAGUID_PRODUCTION = Uint8Array.from([
+  0x61, 0x70, 0x70, 0x61, 0x74, 0x74, 0x65, 0x73, 0x74, 0, 0, 0, 0, 0, 0, 0,
+]);
+/// AAGUID for the development environment: ASCII "appattestdevelop".
+export const AAGUID_DEVELOPMENT = new TextEncoder().encode("appattestdevelop");
+
+/// The cocore provider App ID ("TEAMID.bundleID"). rpIdHash = sha256 of this.
+export const APP_ATTEST_APP_ID = "4L45P7CP9M.dev.cocore.provider";
+
+/// WebAuthn authenticator-data "attested credential data included" flag.
+const FLAG_AT = 0x40;
+
+export interface AppAttestResult {
+  valid: boolean;
+  /** Attested App Attest public key as the uncompressed EC point (0x04‖X‖Y),
+   *  base64. NB: the App Attest key, not the signing key — the binding is the
+   *  nonce check, not this field. */
+  attestedPubkeyUncompressed: string;
+  /** sha256(attested pubkey) — equals authData credentialId and keyId. */
+  keyId: string;
+  aaguid: Uint8Array;
+  rpIdHash: Uint8Array;
+  /** True iff the nonce commits to sha256(authData ‖ sha256(signingPubKey)). */
+  bindsSigningKey: boolean;
+}
+
+export class AppAttestError extends Error {
+  readonly code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = "AppAttestError";
+    this.code = code;
+  }
+}
+
+export interface VerifyAppAttestOptions {
+  /** Verify against this trust anchor instead of the embedded Apple root.
+   *  The cross-lang test path passes the synthetic App Attest root. */
+  trustAnchorDer?: Uint8Array;
+  now?: Date;
+  /** Accept the development AAGUID too (default false: production only). */
+  allowDevelopment?: boolean;
+}
+
+/** Verify an App Attest object. Throws AppAttestError on any failure; returns a
+ *  result with bindsSigningKey=true on success. */
+export function verifyAppAttest(
+  objectDer: Uint8Array,
+  keyId: Uint8Array,
+  signingPubkeyRaw: Uint8Array,
+  appId: string,
+  opts: VerifyAppAttestOptions = {},
+): AppAttestResult {
+  const now = opts.now ?? new Date();
+  const rootDer = opts.trustAnchorDer ?? pemToDer(APPLE_APP_ATTEST_ROOT_CA_PEM);
+  const allowDevelopment = opts.allowDevelopment ?? false;
+
+  // --- 1. CBOR-decode. ---
+  const obj = decodeAttestationObject(objectDer);
+  if (obj.fmt !== "apple-appattest") {
+    throw new AppAttestError("bad-fmt", `unexpected fmt ${JSON.stringify(obj.fmt)}`);
+  }
+  if (obj.x5c.length === 0) {
+    throw new AppAttestError("shape", "attStmt.x5c is empty");
+  }
+
+  // --- 2. Verify the x5c chain to the App Attest root. ---
+  const certs = obj.x5c.map((der, i) => {
+    try {
+      return new X509Certificate(Buffer.from(der));
+    } catch (e) {
+      throw new AppAttestError("parse", `parse cert ${i}: ${(e as Error).message}`);
+    }
+  });
+  let root: X509Certificate;
+  try {
+    root = new X509Certificate(Buffer.from(rootDer));
+  } catch (e) {
+    throw new AppAttestError("bad-trust-anchor", `parse trust anchor: ${(e as Error).message}`);
+  }
+
+  const validAt = (cert: X509Certificate, idx: number): void => {
+    const t = now.getTime();
+    if (t < new Date(cert.validFrom).getTime() || t > new Date(cert.validTo).getTime()) {
+      throw new AppAttestError("not-valid", `cert ${idx} not valid at ${now.toISOString()}`);
+    }
+  };
+  certs.forEach(validAt);
+  validAt(root, -1);
+
+  for (let i = 0; i < certs.length - 1; i++) {
+    if (!certs[i]!.verify(certs[i + 1]!.publicKey)) {
+      throw new AppAttestError("bad-signature", `signature on cert ${i} doesn't verify`);
+    }
+  }
+  const topIdx = certs.length - 1;
+  if (!certs[topIdx]!.verify(root.publicKey)) {
+    throw new AppAttestError(
+      "bad-signature",
+      `top of chain (cert ${topIdx}) not signed by trust anchor`,
+    );
+  }
+
+  // BasicConstraints: leaf is end-entity, issuers are CAs.
+  for (let i = 0; i < certs.length; i++) {
+    const isCa = certs[i]!.ca;
+    if (i === 0 && isCa) {
+      throw new AppAttestError("leaf-is-ca", "leaf (credCert) must be an end-entity, not a CA");
+    }
+    if (i > 0 && !isCa) {
+      throw new AppAttestError("non-ca-issuer", `chain cert ${i} is not a CA but signs cert ${i - 1}`);
+    }
+  }
+
+  const credCert = certs[0]!;
+
+  // --- 3. Recompute nonce and check the credCert nonce extension. ---
+  const clientDataHash = sha256(signingPubkeyRaw);
+  const expectedNonce = sha256(concat(obj.authData, clientDataHash));
+
+  const rawDer = new Uint8Array(credCert.raw.buffer, credCert.raw.byteOffset, credCert.raw.byteLength);
+  const nonceExt = parseExtensions(rawDer).find((e) => e.oid === OID_APP_ATTEST_NONCE);
+  if (!nonceExt) {
+    throw new AppAttestError("no-nonce-extension", "credCert has no nonce extension");
+  }
+  const gotNonce = parseNonceExtension(nonceExt.value);
+  if (!gotNonce) {
+    throw new AppAttestError("bad-nonce-extension", "malformed nonce extension");
+  }
+  if (!ctEq(gotNonce, expectedNonce)) {
+    throw new AppAttestError(
+      "nonce-mismatch",
+      "attestation is not bound to the signing key (nonce mismatch)",
+    );
+  }
+
+  // --- 4. credCert pubkey → credentialId, cross-check authData + keyId. ---
+  const attestedPubkey = uncompressedPoint(credCert);
+  if (!attestedPubkey) {
+    throw new AppAttestError("shape", "credCert public key is not an uncompressed P-256 point");
+  }
+  const pubkeyHash = sha256(attestedPubkey);
+
+  // --- 5. Parse authData; validate rpIdHash / AAGUID / credentialId. ---
+  const ad = parseAuthData(obj.authData);
+  if (!ctEq(ad.rpIdHash, sha256(new TextEncoder().encode(appId)))) {
+    throw new AppAttestError("shape", "rpIdHash != sha256(appId)");
+  }
+  const aaguidOk =
+    ctEq(ad.aaguid, AAGUID_PRODUCTION) ||
+    (allowDevelopment && ctEq(ad.aaguid, AAGUID_DEVELOPMENT));
+  if (!aaguidOk) {
+    throw new AppAttestError(
+      "bad-aaguid",
+      `unrecognized AAGUID ${Buffer.from(ad.aaguid).toString("hex")}`,
+    );
+  }
+  if (!ctEq(ad.credentialId, pubkeyHash)) {
+    throw new AppAttestError("cred-id-mismatch", "credentialId != sha256(attested pubkey)");
+  }
+  if (!ctEq(keyId, pubkeyHash)) {
+    throw new AppAttestError("key-id-mismatch", "keyId != credentialId");
+  }
+
+  return {
+    valid: true,
+    attestedPubkeyUncompressed: Buffer.from(attestedPubkey).toString("base64"),
+    keyId: Buffer.from(pubkeyHash).toString("base64"),
+    aaguid: ad.aaguid,
+    rpIdHash: ad.rpIdHash,
+    bindsSigningKey: true,
+  };
+}
+
+/** Decode base64 object/keyId/publicKey and verify. Returns true iff valid AND
+ *  bound to publicKeyB64. Never throws — callers that want detail use
+ *  verifyAppAttest directly. */
+export function verifyAppAttestB64(
+  objectB64: string,
+  keyIdB64: string,
+  publicKeyB64: string,
+  appId: string,
+  opts: VerifyAppAttestOptions = {},
+): boolean {
+  try {
+    const res = verifyAppAttest(
+      Uint8Array.from(Buffer.from(objectB64, "base64")),
+      Uint8Array.from(Buffer.from(keyIdB64, "base64")),
+      Uint8Array.from(Buffer.from(publicKeyB64, "base64")),
+      appId,
+      opts,
+    );
+    return res.valid && res.bindsSigningKey;
+  } catch (e) {
+    if (e instanceof AppAttestError) return false;
+    throw e;
+  }
+}
+
+// ---- internals -------------------------------------------------------
+
+function sha256(data: Uint8Array): Uint8Array {
+  return Uint8Array.from(createHash("sha256").update(Buffer.from(data)).digest());
+}
+
+function concat(a: Uint8Array, b: Uint8Array): Uint8Array {
+  const out = new Uint8Array(a.length + b.length);
+  out.set(a, 0);
+  out.set(b, a.length);
+  return out;
+}
+
+function ctEq(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let acc = 0;
+  for (let i = 0; i < a.length; i++) acc |= a[i]! ^ b[i]!;
+  return acc === 0;
+}
+
+function pemToDer(pem: string): Uint8Array {
+  const stripped = pem
+    .replace(/-----BEGIN [^-]+-----/, "")
+    .replace(/-----END [^-]+-----/, "")
+    .replace(/\s+/g, "");
+  return Uint8Array.from(Buffer.from(stripped, "base64"));
+}
+
+/** credCert public key as the uncompressed EC point (0x04‖X‖Y, 65 bytes). */
+function uncompressedPoint(cert: X509Certificate): Uint8Array | undefined {
+  try {
+    const jwk = cert.publicKey.export({ format: "jwk" }) as {
+      kty?: string;
+      crv?: string;
+      x?: string;
+      y?: string;
+    };
+    if (jwk.kty === "EC" && jwk.crv === "P-256" && jwk.x && jwk.y) {
+      const x = Buffer.from(jwk.x, "base64url");
+      const y = Buffer.from(jwk.y, "base64url");
+      if (x.length === 32 && y.length === 32) {
+        return Uint8Array.from(Buffer.concat([Buffer.from([0x04]), x, y]));
+      }
+    }
+  } catch {
+    // fall through → undefined
+  }
+  return undefined;
+}
+
+interface AuthData {
+  rpIdHash: Uint8Array;
+  aaguid: Uint8Array;
+  credentialId: Uint8Array;
+}
+
+function parseAuthData(ad: Uint8Array): AuthData {
+  // rpIdHash(32) | flags(1) | signCount(4) | aaguid(16) | credIdLen(2) | credId(L) | cose...
+  if (ad.length < 37) {
+    throw new AppAttestError("short-auth-data", `authData too short (${ad.length} bytes)`);
+  }
+  const rpIdHash = ad.slice(0, 32);
+  const flags = ad[32]!;
+  if ((flags & FLAG_AT) === 0) {
+    throw new AppAttestError("no-attested-credential-data", "AT flag not set in authData");
+  }
+  if (ad.length < 55) {
+    throw new AppAttestError("short-auth-data", `authData too short (${ad.length} bytes)`);
+  }
+  const aaguid = ad.slice(37, 53);
+  const credIdLen = (ad[53]! << 8) | ad[54]!;
+  const end = 55 + credIdLen;
+  if (end > ad.length) {
+    throw new AppAttestError("short-auth-data", `authData too short for credId (${ad.length} bytes)`);
+  }
+  const credentialId = ad.slice(55, end);
+  return { rpIdHash, aaguid, credentialId };
+}
+
+/** The credCert nonce extension extnValue is DER:
+ *  SEQUENCE { [1] EXPLICIT OCTET STRING <nonce> }. Walk it strictly. */
+function parseNonceExtension(extValue: Uint8Array): Uint8Array | undefined {
+  const seq = readTlv(extValue);
+  if (!seq || seq.tag !== 0x30) return undefined; // SEQUENCE
+  const ctx = readTlv(seq.value);
+  if (!ctx || ctx.tag !== 0xa1) return undefined; // [1] constructed
+  const oct = readTlv(ctx.value);
+  if (!oct || oct.tag !== 0x04) return undefined; // OCTET STRING
+  if (oct.value.length !== 32) return undefined; // sha256 nonce
+  return oct.value;
+}
+
+interface Tlv {
+  tag: number;
+  value: Uint8Array;
+  rest: Uint8Array;
+}
+
+/** Minimal strict DER TLV reader (definite lengths only). */
+function readTlv(data: Uint8Array): Tlv | undefined {
+  if (data.length < 2) return undefined;
+  const tag = data[0]!;
+  const firstLen = data[1]!;
+  let len: number;
+  let header: number;
+  if ((firstLen & 0x80) === 0) {
+    len = firstLen;
+    header = 2;
+  } else {
+    const n = firstLen & 0x7f;
+    if (n === 0 || n > 4 || data.length < 2 + n) return undefined;
+    len = 0;
+    for (let i = 0; i < n; i++) len = (len << 8) | data[2 + i]!;
+    header = 2 + n;
+  }
+  const endPos = header + len;
+  if (endPos > data.length) return undefined;
+  return { tag, value: data.slice(header, endPos), rest: data.slice(endPos) };
+}
+
+// ---- minimal CBOR decoder (definite-length maps/arrays/byte+text strings) ---
+//
+// The App Attest object is a small, well-shaped CBOR map; we only need its top
+// level (fmt / attStmt(x5c, receipt) / authData). authData is an opaque byte
+// string here (its inner COSE key isn't needed). We support major types 0
+// (uint, for lengths), 2 (bytes), 3 (text), 4 (array), 5 (map), and skip 1/6/7
+// values we don't traverse. Indefinite lengths are rejected.
+
+interface CborReader {
+  buf: Uint8Array;
+  pos: number;
+}
+
+function cborErr(msg: string): never {
+  throw new AppAttestError("cbor", msg);
+}
+
+function cborReadHead(r: CborReader): { major: number; info: number } {
+  if (r.pos >= r.buf.length) cborErr("unexpected end of CBOR");
+  const b = r.buf[r.pos++]!;
+  return { major: b >> 5, info: b & 0x1f };
+}
+
+function cborReadArg(r: CborReader, info: number): number {
+  if (info < 24) return info;
+  if (info === 24) {
+    if (r.pos + 1 > r.buf.length) cborErr("truncated CBOR arg");
+    return r.buf[r.pos++]!;
+  }
+  if (info === 25) {
+    if (r.pos + 2 > r.buf.length) cborErr("truncated CBOR arg");
+    const v = (r.buf[r.pos]! << 8) | r.buf[r.pos + 1]!;
+    r.pos += 2;
+    return v;
+  }
+  if (info === 26) {
+    if (r.pos + 4 > r.buf.length) cborErr("truncated CBOR arg");
+    const v =
+      r.buf[r.pos]! * 0x1000000 +
+      (r.buf[r.pos + 1]! << 16) +
+      (r.buf[r.pos + 2]! << 8) +
+      r.buf[r.pos + 3]!;
+    r.pos += 4;
+    return v;
+  }
+  if (info === 27) {
+    // 8-byte length — far larger than any attestation object; reject.
+    cborErr("CBOR 64-bit lengths not supported");
+  }
+  cborErr(`unsupported CBOR additional-info ${info}`);
+}
+
+type CborValue = number | string | Uint8Array | CborValue[] | Map<string, CborValue>;
+
+function cborReadValue(r: CborReader): CborValue {
+  const { major, info } = cborReadHead(r);
+  switch (major) {
+    case 0: // unsigned int
+      return cborReadArg(r, info);
+    case 1: // negative int (not traversed in our shape, but decode it)
+      return -1 - cborReadArg(r, info);
+    case 2: {
+      // byte string
+      const len = cborReadArg(r, info);
+      if (r.pos + len > r.buf.length) cborErr("truncated CBOR byte string");
+      const out = r.buf.slice(r.pos, r.pos + len);
+      r.pos += len;
+      return out;
+    }
+    case 3: {
+      // text string
+      const len = cborReadArg(r, info);
+      if (r.pos + len > r.buf.length) cborErr("truncated CBOR text string");
+      const out = new TextDecoder("utf-8").decode(r.buf.slice(r.pos, r.pos + len));
+      r.pos += len;
+      return out;
+    }
+    case 4: {
+      // array
+      const len = cborReadArg(r, info);
+      const arr: CborValue[] = [];
+      for (let i = 0; i < len; i++) arr.push(cborReadValue(r));
+      return arr;
+    }
+    case 5: {
+      // map (text keys expected for our shape)
+      const len = cborReadArg(r, info);
+      const m = new Map<string, CborValue>();
+      for (let i = 0; i < len; i++) {
+        const key = cborReadValue(r);
+        const val = cborReadValue(r);
+        if (typeof key !== "string") cborErr("non-text CBOR map key");
+        m.set(key, val);
+      }
+      return m;
+    }
+    default:
+      cborErr(`unsupported CBOR major type ${major}`);
+  }
+}
+
+interface DecodedObject {
+  fmt: string;
+  x5c: Uint8Array[];
+  authData: Uint8Array;
+}
+
+function decodeAttestationObject(objectDer: Uint8Array): DecodedObject {
+  const top = cborReadValue({ buf: objectDer, pos: 0 });
+  if (!(top instanceof Map)) cborErr("top-level is not a CBOR map");
+  const fmt = top.get("fmt");
+  if (typeof fmt !== "string") cborErr("missing fmt");
+  const attStmt = top.get("attStmt");
+  if (!(attStmt instanceof Map)) cborErr("missing attStmt");
+  const x5cVal = attStmt.get("x5c");
+  if (!Array.isArray(x5cVal)) cborErr("missing attStmt.x5c");
+  const x5c = x5cVal.map((c) => {
+    if (!(c instanceof Uint8Array)) cborErr("attStmt.x5c[] not bytes");
+    return c;
+  });
+  const authData = top.get("authData");
+  if (!(authData instanceof Uint8Array)) cborErr("missing authData");
+  return { fmt, x5c, authData };
+}

--- a/packages/sdk/src/appattest.ts
+++ b/packages/sdk/src/appattest.ts
@@ -155,7 +155,10 @@ export function verifyAppAttest(
       throw new AppAttestError("leaf-is-ca", "leaf (credCert) must be an end-entity, not a CA");
     }
     if (i > 0 && !isCa) {
-      throw new AppAttestError("non-ca-issuer", `chain cert ${i} is not a CA but signs cert ${i - 1}`);
+      throw new AppAttestError(
+        "non-ca-issuer",
+        `chain cert ${i} is not a CA but signs cert ${i - 1}`,
+      );
     }
   }
 
@@ -165,7 +168,11 @@ export function verifyAppAttest(
   const clientDataHash = sha256(signingPubkeyRaw);
   const expectedNonce = sha256(concat(obj.authData, clientDataHash));
 
-  const rawDer = new Uint8Array(credCert.raw.buffer, credCert.raw.byteOffset, credCert.raw.byteLength);
+  const rawDer = new Uint8Array(
+    credCert.raw.buffer,
+    credCert.raw.byteOffset,
+    credCert.raw.byteLength,
+  );
   const nonceExt = parseExtensions(rawDer).find((e) => e.oid === OID_APP_ATTEST_NONCE);
   if (!nonceExt) {
     throw new AppAttestError("no-nonce-extension", "credCert has no nonce extension");
@@ -194,8 +201,7 @@ export function verifyAppAttest(
     throw new AppAttestError("shape", "rpIdHash != sha256(appId)");
   }
   const aaguidOk =
-    ctEq(ad.aaguid, AAGUID_PRODUCTION) ||
-    (allowDevelopment && ctEq(ad.aaguid, AAGUID_DEVELOPMENT));
+    ctEq(ad.aaguid, AAGUID_PRODUCTION) || (allowDevelopment && ctEq(ad.aaguid, AAGUID_DEVELOPMENT));
   if (!aaguidOk) {
     throw new AppAttestError(
       "bad-aaguid",
@@ -317,7 +323,10 @@ function parseAuthData(ad: Uint8Array): AuthData {
   const credIdLen = (ad[53]! << 8) | ad[54]!;
   const end = 55 + credIdLen;
   if (end > ad.length) {
-    throw new AppAttestError("short-auth-data", `authData too short for credId (${ad.length} bytes)`);
+    throw new AppAttestError(
+      "short-auth-data",
+      `authData too short for credId (${ad.length} bytes)`,
+    );
   }
   const credentialId = ad.slice(55, end);
   return { rpIdHash, aaguid, credentialId };

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./canonical.ts";
 export * from "./firehose.ts";
 export * from "./mda.ts";
+export * from "./appattest.ts";
 export * from "./p256.ts";
 export * from "./publish.ts";
 export * from "./seal.ts";

--- a/packages/sdk/src/mda.ts
+++ b/packages/sdk/src/mda.ts
@@ -248,14 +248,16 @@ function pemToDer(pem: string): Uint8Array {
   return Uint8Array.from(Buffer.from(stripped, "base64"));
 }
 
-interface DerExtension {
+export interface DerExtension {
   oid: string;
   value: Uint8Array;
 }
 
 /** Walk an X.509 certificate's DER and yield every extension. We
- *  only need OID + value, which lets us keep the parser minimal. */
-function parseExtensions(certDer: Uint8Array): DerExtension[] {
+ *  only need OID + value, which lets us keep the parser minimal.
+ *  Exported so the App Attest verifier (`appattest.ts`) can reuse the
+ *  same scanner to pull Apple's nonce extension from the credCert. */
+export function parseExtensions(certDer: Uint8Array): DerExtension[] {
   // X.509 layout (RFC 5280 §4.1):
   //   Certificate := SEQUENCE { tbs, sigAlg, sigValue }
   //   tbs := SEQUENCE { version, serial, sigAlg, issuer, validity,

--- a/packages/sdk/src/types.gen.ts
+++ b/packages/sdk/src/types.gen.ts
@@ -101,6 +101,7 @@ export interface AttestationRecord {
   authenticatedRootEnabled: boolean;
   rdmaDisabled?: boolean;
   mdaCertChain?: string[];
+  appAttest?: { object: string; keyId: string };
   selfSignature: string;
   attestedAt: string;
   expiresAt: string;

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -104,6 +104,10 @@ export interface AttestationRecord {
   authenticatedRootEnabled: boolean;
   rdmaDisabled?: boolean;
   mdaCertChain?: string[];
+  /** Apple App Attest evidence (CBOR `object` + `keyId`, both base64). The
+   *  MDM-free path to hardware-attested: bound to `publicKey` via
+   *  clientDataHash = sha256(publicKey). Absent on self-attested machines. */
+  appAttest?: { object: string; keyId: string };
   selfSignature: string;
   attestedAt: string;
   expiresAt: string;

--- a/packages/sdk/src/verify-provider.test.ts
+++ b/packages/sdk/src/verify-provider.test.ts
@@ -404,6 +404,62 @@ const CONF_FIXTURE = join(
   "confidential-attestation-fixture.json",
 );
 
+const CONF_APPATTEST_FIXTURE = join(
+  new URL(".", import.meta.url).pathname,
+  "..",
+  "..",
+  "..",
+  "target",
+  "confidential-appattest-fixture.json",
+);
+
+// The MDM-free parity test: a confidential attestation whose hardware
+// attestation is an App Attest object (no MDA chain) must ALSO verify as
+// attested-confidential, with the App Attest object bound to the signing key.
+test.skipIf(!existsSync(CONF_APPATTEST_FIXTURE))(
+  "cross-language: a Rust App-Attest confidential attestation verifies as attested-confidential",
+  async () => {
+    const f = JSON.parse(readFileSync(CONF_APPATTEST_FIXTURE, "utf-8"));
+    const appAttestRootDer = Uint8Array.from(Buffer.from(f.appAttestRootDerB64, "base64"));
+    const att = f.attestation as AttestationRecord;
+
+    // No MDA chain at all — hardware attestation comes solely from att.appAttest.
+    const noKey = await verifyProviderForSeal(att, undefined, {
+      requireConfidential: true,
+      requireCodeAttested: false,
+      knownGoodCdHashes: [f.knownGoodCdHash],
+      knownGoodMetallibHashes: [f.knownGoodMetallibHash],
+      knownGoodEngineLibHashes: [f.knownGoodEngineLibHash],
+      osFloor: f.osFloor,
+      appAttestTrustAnchorDer: appAttestRootDer,
+      now: () => new Date(),
+    });
+    assert.equal(
+      noKey.tier,
+      "attested-confidential",
+      `unexpected findings: ${JSON.stringify(noKey.findings)}`,
+    );
+    assert.equal(noKey.ok, true);
+    assert.equal(noKey.sealToKey, att.encryptionPubKey);
+
+    // App Attest is load-bearing: verify the SAME (untampered) attestation but
+    // against the real Apple App Attest root, which did not sign the synthetic
+    // object → it fails to verify, doesn't bind, and with no MDA fallback the
+    // result drops to best-effort. selfSignature still passes (publicKey is
+    // unchanged), so the only blocker is the missing hardware attestation.
+    const downgraded = await verifyProviderForSeal(att, undefined, {
+      requireConfidential: false, // observe the downgrade rather than throw
+      requireCodeAttested: false,
+      knownGoodCdHashes: [f.knownGoodCdHash],
+      // omit appAttestTrustAnchorDer → uses the embedded real Apple root
+      now: () => new Date(),
+    });
+    assert.equal(downgraded.tier, "best-effort");
+    assert.ok(codes(downgraded.findings).includes("no-mda-chain"));
+    assert.ok(!codes(downgraded.findings).includes("attestation-signature-invalid"));
+  },
+);
+
 test.skipIf(!existsSync(CONF_FIXTURE))(
   "cross-language: a Rust confidential attestation verifies as attested-confidential",
   async () => {

--- a/packages/sdk/src/verify-provider.ts
+++ b/packages/sdk/src/verify-provider.ts
@@ -33,6 +33,7 @@
 
 import { canonicalBytes } from "./canonical.ts";
 import { type MdaResult, verifyChain, verifyChainAgainst } from "./mda.ts";
+import { verifyAppAttestB64, APP_ATTEST_APP_ID } from "./appattest.ts";
 import { verifyAttestationSignature, verifyP256, SignatureVerifyError } from "./p256.ts";
 import type { AttestationRecord, Tier } from "./types.ts";
 import type { Finding, Severity, ValidationReport } from "./validate.ts";
@@ -115,6 +116,13 @@ export interface VerifyProviderOptions {
    *  cross-language fixture sets it to a synthetic root. Mirrors mda.ts's
    *  `verifyChainAgainst`. */
   trustAnchorDer?: Uint8Array;
+  /** ADVANCED / TEST ONLY. Verify the App Attest object against this DER trust
+   *  anchor instead of the embedded Apple App Attest Root. Production callers
+   *  leave this unset; the cross-language fixture sets a synthetic root. */
+  appAttestTrustAnchorDer?: Uint8Array;
+  /** Accept the development App Attest AAGUID in addition to production.
+   *  Default false (production only). Test/dev seam. */
+  allowDevelopmentAppAttest?: boolean;
 }
 
 export interface ProviderVerifyResult extends ValidationReport {
@@ -211,10 +219,34 @@ export async function verifyProviderForSeal(
     }
   }
 
-  // --- 1+2. MDA chain present, verifies, and is bound to the signing key. ---
+  // --- 1+2. Hardware attestation: a bound App Attest object OR a bound MDA
+  // chain. Either proves genuine Apple hardware tied to the signing key.
+  //
+  // App Attest (attestation.appAttest) is the MDM-free path: the helper set
+  // clientDataHash = sha256(publicKey), so a verifying object is bound to the
+  // signing key by construction (verifyAppAttestB64 checks the credCert nonce
+  // extension). If a bound App Attest object is present it SATISFIES the
+  // hardware-attestation requirement and the MDA gate is skipped; otherwise we
+  // fall back to the MDA chain exactly as before.
   let mda: MdaResult | undefined;
-  if (!mdaChain || mdaChain.length === 0) {
-    block("no-mda-chain", "attestation carries no MDA certificate chain");
+  const aa = attestation.appAttest;
+  const appAttestBinds =
+    !!aa &&
+    !!aa.object &&
+    !!aa.keyId &&
+    verifyAppAttestB64(aa.object, aa.keyId, attestation.publicKey, APP_ATTEST_APP_ID, {
+      trustAnchorDer: opts.appAttestTrustAnchorDer,
+      allowDevelopment: opts.allowDevelopmentAppAttest,
+      now,
+    });
+
+  if (appAttestBinds) {
+    // Hardware-attested via App Attest; no MDA chain required.
+  } else if (!mdaChain || mdaChain.length === 0) {
+    block(
+      "no-mda-chain",
+      "attestation carries no MDA certificate chain and no valid bound App Attest object",
+    );
   } else {
     try {
       const chainDer = mdaChain.map((b64) => base64ToBytes(b64));

--- a/provider/Cargo.lock
+++ b/provider/Cargo.lock
@@ -260,6 +260,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,6 +354,7 @@ dependencies = [
  "asn1-rs",
  "base64",
  "chrono",
+ "ciborium",
  "clap",
  "crypto_box",
  "dirs",
@@ -433,6 +461,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -874,6 +908,17 @@ dependencies = [
  "ff",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2131,7 +2176,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3150,7 +3195,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -84,6 +84,10 @@ x509-parser = { version = "0.16", features = ["verify"] }
 asn1-rs = "0.6"
 oid-registry = "0.7"
 
+# CBOR — decode the Apple App Attest attestation object (a CBOR map of
+# fmt / attStmt(x5c, receipt) / authData). Used by `appattest.rs`.
+ciborium = "0.2"
+
 # POSIX / libc — used for PT_DENY_ATTACH and rlimit calls on macOS
 libc = "0.2"
 

--- a/provider/spikes/app-attest/README.md
+++ b/provider/spikes/app-attest/README.md
@@ -1,0 +1,86 @@
+# App Attest companion (`cocore-appattest`)
+
+The MDM-free path to **`trustLevel: hardware-attested`**. This helper drives
+Apple's App Attest API to produce an attestation object that is *bound to the
+agent's receipt-signing key*, which the provider embeds in its
+`dev.cocore.compute.attestation` record (the `appAttest` field). The verifier
+(`appattest.rs` / `appattest.ts` / `appattest.py`) confirms it offline.
+
+## Why App Attest (not MDM/step-ca/SCEP)
+
+The hardware-attested flip is gated by **binding**: the Apple attestation must
+commit to *our* P-256 signing key, or a genuine Apple chain for an unrelated
+device could be stapled on. The MDM `device-attest-01` flow attests a *fresh
+ACME key* with an Apple-chosen nonce — neither binds to our signing key, so its
+chain verifies but is rejected by the binding gate.
+
+App Attest lets the app choose the attested data. We set
+
+```
+clientDataHash = SHA256(signingPubKeyBytes)   # the 64-byte raw P-256 X‖Y point
+```
+
+Apple commits that hash into the attestation's credential-certificate nonce
+extension (OID `1.2.840.113635.100.8.2`). The verifier recomputes
+`nonce = SHA256(authData ‖ SHA256(publicKey))` and requires it to equal that
+extension. That equality **is** the binding — by construction, no CA changes.
+
+### What it proves (and the ceiling)
+
+Proves: genuine, un-tampered Apple hardware holds a Secure-Enclave key, and our
+signing key is what was attested (via `clientDataHash`). Also binds the App ID /
+team. It does **not** by itself prove the signing key is SE-resident, nor that
+the running binary is honest — those remain carried by the SE-backed signing
+identity + hardened runtime + the cdHash known-good gate (the same
+self-measurement ceiling the MDA path has). `hardware-attested` means *genuine
+Apple hardware*, not *honest binary*.
+
+## One-time Apple Developer portal setup (ops)
+
+App Attest requires the entitlement
+`com.apple.developer.devicecheck.appattest-environment`, which must be
+**authorized by the embedded provisioning profile**. Same Team `4L45P7CP9M`,
+same App ID `dev.cocore.provider` already used for APNs.
+
+1. Apple Developer portal → Identifiers → `dev.cocore.provider` → enable the
+   **App Attest** capability (under DeviceCheck on some portal versions). Save.
+2. Profiles → regenerate the `dev.cocore.provider` provisioning profile so it
+   carries the new capability. Download it.
+3. Use that profile path with `build.sh` / `run.sh`.
+
+Until the profile authorizes it, `codesign` still succeeds but
+`DCAppAttestService.attestKey` returns an error at runtime.
+
+## Run
+
+```bash
+# Needs a real Apple-silicon Mac (App Attest is unsupported in VMs / on Intel).
+./run.sh ~/Downloads/cocore_provisioning_profile.provisionprofile
+```
+
+`run.sh` builds + signs the helper, reads the live signing pubkey via
+`cocore agent pubkey`, runs the helper, and writes a self-contained fixture to
+`target/appattest-device-fixture.json`:
+
+```json
+{
+  "object": "<base64 CBOR attestation object>",
+  "keyId": "<base64 App Attest key id>",
+  "publicKey": "<base64 64-byte signing pubkey it bound to>",
+  "clientDataHashHex": "...",
+  "appId": "4L45P7CP9M.dev.cocore.provider",
+  "environment": "production"
+}
+```
+
+That fixture is the real device vector the cross-language verifier tests run
+against (they otherwise use synthetic, self-rooted vectors). Point the Rust
+test at it with `COCORE_APPATTEST_FIXTURE=target/appattest-device-fixture.json`.
+
+## Production wiring
+
+The same binary ships inside the app bundle and is invoked by the agent via the
+`COCORE_APPATTEST_BINARY` env var (see `provider/src/mda_loader.rs`):
+`cocore-appattest <signing-pubkey-b64>` → JSON `{object, keyId}` on stdout. The
+agent verifies the object locally (same discipline as the MDA path — only embeds
+evidence it has itself confirmed binds) before publishing it.

--- a/provider/spikes/app-attest/build.sh
+++ b/provider/spikes/app-attest/build.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Build + Developer-ID-sign the cocore-appattest helper .app.
+#
+#   ./build.sh [path-to.provisionprofile]
+#
+# The profile MUST authorize com.apple.developer.devicecheck.appattest-environment
+# (regenerate the dev.cocore.provider profile in the Apple Developer portal with
+# the App Attest capability — see README.md). The same profile that carries the
+# APNs aps-environment can carry App Attest; you just re-add the capability and
+# regenerate.
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+PROFILE="${1:-$HOME/Downloads/cocore_provisioning_profile.provisionprofile}"
+IDENTITY="${COCORE_SIGN_IDENTITY:-Developer ID Application: DEVIN FRANCIS GAFFNEY (4L45P7CP9M)}"
+APP="$HERE/build/cocore-appattest.app"
+
+[ -f "$PROFILE" ] || { echo "provisioning profile not found: $PROFILE" >&2; exit 1; }
+
+rm -rf "$HERE/build"
+mkdir -p "$APP/Contents/MacOS"
+
+echo "==> compiling helper"
+swiftc -O "$HERE/helper/main.swift" -o "$APP/Contents/MacOS/cocore-appattest" \
+    -framework DeviceCheck -framework CryptoKit
+
+echo "==> assembling bundle"
+cp "$HERE/helper/Info.plist" "$APP/Contents/Info.plist"
+cp "$PROFILE"                "$APP/Contents/embedded.provisionprofile"
+
+echo "==> signing (Developer ID + hardened runtime + entitlements)"
+# runtime alone is fine here — this helper doesn't load third-party dylibs, and
+# App Attest only needs the entitlement to be authorized by the profile.
+codesign --force --options runtime --timestamp \
+    --entitlements "$HERE/helper/entitlements.plist" \
+    --sign "$IDENTITY" "$APP"
+
+echo "==> verifying signature + entitlements"
+codesign -dvvv "$APP" 2>&1 | grep -iE 'Identifier|TeamIdentifier|Authority=Developer' || true
+echo "--- entitlements ---"
+codesign -d --entitlements - --xml "$APP" 2>/dev/null | plutil -p - 2>/dev/null \
+    | grep -iE 'appattest|application-identifier|team-identifier' || true
+
+echo "built: $APP/Contents/MacOS/cocore-appattest"

--- a/provider/spikes/app-attest/helper/Info.plist
+++ b/provider/spikes/app-attest/helper/Info.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- MUST equal the provisioning profile's App ID suffix. The embedded
+         profile is 4L45P7CP9M.dev.cocore.provider (the same App ID used for
+         the APNs spike), now ALSO carrying the App Attest capability. -->
+    <key>CFBundleIdentifier</key>
+    <string>dev.cocore.provider</string>
+    <key>CFBundleName</key>
+    <string>cocore-appattest</string>
+    <key>CFBundleExecutable</key>
+    <string>cocore-appattest</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSUIElement</key>
+    <true/>
+    <key>LSMinimumSystemVersion</key>
+    <string>13.0</string>
+</dict>
+</plist>

--- a/provider/spikes/app-attest/helper/entitlements.plist
+++ b/provider/spikes/app-attest/helper/entitlements.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- The App Attest entitlement. AMFI/DeviceCheck only let
+         DCAppAttestService produce a genuine attestation when this is present
+         AND authorized by the embedded provisioning profile. For a Developer
+         ID (non-App-Store) build the value is "production", which attests
+         against Apple's production App Attest servers and yields the
+         production AAGUID ("appattest\0\0\0\0\0\0\0") in authData.
+
+         To get a profile that authorizes this you MUST, in the Apple Developer
+         portal: edit the dev.cocore.provider App ID, enable the "App Attest"
+         capability (App Attest has no separate toggle in some portal versions;
+         it rides under DeviceCheck), and regenerate the provisioning profile.
+         See ../README.md. Until the profile carries it, codesign will succeed
+         but DCAppAttestService.attestKey returns an error at runtime. -->
+    <key>com.apple.developer.devicecheck.appattest-environment</key>
+    <string>production</string>
+
+    <!-- These three MUST match the embedded provisioning profile exactly. -->
+    <key>com.apple.application-identifier</key>
+    <string>4L45P7CP9M.dev.cocore.provider</string>
+    <key>com.apple.developer.team-identifier</key>
+    <string>4L45P7CP9M</string>
+</dict>
+</plist>

--- a/provider/spikes/app-attest/helper/main.swift
+++ b/provider/spikes/app-attest/helper/main.swift
@@ -1,0 +1,122 @@
+// cocore-appattest — the App Attest companion helper.
+//
+// Purpose: produce an Apple App Attest attestation object BOUND to the
+// agent's receipt-signing P-256 key, so the provider can publish it in its
+// `dev.cocore.compute.attestation` record and earn trustLevel
+// `hardware-attested` — WITHOUT any MDM / step-ca / SCEP stack.
+//
+// The binding is by construction: we set
+//
+//     clientDataHash = SHA256(signingPubKeyBytes)
+//
+// where `signingPubKeyBytes` is the raw 64-byte P-256 X‖Y point the agent
+// publishes as `attestation.publicKey`. Apple commits that hash into the
+// attestation's credential-certificate nonce extension
+// (OID 1.2.840.113635.100.8.2). The verifier (appattest.rs / appattest.ts /
+// appattest.py) recomputes `nonce = SHA256(authData ‖ SHA256(publicKey))` and
+// requires it to equal that extension — that IS the binding to the signing
+// key. See lexicons/dev/cocore/compute/attestation.json#appAttest.
+//
+// I/O contract (also consumed by the Rust agent via COCORE_APPATTEST_BINARY):
+//   argv[1]  base64 of the raw 64-byte P-256 X‖Y signing public key
+//            (falls back to reading the same value from stdin if absent).
+//   stdout   a single JSON object:
+//              { "object": "<base64 CBOR attestation object>",
+//                "keyId":  "<base64 App Attest key id = SHA256(attested pubkey)>",
+//                "clientDataHashHex": "<hex>",
+//                "appId": "TEAMID.dev.cocore.provider",
+//                "environment": "production" }
+//   exit 0   success. Non-zero + a diagnostic on stderr otherwise (e.g. the
+//            device doesn't support App Attest, or the entitlement is missing).
+//
+// stderr may contain device-identifying material on error paths, so the agent
+// (mda_loader::load_appattest) deliberately does NOT route it to its logger.
+//
+// Build + sign: see ../build.sh. App Attest requires the entitlement
+// `com.apple.developer.devicecheck.appattest-environment`, which must be in the
+// embedded provisioning profile (regenerate the dev.cocore.provider profile in
+// the Apple Developer portal with the App Attest capability — see ../README.md).
+
+import CryptoKit
+import DeviceCheck
+import Foundation
+
+let APP_ID = "4L45P7CP9M.dev.cocore.provider"
+let ENVIRONMENT = "production"
+
+func die(_ msg: String) -> Never {
+    FileHandle.standardError.write(Data(("cocore-appattest: " + msg + "\n").utf8))
+    exit(1)
+}
+
+func readSigningPubKeyB64() -> String {
+    if CommandLine.arguments.count >= 2 {
+        let a = CommandLine.arguments[1].trimmingCharacters(in: .whitespacesAndNewlines)
+        if !a.isEmpty { return a }
+    }
+    // Fall back to stdin (one line / whitespace-trimmed).
+    let data = FileHandle.standardInput.readDataToEndOfFile()
+    let s = String(decoding: data, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
+    if s.isEmpty { die("no signing public key on argv[1] or stdin") }
+    return s
+}
+
+let pubKeyB64 = readSigningPubKeyB64()
+guard let pubKey = Data(base64Encoded: pubKeyB64) else {
+    die("argv[1]/stdin is not valid base64")
+}
+// The agent publishes the raw 64-byte X‖Y point. Tolerate the 65-byte
+// uncompressed-with-0x04-prefix form too, but bind to exactly what the
+// verifier will hash, which is the published `publicKey` bytes.
+if pubKey.count != 64 && !(pubKey.count == 65 && pubKey.first == 0x04) {
+    die("signing public key must be 64 raw P-256 bytes (X‖Y); got \(pubKey.count)")
+}
+
+let service = DCAppAttestService.shared
+guard service.isSupported else {
+    die("DCAppAttestService not supported on this device (needs Apple silicon + Secure Enclave, and a non-sandboxed signed build)")
+}
+
+// clientDataHash = SHA256(published signing pubkey). This is the value Apple
+// stamps into the credCert nonce extension; the verifier recomputes it.
+let clientDataHash = Data(SHA256.hash(data: pubKey))
+
+// generateKey → attestKey, both async completion-handler APIs; drive them
+// synchronously with a semaphore since this is a one-shot CLI.
+let sem = DispatchSemaphore(value: 0)
+var keyIdOut: String?
+var attestationOut: Data?
+var errOut: Error?
+
+service.generateKey { keyId, error in
+    if let error = error { errOut = error; sem.signal(); return }
+    guard let keyId = keyId else { errOut = nil; sem.signal(); return }
+    keyIdOut = keyId
+    service.attestKey(keyId, clientDataHash: clientDataHash) { attestation, error in
+        if let error = error { errOut = error }
+        attestationOut = attestation
+        sem.signal()
+    }
+}
+// Bounded wait so a wedged framework call can't hang the agent's boot.
+if sem.wait(timeout: .now() + 20) == .timedOut {
+    die("App Attest call timed out after 20s")
+}
+
+if let e = errOut { die("App Attest failed: \(e.localizedDescription)") }
+guard let keyId = keyIdOut else { die("generateKey returned no key id") }
+guard let attestation = attestationOut else { die("attestKey returned no attestation object") }
+
+// The Apple key id is already base64 (it is the SHA256 of the attested public
+// key). We emit it verbatim so `keyId` in the record decodes to that 32-byte
+// hash, which the verifier cross-checks against authData's credentialId.
+let out: [String: String] = [
+    "object": attestation.base64EncodedString(),
+    "keyId": keyId,
+    "clientDataHashHex": clientDataHash.map { String(format: "%02x", $0) }.joined(),
+    "appId": APP_ID,
+    "environment": ENVIRONMENT,
+]
+let json = try! JSONSerialization.data(withJSONObject: out, options: [.sortedKeys])
+FileHandle.standardOutput.write(json)
+FileHandle.standardOutput.write(Data("\n".utf8))

--- a/provider/spikes/app-attest/run.sh
+++ b/provider/spikes/app-attest/run.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Build + run the App Attest helper against this machine's REAL receipt-signing
+# key, and write a cross-language test fixture to target/appattest-device-fixture.json.
+#
+#   ./run.sh [path-to.provisionprofile]
+#
+# Prereqs:
+#   * Apple silicon Mac with a Secure Enclave (App Attest is unsupported in VMs
+#     and on Intel).
+#   * The dev.cocore.provider provisioning profile regenerated WITH the App
+#     Attest capability (see README.md). Without it the build still signs, but
+#     attestKey fails at runtime.
+#   * A built `cocore` agent on PATH (or set COCORE_BIN) so we can read the live
+#     signing pubkey via `cocore agent pubkey`. Falls back to a throwaway random
+#     key (smoke-test only — the resulting object won't bind to a real signer).
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$HERE/../../.." && pwd)"
+PROFILE="${1:-$HOME/Downloads/cocore_provisioning_profile.provisionprofile}"
+COCORE_BIN="${COCORE_BIN:-cocore}"
+OUT="$REPO/target/appattest-device-fixture.json"
+
+"$HERE/build.sh" "$PROFILE"
+HELPER="$HERE/build/cocore-appattest.app/Contents/MacOS/cocore-appattest"
+
+# Resolve the signing pubkey: prefer the live agent identity.
+if PUBKEY="$("$COCORE_BIN" agent pubkey 2>/dev/null)" && [ -n "$PUBKEY" ]; then
+    echo "==> using live signing pubkey from \`$COCORE_BIN agent pubkey\`"
+else
+    echo "==> WARNING: could not read live pubkey; generating a throwaway key (smoke test only)" >&2
+    PUBKEY="$(openssl ecparam -name prime256v1 -genkey -noout 2>/dev/null \
+        | openssl ec -pubout -outform DER 2>/dev/null \
+        | tail -c 65 | tail -c +2 | base64)"   # last 64 bytes = raw X‖Y
+fi
+
+echo "==> running App Attest helper"
+HELPER_JSON="$("$HELPER" "$PUBKEY")"
+echo "$HELPER_JSON" | python3 -m json.tool >/dev/null || { echo "helper did not emit valid JSON" >&2; exit 1; }
+
+mkdir -p "$REPO/target"
+# Bundle the helper output + the pubkey it bound to, so the verifier fixture is
+# self-contained.
+python3 - "$PUBKEY" <<PY > "$OUT"
+import json, sys
+helper = json.loads('''$HELPER_JSON''')
+helper["publicKey"] = sys.argv[1]
+print(json.dumps(helper, indent=2, sort_keys=True))
+PY
+
+echo "wrote $OUT"
+echo "--- fixture ---"
+python3 -m json.tool "$OUT"
+echo
+echo "Next: this fixture feeds the cross-language App Attest verifier tests."
+echo "  Rust: provider/src/appattest.rs honours COCORE_APPATTEST_FIXTURE=$OUT"

--- a/provider/src/appattest.rs
+++ b/provider/src/appattest.rs
@@ -1,0 +1,702 @@
+//! Apple App Attest attestation verification.
+//!
+//! The MDM-free path to `trustLevel: hardware-attested`. Parallel to
+//! [`crate::mda`] (which verifies an MDA x509 chain), this module verifies an
+//! Apple App Attest *attestation object* — a CBOR/WebAuthn-shaped blob produced
+//! by `DCAppAttestService` — and confirms it is **bound to the provider's
+//! receipt-signing key** via the credential certificate's nonce extension.
+//!
+//! ## Why a separate verifier
+//!
+//! App Attest is a different beast from MDA: a different Apple root (the App
+//! Attest Root CA, not the Enterprise Attestation Root), a CBOR container
+//! instead of a bare cert chain, and the key binding lives in a nonce that
+//! commits to a caller-chosen `clientDataHash` rather than in a freshness OID.
+//! The helper (`provider/spikes/app-attest`) sets
+//! `clientDataHash = sha256(signingPubKey)`, so the binding check here is:
+//!
+//! ```text
+//! nonce == sha256( authData ‖ sha256(signingPubKey) )   ==  credCert ext 1.2.840.113635.100.8.2
+//! ```
+//!
+//! ## Verification steps (Apple "Validating Apps That Connect to Your Server")
+//!
+//!   1. CBOR-decode the object; require `fmt == "apple-appattest"`.
+//!   2. Verify the `attStmt.x5c` chain (leaf = credCert, then the App Attest
+//!      intermediate) up to the embedded Apple App Attest Root CA: every
+//!      adjacent signature, validity windows, and BasicConstraints (leaf is an
+//!      end-entity, the issuer is a CA).
+//!   3. Recompute `nonce = sha256(authData ‖ clientDataHash)` where
+//!      `clientDataHash = sha256(signingPubKey)`, and require it to equal the
+//!      OCTET STRING inside the credCert's `1.2.840.113635.100.8.2` extension.
+//!      THIS is the binding to the signing key.
+//!   4. `credentialId` in authData == `sha256(credCert uncompressed pubkey)`,
+//!      and that also equals the claimed `keyId`.
+//!   5. authData's `rpIdHash == sha256(appId)`, the AAGUID is the genuine
+//!      App-Attest value (production by default), and the AT flag is set.
+//!
+//! What we deliberately do NOT do (matching the MDA module's posture): CRL/OCSP
+//! revocation (App Attest leaf certs are short-lived), and the App Attest
+//! *receipt* fraud-metric exchange with Apple (a v2 freshness concern — see the
+//! handoff). The object is self-verifying offline against the embedded root,
+//! honoring invariant #2.
+
+use sha2::{Digest, Sha256};
+use x509_parser::prelude::{FromDer, X509Certificate};
+
+/// Apple App Attest Root CA, P-384, valid 2020 → 2045.
+/// Source: <https://www.apple.com/certificateauthority/Apple_App_Attestation_Root_CA.pem>
+/// (SHA-256 fingerprint 1C:B9:82:3B:A2:8B:A6:AD:2D:33:A0:06:94:1D:E2:AE:4F:51:3E:F1:D4:E8:31:B9:F7:E0:FA:7B:62:42:C9:32).
+/// Distinct from the Enterprise Attestation Root the MDA path embeds — we ship both.
+pub const APPLE_APP_ATTEST_ROOT_CA_PEM: &str = concat!(
+    "-----BEGIN CERTIFICATE-----\n",
+    "MIICITCCAaegAwIBAgIQC/O+DvHN0uD7jG5yH2IXmDAKBggqhkjOPQQDAzBSMSYw\n",
+    "JAYDVQQDDB1BcHBsZSBBcHAgQXR0ZXN0YXRpb24gUm9vdCBDQTETMBEGA1UECgwK\n",
+    "QXBwbGUgSW5jLjETMBEGA1UECAwKQ2FsaWZvcm5pYTAeFw0yMDAzMTgxODMyNTNa\n",
+    "Fw00NTAzMTUwMDAwMDBaMFIxJjAkBgNVBAMMHUFwcGxlIEFwcCBBdHRlc3RhdGlv\n",
+    "biBSb290IENBMRMwEQYDVQQKDApBcHBsZSBJbmMuMRMwEQYDVQQIDApDYWxpZm9y\n",
+    "bmlhMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAERTHhmLW07ATaFQIEVwTtT4dyctdh\n",
+    "NbJhFs/Ii2FdCgAHGbpphY3+d8qjuDngIN3WVhQUBHAoMeQ/cLiP1sOUtgjqK9au\n",
+    "Yen1mMEvRq9Sk3Jm5X8U62H+xTD3FE9TgS41o0IwQDAPBgNVHRMBAf8EBTADAQH/\n",
+    "MB0GA1UdDgQWBBSskRBTM72+aEH/pwyp5frq5eWKoTAOBgNVHQ8BAf8EBAMCAQYw\n",
+    "CgYIKoZIzj0EAwMDaAAwZQIwQgFGnByvsiVbpTKwSga0kP0e8EeDS4+sQmTvb7vn\n",
+    "53O5+FRXgeLhpJ06ysC5PrOyAjEAp5U4xDgEgllF7En3VcE3iexZZtKeYnpqtijV\n",
+    "oyFraWVIyd/dganmrduC1bmTBGwD\n",
+    "-----END CERTIFICATE-----\n"
+);
+
+/// Apple's nonce extension OID 1.2.840.113635.100.8.2, as the pre-computed DER
+/// component suffix (same encoding scheme `mda.rs` uses for its OID constants).
+const OID_APP_ATTEST_NONCE: &[u8] = &[42, 134, 72, 134, 247, 99, 100, 8, 2];
+
+/// AAGUID stamped into authData for genuine production App Attest:
+/// ASCII "appattest" padded to 16 bytes with zeros.
+pub const AAGUID_PRODUCTION: &[u8; 16] =
+    &[0x61, 0x70, 0x70, 0x61, 0x74, 0x74, 0x65, 0x73, 0x74, 0, 0, 0, 0, 0, 0, 0];
+/// AAGUID for the development environment: ASCII "appattestdevelop" (16 bytes).
+pub const AAGUID_DEVELOPMENT: &[u8; 16] = b"appattestdevelop";
+
+/// WebAuthn authenticator-data "attested credential data included" flag.
+const FLAG_AT: u8 = 0x40;
+
+/// The cocore provider App ID — "TEAMID.bundleID". App Attest's rpIdHash is
+/// `sha256` of this; an attestation for any other App ID is rejected. Matches
+/// the entitlements in `provider/spikes/app-attest/helper/entitlements.plist`
+/// and `provider/cocore-provider.entitlements`.
+pub const APP_ATTEST_APP_ID: &str = "4L45P7CP9M.dev.cocore.provider";
+
+#[derive(Debug, Clone, Default)]
+pub struct AppAttestResult {
+    pub valid: bool,
+    /// The attested App Attest public key as the uncompressed EC point
+    /// (0x04‖X‖Y, 65 bytes). NB: this is the App Attest key, NOT the signing
+    /// key — the binding to the signing key is the nonce check, not this field.
+    pub attested_pubkey_uncompressed: Vec<u8>,
+    /// `sha256(attested_pubkey_uncompressed)` — equals the authData credentialId
+    /// and the claimed keyId.
+    pub key_id: Vec<u8>,
+    pub aaguid: Vec<u8>,
+    pub rp_id_hash: Vec<u8>,
+    /// True iff the nonce extension commits to `sha256(authData ‖ sha256(signingPubKey))`.
+    pub binds_signing_key: bool,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum AppAttestError {
+    #[error("CBOR decode: {0}")]
+    Cbor(String),
+    #[error("attestation object missing or malformed field: {0}")]
+    Shape(String),
+    #[error("unexpected fmt {0:?}, want \"apple-appattest\"")]
+    BadFmt(String),
+    #[error("parse trust anchor: {0}")]
+    BadTrustAnchor(String),
+    #[error("parse cert {index}: {message}")]
+    Parse { index: usize, message: String },
+    #[error("signature verification failed for cert {index}: {message}")]
+    BadSignature { index: usize, message: String },
+    #[error("cert {index} is not valid at {at}")]
+    NotValid { index: usize, at: String },
+    #[error("CA constraint violation for cert {index}: {message}")]
+    CaConstraint { index: usize, message: String },
+    #[error("credCert has no nonce extension (OID 1.2.840.113635.100.8.2)")]
+    NoNonceExtension,
+    #[error("malformed nonce extension")]
+    BadNonceExtension,
+    #[error("nonce mismatch: attestation is not bound to the signing key")]
+    NonceMismatch,
+    #[error("authData too short ({0} bytes)")]
+    ShortAuthData(usize),
+    #[error("attested-credential-data flag (AT) not set in authData")]
+    NoAttestedCredentialData,
+    #[error("unrecognized AAGUID {0} (not genuine App Attest hardware)")]
+    BadAaguid(String),
+    #[error("credentialId != sha256(attested pubkey)")]
+    CredIdMismatch,
+    #[error("keyId != credentialId")]
+    KeyIdMismatch,
+}
+
+/// Verify an App Attest object against the embedded Apple App Attest Root CA,
+/// at the current time, requiring the production AAGUID.
+///
+/// * `object_der` — the CBOR attestation object bytes.
+/// * `key_id` — the claimed App Attest key id (32 bytes, = sha256(attested pubkey)).
+/// * `signing_pubkey_raw` — the decoded `attestation.publicKey` (64-byte raw X‖Y).
+/// * `app_id` — "TEAMID.bundleID", e.g. "4L45P7CP9M.dev.cocore.provider".
+pub fn verify(
+    object_der: &[u8],
+    key_id: &[u8],
+    signing_pubkey_raw: &[u8],
+    app_id: &str,
+) -> Result<AppAttestResult, AppAttestError> {
+    let root_der = pem_to_der(APPLE_APP_ATTEST_ROOT_CA_PEM).map_err(AppAttestError::BadTrustAnchor)?;
+    verify_against(
+        object_der,
+        key_id,
+        signing_pubkey_raw,
+        app_id,
+        &root_der,
+        &chrono::Utc::now(),
+        false,
+    )
+}
+
+/// As [`verify`], but against a caller-supplied trust anchor / clock, and with
+/// the development AAGUID optionally allowed. The test path uses this with a
+/// synthetic root; the production path uses [`verify`].
+pub fn verify_against(
+    object_der: &[u8],
+    key_id: &[u8],
+    signing_pubkey_raw: &[u8],
+    app_id: &str,
+    root_ca_der: &[u8],
+    now: &chrono::DateTime<chrono::Utc>,
+    allow_development: bool,
+) -> Result<AppAttestResult, AppAttestError> {
+    // --- 1. CBOR-decode the attestation object. ---
+    let value: ciborium::value::Value =
+        ciborium::de::from_reader(object_der).map_err(|e| AppAttestError::Cbor(format!("{e}")))?;
+    let obj = AttestationObject::from_cbor(&value)?;
+    if obj.fmt != "apple-appattest" {
+        return Err(AppAttestError::BadFmt(obj.fmt));
+    }
+    if obj.x5c.is_empty() {
+        return Err(AppAttestError::Shape("attStmt.x5c is empty".into()));
+    }
+
+    // --- 2. Verify the x5c chain to the App Attest root. ---
+    let mut parsed: Vec<X509Certificate> = Vec::with_capacity(obj.x5c.len());
+    for (i, der) in obj.x5c.iter().enumerate() {
+        let (_, cert) = X509Certificate::from_der(der).map_err(|e| AppAttestError::Parse {
+            index: i,
+            message: format!("{e}"),
+        })?;
+        parsed.push(cert);
+    }
+    let (_, root) = X509Certificate::from_der(root_ca_der)
+        .map_err(|e| AppAttestError::BadTrustAnchor(format!("{e}")))?;
+
+    let now_unix = now.timestamp();
+    let valid_at = |cert: &X509Certificate, idx: usize| -> Result<(), AppAttestError> {
+        let nb = cert.validity().not_before.timestamp();
+        let na = cert.validity().not_after.timestamp();
+        if now_unix < nb || now_unix > na {
+            return Err(AppAttestError::NotValid {
+                index: idx,
+                at: now.to_rfc3339(),
+            });
+        }
+        Ok(())
+    };
+    for (i, cert) in parsed.iter().enumerate() {
+        valid_at(cert, i)?;
+    }
+    valid_at(&root, usize::MAX)?;
+
+    // certs[i] signed by certs[i+1]; top of chain signed by the root.
+    for i in 0..(parsed.len().saturating_sub(1)) {
+        parsed[i]
+            .verify_signature(Some(parsed[i + 1].public_key()))
+            .map_err(|e| AppAttestError::BadSignature {
+                index: i,
+                message: format!("{e:?}"),
+            })?;
+    }
+    let top = &parsed[parsed.len() - 1];
+    top.verify_signature(Some(root.public_key()))
+        .map_err(|e| AppAttestError::BadSignature {
+            index: parsed.len() - 1,
+            message: format!("{e:?}"),
+        })?;
+
+    // BasicConstraints: leaf is an end-entity, every issuer in the chain is a CA.
+    // Blocks the same leaf-as-issuer forgery the MDA verifier guards against.
+    use x509_parser::extensions::ParsedExtension;
+    for (i, cert) in parsed.iter().enumerate() {
+        let is_ca = cert.extensions().iter().any(
+            |ext| matches!(ext.parsed_extension(), ParsedExtension::BasicConstraints(bc) if bc.ca),
+        );
+        if i == 0 && is_ca {
+            return Err(AppAttestError::CaConstraint {
+                index: 0,
+                message: "leaf (credCert) must be an end-entity, not a CA".into(),
+            });
+        }
+        if i > 0 && !is_ca {
+            return Err(AppAttestError::CaConstraint {
+                index: i,
+                message: format!("chain cert {i} is not a CA but signs cert {}", i - 1),
+            });
+        }
+    }
+
+    let cred_cert = &parsed[0];
+
+    // --- 3. Recompute the nonce and check the credCert nonce extension. ---
+    // clientDataHash = sha256(signing pubkey) — the binding the helper chose.
+    let client_data_hash = Sha256::digest(signing_pubkey_raw);
+    let mut nonce_in = Vec::with_capacity(obj.auth_data.len() + 32);
+    nonce_in.extend_from_slice(&obj.auth_data);
+    nonce_in.extend_from_slice(&client_data_hash);
+    let expected_nonce = Sha256::digest(&nonce_in);
+
+    let nonce_ext = cred_cert
+        .extensions()
+        .iter()
+        .find(|ext| ext.oid.as_bytes() == OID_APP_ATTEST_NONCE)
+        .ok_or(AppAttestError::NoNonceExtension)?;
+    let got_nonce = parse_nonce_extension(nonce_ext.value).ok_or(AppAttestError::BadNonceExtension)?;
+    if !ct_eq(&got_nonce, expected_nonce.as_slice()) {
+        return Err(AppAttestError::NonceMismatch);
+    }
+
+    // --- 4. credCert pubkey → credentialId, cross-check authData + keyId. ---
+    let attested_pubkey = {
+        let raw = cred_cert.public_key().subject_public_key.data.as_ref();
+        if raw.len() != 65 || raw[0] != 0x04 {
+            return Err(AppAttestError::Shape(format!(
+                "credCert public key is not an uncompressed P-256 point ({} bytes)",
+                raw.len()
+            )));
+        }
+        raw.to_vec()
+    };
+    let pubkey_hash = Sha256::digest(&attested_pubkey);
+
+    // --- 5. Parse authData and validate rpIdHash / AAGUID / credentialId. ---
+    let ad = parse_auth_data(&obj.auth_data)?;
+    let rp_id_expected = Sha256::digest(app_id.as_bytes());
+    // rpIdHash mismatch is fatal — the attestation is for a different App ID.
+    if !ct_eq(&ad.rp_id_hash, rp_id_expected.as_slice()) {
+        return Err(AppAttestError::Shape("rpIdHash != sha256(appId)".into()));
+    }
+    let aaguid_ok = ad.aaguid == AAGUID_PRODUCTION
+        || (allow_development && ad.aaguid.as_slice() == AAGUID_DEVELOPMENT.as_slice());
+    if !aaguid_ok {
+        return Err(AppAttestError::BadAaguid(hex::encode(&ad.aaguid)));
+    }
+    if !ct_eq(&ad.credential_id, pubkey_hash.as_slice()) {
+        return Err(AppAttestError::CredIdMismatch);
+    }
+    if !ct_eq(key_id, pubkey_hash.as_slice()) {
+        return Err(AppAttestError::KeyIdMismatch);
+    }
+
+    Ok(AppAttestResult {
+        valid: true,
+        attested_pubkey_uncompressed: attested_pubkey,
+        key_id: pubkey_hash.to_vec(),
+        aaguid: ad.aaguid,
+        rp_id_hash: ad.rp_id_hash,
+        binds_signing_key: true,
+    })
+}
+
+/// Convenience: decode base64 `object` + `keyId` + `publicKey` and verify.
+/// Returns `true` iff the App Attest evidence is valid AND bound to `public_key_b64`.
+pub fn verify_b64(
+    object_b64: &str,
+    key_id_b64: &str,
+    public_key_b64: &str,
+    app_id: &str,
+) -> bool {
+    use base64::{engine::general_purpose::STANDARD as B64, Engine};
+    let (Ok(object), Ok(key_id), Ok(pubkey)) = (
+        B64.decode(object_b64),
+        B64.decode(key_id_b64),
+        B64.decode(public_key_b64),
+    ) else {
+        return false;
+    };
+    matches!(
+        verify(&object, &key_id, &pubkey, app_id),
+        Ok(res) if res.valid && res.binds_signing_key
+    )
+}
+
+// ---- internals ----
+
+struct AttestationObject {
+    fmt: String,
+    x5c: Vec<Vec<u8>>,
+    auth_data: Vec<u8>,
+}
+
+impl AttestationObject {
+    fn from_cbor(v: &ciborium::value::Value) -> Result<Self, AppAttestError> {
+        let map = v
+            .as_map()
+            .ok_or_else(|| AppAttestError::Shape("top-level is not a CBOR map".into()))?;
+        let get = |key: &str| map.iter().find(|(k, _)| k.as_text() == Some(key)).map(|(_, val)| val);
+
+        let fmt = get("fmt")
+            .and_then(|x| x.as_text())
+            .ok_or_else(|| AppAttestError::Shape("fmt".into()))?
+            .to_string();
+        let att_stmt = get("attStmt")
+            .and_then(|x| x.as_map())
+            .ok_or_else(|| AppAttestError::Shape("attStmt".into()))?;
+        let x5c_val = att_stmt
+            .iter()
+            .find(|(k, _)| k.as_text() == Some("x5c"))
+            .map(|(_, val)| val)
+            .and_then(|x| x.as_array())
+            .ok_or_else(|| AppAttestError::Shape("attStmt.x5c".into()))?;
+        let mut x5c = Vec::with_capacity(x5c_val.len());
+        for c in x5c_val {
+            x5c.push(
+                c.as_bytes()
+                    .ok_or_else(|| AppAttestError::Shape("attStmt.x5c[] not bytes".into()))?
+                    .clone(),
+            );
+        }
+        let auth_data = get("authData")
+            .and_then(|x| x.as_bytes())
+            .ok_or_else(|| AppAttestError::Shape("authData".into()))?
+            .clone();
+        Ok(AttestationObject { fmt, x5c, auth_data })
+    }
+}
+
+struct AuthData {
+    rp_id_hash: Vec<u8>,
+    aaguid: Vec<u8>,
+    credential_id: Vec<u8>,
+}
+
+fn parse_auth_data(ad: &[u8]) -> Result<AuthData, AppAttestError> {
+    // rpIdHash(32) | flags(1) | signCount(4) | aaguid(16) | credIdLen(2) | credId(L) | cose...
+    if ad.len() < 37 {
+        return Err(AppAttestError::ShortAuthData(ad.len()));
+    }
+    let rp_id_hash = ad[0..32].to_vec();
+    let flags = ad[32];
+    if flags & FLAG_AT == 0 {
+        return Err(AppAttestError::NoAttestedCredentialData);
+    }
+    if ad.len() < 55 {
+        return Err(AppAttestError::ShortAuthData(ad.len()));
+    }
+    let aaguid = ad[37..53].to_vec();
+    let cred_id_len = u16::from_be_bytes([ad[53], ad[54]]) as usize;
+    let end = 55usize
+        .checked_add(cred_id_len)
+        .filter(|&e| e <= ad.len())
+        .ok_or(AppAttestError::ShortAuthData(ad.len()))?;
+    let credential_id = ad[55..end].to_vec();
+    Ok(AuthData {
+        rp_id_hash,
+        aaguid,
+        credential_id,
+    })
+}
+
+/// The credCert nonce extension's extnValue is DER:
+/// `SEQUENCE { [1] EXPLICIT OCTET STRING <nonce> }`. Walk it strictly.
+fn parse_nonce_extension(ext_value: &[u8]) -> Option<Vec<u8>> {
+    let (tag, seq_body, _) = read_tlv(ext_value)?;
+    if tag != 0x30 {
+        return None; // SEQUENCE
+    }
+    let (tag, ctx_body, _) = read_tlv(seq_body)?;
+    if tag != 0xA1 {
+        return None; // [1] constructed (context-specific)
+    }
+    let (tag, octets, _) = read_tlv(ctx_body)?;
+    if tag != 0x04 {
+        return None; // OCTET STRING
+    }
+    if octets.len() != 32 {
+        return None; // App Attest nonce is sha256 → 32 bytes
+    }
+    Some(octets.to_vec())
+}
+
+/// Minimal strict DER TLV reader. Returns `(tag, value, rest)`. Handles
+/// short-form and long-form definite lengths; rejects indefinite length.
+fn read_tlv(data: &[u8]) -> Option<(u8, &[u8], &[u8])> {
+    if data.len() < 2 {
+        return None;
+    }
+    let tag = data[0];
+    let first_len = data[1];
+    let (len, header) = if first_len & 0x80 == 0 {
+        (first_len as usize, 2usize)
+    } else {
+        let n = (first_len & 0x7f) as usize;
+        if n == 0 || n > 4 || data.len() < 2 + n {
+            return None; // indefinite (0) or implausibly large
+        }
+        let mut l = 0usize;
+        for &b in &data[2..2 + n] {
+            l = (l << 8) | b as usize;
+        }
+        (l, 2 + n)
+    };
+    let end = header.checked_add(len)?;
+    if end > data.len() {
+        return None;
+    }
+    Some((tag, &data[header..end], &data[end..]))
+}
+
+/// Constant-time byte-slice equality (length-checked).
+fn ct_eq(a: &[u8], b: &[u8]) -> bool {
+    a.len() == b.len() && a.iter().zip(b.iter()).fold(0u8, |acc, (x, y)| acc | (x ^ y)) == 0
+}
+
+fn pem_to_der(pem: &str) -> Result<Vec<u8>, String> {
+    let mut acc = String::new();
+    let mut in_block = false;
+    for line in pem.lines() {
+        if line.starts_with("-----BEGIN") {
+            in_block = true;
+            continue;
+        }
+        if line.starts_with("-----END") {
+            break;
+        }
+        if in_block {
+            acc.push_str(line.trim());
+        }
+    }
+    use base64::{engine::general_purpose::STANDARD as B64, Engine};
+    B64.decode(acc).map_err(|e| format!("base64: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rcgen::{
+        BasicConstraints, CertificateParams, CustomExtension, DistinguishedName, DnType, IsCa,
+        KeyPair, PKCS_ECDSA_P256_SHA256,
+    };
+    use x509_parser::prelude::SubjectPublicKeyInfo;
+
+    const TEST_APP_ID: &str = "4L45P7CP9M.dev.cocore.provider";
+
+    /// DER-encode `SEQUENCE { [1] EXPLICIT OCTET STRING <nonce> }`, the shape of
+    /// Apple's credCert nonce extension extnValue.
+    fn nonce_extension_der(nonce: &[u8]) -> Vec<u8> {
+        // OCTET STRING
+        let mut os = vec![0x04, nonce.len() as u8];
+        os.extend_from_slice(nonce);
+        // [1] EXPLICIT wrapping the OCTET STRING
+        let mut ctx = vec![0xA1, os.len() as u8];
+        ctx.extend_from_slice(&os);
+        // SEQUENCE wrapping that
+        let mut seq = vec![0x30, ctx.len() as u8];
+        seq.extend_from_slice(&ctx);
+        seq
+    }
+
+    fn uncompressed_point(key: &KeyPair) -> Vec<u8> {
+        let spki = key.public_key_der();
+        let (_, info) = SubjectPublicKeyInfo::from_der(&spki).unwrap();
+        info.subject_public_key.data.to_vec()
+    }
+
+    /// Build a full synthetic App Attest attestation object bound to
+    /// `signing_pubkey`, returning `(object_cbor, key_id, root_der)`.
+    fn synth_object(signing_pubkey: &[u8], aaguid: &[u8; 16]) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+        let now = time::OffsetDateTime::now_utc();
+        let nb = now - time::Duration::HOUR;
+        let na = now + time::Duration::days(365);
+
+        // Root (CA).
+        let mut root_params = CertificateParams::new(vec!["Test AppAttest Root".into()]).unwrap();
+        root_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        root_params.not_before = nb;
+        root_params.not_after = na;
+        let root_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+        let root_cert = root_params.self_signed(&root_key).unwrap();
+
+        // Intermediate (CA, signed by root).
+        let mut int_params = CertificateParams::new(vec!["Test AppAttest CA".into()]).unwrap();
+        int_params.is_ca = IsCa::Ca(BasicConstraints::Constrained(0));
+        int_params.not_before = nb;
+        int_params.not_after = na;
+        let int_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+        let int_cert = int_params.signed_by(&int_key, &root_cert, &root_key).unwrap();
+
+        // Leaf (credCert): generate its key first so we can derive credentialId
+        // and the authData the nonce commits to.
+        let leaf_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+        let leaf_point = uncompressed_point(&leaf_key);
+        let cred_id = Sha256::digest(&leaf_point).to_vec();
+
+        // authData = rpIdHash | flags(AT) | signCount=0 | aaguid | credIdLen | credId
+        let mut auth_data = Vec::new();
+        auth_data.extend_from_slice(Sha256::digest(TEST_APP_ID.as_bytes()).as_slice());
+        auth_data.push(FLAG_AT);
+        auth_data.extend_from_slice(&0u32.to_be_bytes());
+        auth_data.extend_from_slice(aaguid);
+        auth_data.extend_from_slice(&(cred_id.len() as u16).to_be_bytes());
+        auth_data.extend_from_slice(&cred_id);
+
+        // nonce = sha256(authData || sha256(signing pubkey))
+        let client_data_hash = Sha256::digest(signing_pubkey);
+        let mut nonce_in = auth_data.clone();
+        nonce_in.extend_from_slice(&client_data_hash);
+        let nonce = Sha256::digest(&nonce_in).to_vec();
+
+        // Leaf cert with the nonce extension.
+        let mut leaf_params = CertificateParams::new(vec!["credCert".into()]).unwrap();
+        let mut dn = DistinguishedName::new();
+        dn.push(DnType::CommonName, "credCert");
+        leaf_params.distinguished_name = dn;
+        leaf_params.is_ca = IsCa::NoCa;
+        leaf_params.not_before = nb;
+        leaf_params.not_after = na;
+        const NONCE_OID: &[u64] = &[1, 2, 840, 113635, 100, 8, 2];
+        let mut ext = CustomExtension::from_oid_content(NONCE_OID, nonce_extension_der(&nonce));
+        ext.set_criticality(false);
+        leaf_params.custom_extensions.push(ext);
+        let leaf_cert = leaf_params.signed_by(&leaf_key, &int_cert, &int_key).unwrap();
+
+        // CBOR object.
+        use ciborium::value::Value;
+        let obj = Value::Map(vec![
+            (Value::Text("fmt".into()), Value::Text("apple-appattest".into())),
+            (
+                Value::Text("attStmt".into()),
+                Value::Map(vec![
+                    (
+                        Value::Text("x5c".into()),
+                        Value::Array(vec![
+                            Value::Bytes(leaf_cert.der().to_vec()),
+                            Value::Bytes(int_cert.der().to_vec()),
+                        ]),
+                    ),
+                    (Value::Text("receipt".into()), Value::Bytes(vec![])),
+                ]),
+            ),
+            (Value::Text("authData".into()), Value::Bytes(auth_data)),
+        ]);
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&obj, &mut buf).unwrap();
+        (buf, cred_id, root_cert.der().to_vec())
+    }
+
+    fn now() -> chrono::DateTime<chrono::Utc> {
+        chrono::Utc::now()
+    }
+
+    #[test]
+    fn embedded_app_attest_root_parses() {
+        let der = pem_to_der(APPLE_APP_ATTEST_ROOT_CA_PEM).unwrap();
+        let (_, cert) = X509Certificate::from_der(&der).unwrap();
+        let cn: Vec<&str> = cert
+            .subject()
+            .iter_common_name()
+            .filter_map(|c| c.attr_value().as_str().ok())
+            .collect();
+        assert!(cn.iter().any(|s| s.contains("Apple App Attestation")));
+    }
+
+    #[test]
+    fn happy_path_binds_and_verifies() {
+        let signing = vec![7u8; 64];
+        let (object, key_id, root) = synth_object(&signing, AAGUID_PRODUCTION);
+        let res = verify_against(&object, &key_id, &signing, TEST_APP_ID, &root, &now(), false)
+            .expect("should verify");
+        assert!(res.valid);
+        assert!(res.binds_signing_key);
+        assert_eq!(res.key_id, key_id);
+        assert_eq!(res.aaguid, AAGUID_PRODUCTION.to_vec());
+    }
+
+    #[test]
+    fn wrong_signing_key_breaks_binding() {
+        // Object bound to `signing`; verify with a DIFFERENT key → nonce mismatch.
+        let signing = vec![7u8; 64];
+        let (object, key_id, root) = synth_object(&signing, AAGUID_PRODUCTION);
+        let other = vec![9u8; 64];
+        let err = verify_against(&object, &key_id, &other, TEST_APP_ID, &root, &now(), false)
+            .unwrap_err();
+        assert!(matches!(err, AppAttestError::NonceMismatch), "got {err:?}");
+    }
+
+    #[test]
+    fn wrong_root_rejects() {
+        let signing = vec![7u8; 64];
+        let (object, key_id, _root) = synth_object(&signing, AAGUID_PRODUCTION);
+        // Verify against Apple's real root, which did not sign the synthetic chain.
+        let apple = pem_to_der(APPLE_APP_ATTEST_ROOT_CA_PEM).unwrap();
+        let err = verify_against(&object, &key_id, &signing, TEST_APP_ID, &apple, &now(), false)
+            .unwrap_err();
+        assert!(matches!(err, AppAttestError::BadSignature { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn wrong_app_id_rejected() {
+        let signing = vec![7u8; 64];
+        let (object, key_id, root) = synth_object(&signing, AAGUID_PRODUCTION);
+        let err = verify_against(
+            &object,
+            &key_id,
+            &signing,
+            "4L45P7CP9M.com.evil.fork",
+            &root,
+            &now(),
+            false,
+        )
+        .unwrap_err();
+        assert!(matches!(err, AppAttestError::Shape(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn development_aaguid_rejected_unless_allowed() {
+        let signing = vec![7u8; 64];
+        let (object, key_id, root) = synth_object(&signing, AAGUID_DEVELOPMENT);
+        // Default (production-only) rejects the development AAGUID.
+        let err = verify_against(&object, &key_id, &signing, TEST_APP_ID, &root, &now(), false)
+            .unwrap_err();
+        assert!(matches!(err, AppAttestError::BadAaguid(_)), "got {err:?}");
+        // With allow_development it passes.
+        let res = verify_against(&object, &key_id, &signing, TEST_APP_ID, &root, &now(), true)
+            .expect("dev aaguid allowed");
+        assert!(res.valid);
+    }
+
+    #[test]
+    fn wrong_key_id_rejected() {
+        let signing = vec![7u8; 64];
+        let (object, _key_id, root) = synth_object(&signing, AAGUID_PRODUCTION);
+        let bogus = vec![0u8; 32];
+        let err = verify_against(&object, &bogus, &signing, TEST_APP_ID, &root, &now(), false)
+            .unwrap_err();
+        assert!(matches!(err, AppAttestError::KeyIdMismatch), "got {err:?}");
+    }
+
+    #[test]
+    fn parse_nonce_extension_walks_der() {
+        let nonce = vec![0xABu8; 32];
+        let der = nonce_extension_der(&nonce);
+        assert_eq!(parse_nonce_extension(&der), Some(nonce));
+        // A 31-byte "nonce" (wrong length) is rejected.
+        let bad = nonce_extension_der(&vec![0u8; 31]);
+        assert_eq!(parse_nonce_extension(&bad), None);
+    }
+}

--- a/provider/src/appattest.rs
+++ b/provider/src/appattest.rs
@@ -71,8 +71,9 @@ const OID_APP_ATTEST_NONCE: &[u8] = &[42, 134, 72, 134, 247, 99, 100, 8, 2];
 
 /// AAGUID stamped into authData for genuine production App Attest:
 /// ASCII "appattest" padded to 16 bytes with zeros.
-pub const AAGUID_PRODUCTION: &[u8; 16] =
-    &[0x61, 0x70, 0x70, 0x61, 0x74, 0x74, 0x65, 0x73, 0x74, 0, 0, 0, 0, 0, 0, 0];
+pub const AAGUID_PRODUCTION: &[u8; 16] = &[
+    0x61, 0x70, 0x70, 0x61, 0x74, 0x74, 0x65, 0x73, 0x74, 0, 0, 0, 0, 0, 0, 0,
+];
 /// AAGUID for the development environment: ASCII "appattestdevelop" (16 bytes).
 pub const AAGUID_DEVELOPMENT: &[u8; 16] = b"appattestdevelop";
 
@@ -150,7 +151,8 @@ pub fn verify(
     signing_pubkey_raw: &[u8],
     app_id: &str,
 ) -> Result<AppAttestResult, AppAttestError> {
-    let root_der = pem_to_der(APPLE_APP_ATTEST_ROOT_CA_PEM).map_err(AppAttestError::BadTrustAnchor)?;
+    let root_der =
+        pem_to_der(APPLE_APP_ATTEST_ROOT_CA_PEM).map_err(AppAttestError::BadTrustAnchor)?;
     verify_against(
         object_der,
         key_id,
@@ -266,7 +268,8 @@ pub fn verify_against(
         .iter()
         .find(|ext| ext.oid.as_bytes() == OID_APP_ATTEST_NONCE)
         .ok_or(AppAttestError::NoNonceExtension)?;
-    let got_nonce = parse_nonce_extension(nonce_ext.value).ok_or(AppAttestError::BadNonceExtension)?;
+    let got_nonce =
+        parse_nonce_extension(nonce_ext.value).ok_or(AppAttestError::BadNonceExtension)?;
     if !ct_eq(&got_nonce, expected_nonce.as_slice()) {
         return Err(AppAttestError::NonceMismatch);
     }
@@ -315,12 +318,7 @@ pub fn verify_against(
 
 /// Convenience: decode base64 `object` + `keyId` + `publicKey` and verify.
 /// Returns `true` iff the App Attest evidence is valid AND bound to `public_key_b64`.
-pub fn verify_b64(
-    object_b64: &str,
-    key_id_b64: &str,
-    public_key_b64: &str,
-    app_id: &str,
-) -> bool {
+pub fn verify_b64(object_b64: &str, key_id_b64: &str, public_key_b64: &str, app_id: &str) -> bool {
     use base64::{engine::general_purpose::STANDARD as B64, Engine};
     let (Ok(object), Ok(key_id), Ok(pubkey)) = (
         B64.decode(object_b64),
@@ -348,7 +346,11 @@ impl AttestationObject {
         let map = v
             .as_map()
             .ok_or_else(|| AppAttestError::Shape("top-level is not a CBOR map".into()))?;
-        let get = |key: &str| map.iter().find(|(k, _)| k.as_text() == Some(key)).map(|(_, val)| val);
+        let get = |key: &str| {
+            map.iter()
+                .find(|(k, _)| k.as_text() == Some(key))
+                .map(|(_, val)| val)
+        };
 
         let fmt = get("fmt")
             .and_then(|x| x.as_text())
@@ -375,7 +377,11 @@ impl AttestationObject {
             .and_then(|x| x.as_bytes())
             .ok_or_else(|| AppAttestError::Shape("authData".into()))?
             .clone();
-        Ok(AttestationObject { fmt, x5c, auth_data })
+        Ok(AttestationObject {
+            fmt,
+            x5c,
+            auth_data,
+        })
     }
 }
 
@@ -463,7 +469,11 @@ fn read_tlv(data: &[u8]) -> Option<(u8, &[u8], &[u8])> {
 
 /// Constant-time byte-slice equality (length-checked).
 fn ct_eq(a: &[u8], b: &[u8]) -> bool {
-    a.len() == b.len() && a.iter().zip(b.iter()).fold(0u8, |acc, (x, y)| acc | (x ^ y)) == 0
+    a.len() == b.len()
+        && a.iter()
+            .zip(b.iter())
+            .fold(0u8, |acc, (x, y)| acc | (x ^ y))
+            == 0
 }
 
 fn pem_to_der(pem: &str) -> Result<Vec<u8>, String> {
@@ -538,7 +548,9 @@ mod tests {
         int_params.not_before = nb;
         int_params.not_after = na;
         let int_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
-        let int_cert = int_params.signed_by(&int_key, &root_cert, &root_key).unwrap();
+        let int_cert = int_params
+            .signed_by(&int_key, &root_cert, &root_key)
+            .unwrap();
 
         // Leaf (credCert): generate its key first so we can derive credentialId
         // and the authData the nonce commits to.
@@ -573,12 +585,17 @@ mod tests {
         let mut ext = CustomExtension::from_oid_content(NONCE_OID, nonce_extension_der(&nonce));
         ext.set_criticality(false);
         leaf_params.custom_extensions.push(ext);
-        let leaf_cert = leaf_params.signed_by(&leaf_key, &int_cert, &int_key).unwrap();
+        let leaf_cert = leaf_params
+            .signed_by(&leaf_key, &int_cert, &int_key)
+            .unwrap();
 
         // CBOR object.
         use ciborium::value::Value;
         let obj = Value::Map(vec![
-            (Value::Text("fmt".into()), Value::Text("apple-appattest".into())),
+            (
+                Value::Text("fmt".into()),
+                Value::Text("apple-appattest".into()),
+            ),
             (
                 Value::Text("attStmt".into()),
                 Value::Map(vec![
@@ -619,8 +636,16 @@ mod tests {
     fn happy_path_binds_and_verifies() {
         let signing = vec![7u8; 64];
         let (object, key_id, root) = synth_object(&signing, AAGUID_PRODUCTION);
-        let res = verify_against(&object, &key_id, &signing, TEST_APP_ID, &root, &now(), false)
-            .expect("should verify");
+        let res = verify_against(
+            &object,
+            &key_id,
+            &signing,
+            TEST_APP_ID,
+            &root,
+            &now(),
+            false,
+        )
+        .expect("should verify");
         assert!(res.valid);
         assert!(res.binds_signing_key);
         assert_eq!(res.key_id, key_id);
@@ -644,9 +669,20 @@ mod tests {
         let (object, key_id, _root) = synth_object(&signing, AAGUID_PRODUCTION);
         // Verify against Apple's real root, which did not sign the synthetic chain.
         let apple = pem_to_der(APPLE_APP_ATTEST_ROOT_CA_PEM).unwrap();
-        let err = verify_against(&object, &key_id, &signing, TEST_APP_ID, &apple, &now(), false)
-            .unwrap_err();
-        assert!(matches!(err, AppAttestError::BadSignature { .. }), "got {err:?}");
+        let err = verify_against(
+            &object,
+            &key_id,
+            &signing,
+            TEST_APP_ID,
+            &apple,
+            &now(),
+            false,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, AppAttestError::BadSignature { .. }),
+            "got {err:?}"
+        );
     }
 
     #[test]
@@ -671,8 +707,16 @@ mod tests {
         let signing = vec![7u8; 64];
         let (object, key_id, root) = synth_object(&signing, AAGUID_DEVELOPMENT);
         // Default (production-only) rejects the development AAGUID.
-        let err = verify_against(&object, &key_id, &signing, TEST_APP_ID, &root, &now(), false)
-            .unwrap_err();
+        let err = verify_against(
+            &object,
+            &key_id,
+            &signing,
+            TEST_APP_ID,
+            &root,
+            &now(),
+            false,
+        )
+        .unwrap_err();
         assert!(matches!(err, AppAttestError::BadAaguid(_)), "got {err:?}");
         // With allow_development it passes.
         let res = verify_against(&object, &key_id, &signing, TEST_APP_ID, &root, &now(), true)
@@ -696,7 +740,7 @@ mod tests {
         let der = nonce_extension_der(&nonce);
         assert_eq!(parse_nonce_extension(&der), Some(nonce));
         // A 31-byte "nonce" (wrong length) is rejected.
-        let bad = nonce_extension_der(&vec![0u8; 31]);
+        let bad = nonce_extension_der(&[0u8; 31]);
         assert_eq!(parse_nonce_extension(&bad), None);
     }
 }

--- a/provider/src/attestation.rs
+++ b/provider/src/attestation.rs
@@ -17,6 +17,15 @@ use serde::Serialize;
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 
+/// Apple App Attest evidence as it rides in the record. Field names match the
+/// lexicon's `appAttest` object (`{ object, keyId }`), both base64.
+#[allow(non_snake_case)]
+#[derive(Debug, Clone, Serialize)]
+pub struct AppAttestEvidence {
+    pub object: String,
+    pub keyId: String,
+}
+
 #[derive(Debug, Clone)]
 pub struct AttestationInputs {
     pub provider_did: String,
@@ -32,6 +41,11 @@ pub struct AttestationInputs {
     pub authenticated_root_enabled: bool,
     pub rdma_disabled: bool,
     pub mda_cert_chain: Vec<Vec<u8>>,
+    /// Optional Apple App Attest evidence (base64 CBOR `object` + `keyId`),
+    /// acquired via [`crate::mda_loader::load_appattest`]. Embedded only if it
+    /// verifies Apple-App-Attest-rooted AND binds to this signer; the
+    /// MDM-free path to hardware-attested.
+    pub app_attest: Option<AppAttestEvidence>,
     // --- WS-CDHASH: OS-enforced measured identity + hardened-runtime posture
     // (read live via `codesign::read_self`). ---
     pub cd_hash: Option<String>,
@@ -73,6 +87,8 @@ pub struct AttestationRecord {
     pub rdmaDisabled: bool,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub mdaCertChain: Vec<String>, // base64
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub appAttest: Option<AppAttestEvidence>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cdHash: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -166,6 +182,7 @@ pub fn build_stub_inputs(provider_did: &str, encryption_pub_key_b64: &str) -> At
         authenticated_root_enabled: false,
         rdma_disabled: true,
         mda_cert_chain: Vec::new(),
+        app_attest: None,
         cd_hash: cs.cd_hash,
         team_id: cs.team_id,
         hardened_runtime: cs.hardened_runtime,
@@ -255,6 +272,31 @@ pub fn build(
     };
     let mda_chain_b64: Vec<String> = mda_chain.iter().map(|c| B64.encode(c)).collect();
 
+    // App Attest evidence — the MDM-free path to hardware-attested. Same
+    // discipline as the MDA chain: embed it ONLY if it verifies
+    // Apple-App-Attest-rooted AND binds to this signing key (its credCert nonce
+    // commits to sha256(signing pubkey)). An object that doesn't bind is a
+    // hardware claim for the wrong key, so drop it and stay self-attested.
+    let app_attest: Option<AppAttestEvidence> = match &inputs.app_attest {
+        None => None,
+        Some(ev) => {
+            if crate::appattest::verify_b64(
+                &ev.object,
+                &ev.keyId,
+                &public_key_b64,
+                crate::appattest::APP_ATTEST_APP_ID,
+            ) {
+                Some(ev.clone())
+            } else {
+                tracing::warn!(
+                    "App Attest evidence failed verification or is not bound to our signing key; \
+                     dropping it and staying self-attested on the App Attest path"
+                );
+                None
+            }
+        }
+    };
+
     // Producer's HONEST self-asserted tier. `attested-confidential` is the
     // CONFIDENTIALITY axis — "the prompt is handled only inside this measured,
     // signed binary, and the operator can't read it." It is ORTHOGONAL to
@@ -328,6 +370,12 @@ pub fn build(
         if let Some(eh) = &inputs.engine_lib_hash {
             map.insert("engineLibHash".into(), Value::String(eh.clone()));
         }
+        if let Some(ev) = &app_attest {
+            map.insert(
+                "appAttest".into(),
+                json!({ "object": ev.object, "keyId": ev.keyId }),
+            );
+        }
     }
     let canonical = to_canonical_bytes(&unsigned)?;
     let sig = signer
@@ -348,6 +396,7 @@ pub fn build(
         authenticatedRootEnabled: inputs.authenticated_root_enabled,
         rdmaDisabled: inputs.rdma_disabled,
         mdaCertChain: mda_chain_b64,
+        appAttest: app_attest,
         cdHash: inputs.cd_hash,
         teamId: inputs.team_id,
         hardenedRuntime: inputs.hardened_runtime,
@@ -415,6 +464,7 @@ mod tests {
             authenticated_root_enabled: true,
             rdma_disabled: true,
             mda_cert_chain: vec![],
+            app_attest: None,
             cd_hash: Some("ab".repeat(20)),
             team_id: Some("TEAM123456".into()),
             hardened_runtime: true,
@@ -461,6 +511,7 @@ mod tests {
             authenticated_root_enabled: true,
             rdma_disabled: true,
             mda_cert_chain: vec![b"leaf-cert-der".to_vec(), b"intermediate-cert-der".to_vec()],
+            app_attest: None,
             cd_hash: Some("cd".repeat(20)),
             team_id: None,
             hardened_runtime: true,
@@ -486,6 +537,53 @@ mod tests {
         assert_eq!(
             rec.tier, "attested-confidential",
             "a full confidential posture earns the tier regardless of the MDA chain"
+        );
+    }
+
+    #[test]
+    fn unverifiable_app_attest_is_dropped_not_embedded() {
+        // Same discipline as the MDA chain: bogus App Attest evidence (not an
+        // Apple-App-Attest-rooted, signer-bound object) must be dropped, leaving
+        // the record self-attested with no `appAttest`. The positive embed path
+        // needs a real Apple-rooted object (real device / cross-lang fixture).
+        let _g = identity_lock();
+        let signer = load_or_create_identity().unwrap();
+        let mut inputs = AttestationInputs {
+            provider_did: "did:plc:test".into(),
+            encryption_pub_key_b64: "abc".into(),
+            chip_name: "Apple M4".into(),
+            hardware_model: "Mac15,12".into(),
+            serial_number: "AA-TEST".into(),
+            os_version: "26.0".into(),
+            binary_path: std::path::PathBuf::from("/nonexistent"),
+            sip_enabled: true,
+            secure_boot_enabled: true,
+            secure_enclave_available: true,
+            authenticated_root_enabled: true,
+            rdma_disabled: true,
+            mda_cert_chain: vec![],
+            app_attest: None,
+            cd_hash: Some("cd".repeat(20)),
+            team_id: None,
+            hardened_runtime: true,
+            library_validation: true,
+            get_task_allow: false,
+            metallib_hash: None,
+            engine_lib_hash: None,
+            in_process_backend: true,
+            anti_debug: true,
+            core_dumps_disabled: true,
+            env_scrubbed: true,
+        };
+        use base64::{engine::general_purpose::STANDARD as B64, Engine};
+        inputs.app_attest = Some(AppAttestEvidence {
+            object: B64.encode(b"not-a-real-cbor-attestation-object"),
+            keyId: B64.encode([0u8; 32]),
+        });
+        let rec = build(inputs, &*signer).unwrap();
+        assert!(
+            rec.appAttest.is_none(),
+            "unverifiable App Attest evidence must be dropped, not embedded"
         );
     }
 }

--- a/provider/src/lib.rs
+++ b/provider/src/lib.rs
@@ -28,6 +28,7 @@ pub mod hypervisor;
 // alongside the rest of the in-process Python design. See
 // `engines::subprocess` for the replacement (out-of-process Python via
 // uvicorn-on-UDS).
+pub mod appattest;
 pub mod mda;
 pub mod mda_loader;
 pub mod oauth;

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -64,6 +64,11 @@ enum AgentCmd {
     },
     /// Print the active session's identity for debugging.
     Whoami,
+    /// Print this machine's receipt-signing P-256 public key (base64 of the
+    /// raw 64-byte X‖Y point — the value published as `attestation.publicKey`).
+    /// The App Attest helper hashes this for its clientDataHash binding; the
+    /// spike runner reads it via this command.
+    Pubkey,
     /// Print this machine's owner-chosen trust tier from its PDS provider
     /// record: `attested-confidential` or `best-effort`. The macOS tray's
     /// agent supervisor runs this to decide which worker binary to spawn (the
@@ -201,6 +206,7 @@ async fn main() -> Result<()> {
         Cmd::Agent(AgentCmd::Pair { console }) => cmd_pair(&console).await,
         Cmd::Agent(AgentCmd::Serve { advisor }) => cmd_serve_entry(advisor).await,
         Cmd::Agent(AgentCmd::Whoami) => cmd_whoami(),
+        Cmd::Agent(AgentCmd::Pubkey) => cmd_pubkey(),
         Cmd::Agent(AgentCmd::Tier) => cmd_print_tier().await,
         Cmd::Agent(AgentCmd::Confidential { off }) => cmd_set_confidential(!off).await,
         Cmd::Agent(AgentCmd::Doctor { console, fix }) => doctor::run(&console, fix).await,
@@ -1238,8 +1244,11 @@ async fn cmd_serve(
     let mut attestation_inputs =
         attestation::build_stub_inputs(&session.did, &enc.public_key_b64());
     let mda_cert_chain = cocore_provider::mda_loader::try_load();
-    let has_mda_chain = !mda_cert_chain.is_empty();
     attestation_inputs.mda_cert_chain = mda_cert_chain;
+    // App Attest evidence (MDM-free hardware-attested path), bound to this
+    // machine's signing key. `build` re-verifies + only embeds it if it binds.
+    attestation_inputs.app_attest =
+        cocore_provider::mda_loader::load_appattest(&signer.public_key_b64());
     attestation_inputs.in_process_backend = engines.entries().iter().any(|(_, e)| e.in_process());
     attestation_inputs.metallib_hash = engines
         .entries()
@@ -1252,7 +1261,11 @@ async fn cmd_serve(
     let built_attestation = attestation::build(attestation_inputs, &*signer);
     let (achieved_trust_level, achieved_tier) = match &built_attestation {
         Ok(rec) => (
-            if has_mda_chain {
+            // Derive from what the attestation ACTUALLY embedded, not from what
+            // was loaded: `build` drops any MDA chain / App Attest object that
+            // doesn't verify Apple-rooted AND bind to our signing key. Either a
+            // bound MDA chain or bound App Attest earns hardware-attested.
+            if !rec.mdaCertChain.is_empty() || rec.appAttest.is_some() {
                 TrustLevel::HardwareAttested
             } else {
                 TrustLevel::SelfAttested
@@ -2190,6 +2203,15 @@ fn cmd_whoami() -> Result<()> {
         }
         None => println!("not paired; run `cocore agent pair`"),
     }
+    Ok(())
+}
+
+/// `cocore agent pubkey`: print the base64 receipt-signing public key. Loads
+/// (or creates) the Secure Enclave identity, same as the serve loop, so the
+/// printed key matches what attestations publish.
+fn cmd_pubkey() -> Result<()> {
+    let signer = secure_enclave::load_or_create_identity()?;
+    println!("{}", signer.public_key_b64());
     Ok(())
 }
 

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -1243,10 +1243,18 @@ async fn cmd_serve(
     // native engine serves under a hardened-attested posture.
     let mut attestation_inputs =
         attestation::build_stub_inputs(&session.did, &enc.public_key_b64());
+    // MDA option-B (the live macOS hardware-attested path): if the Secure Mode
+    // wizard wired the request env (URL + serial + UDID), ask the coordinator to
+    // trigger a key-bound DeviceInformation attestation (DeviceAttestationNonce =
+    // sha256(pubkey)) before we read the chain. Best-effort + fail-soft;
+    // Apple-rate-limited to ~weekly, so repeats are harmless. No-op unless wired.
+    cocore_provider::mda_loader::request_attestation(&signer.public_key_b64());
     let mda_cert_chain = cocore_provider::mda_loader::try_load();
     attestation_inputs.mda_cert_chain = mda_cert_chain;
-    // App Attest evidence (MDM-free hardware-attested path), bound to this
-    // machine's signing key. `build` re-verifies + only embeds it if it binds.
+    // App Attest evidence — bound to this signing key; `build` re-verifies + only
+    // embeds it if it binds. NB: App Attest is iOS-only (non-functional on macOS,
+    // DCAppAttestService.isSupported=false); this stays a no-op on the Mac and is
+    // retained for a future iOS companion. macOS binds via the MDA chain above.
     attestation_inputs.app_attest =
         cocore_provider::mda_loader::load_appattest(&signer.public_key_b64());
     attestation_inputs.in_process_backend = engines.entries().iter().any(|(_, e)| e.in_process());

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -44,11 +44,7 @@ enum AgentCmd {
     /// approves the pairing and delivers a session blob to this
     /// agent. Persists the session at `~/.cocore/session.json`.
     Pair {
-        #[arg(
-            long,
-            env = "COCORE_CONSOLE",
-            default_value = "https://console.cocore.dev"
-        )]
+        #[arg(long, env = "COCORE_CONSOLE", default_value = "https://cocore.dev")]
         console: String,
     },
     /// Run the agent: connect to the advisor, register, heartbeat,
@@ -97,11 +93,7 @@ enum AgentCmd {
     /// commands the user runs themselves, since they require a
     /// browser or write to the binary on disk.
     Doctor {
-        #[arg(
-            long,
-            env = "COCORE_CONSOLE",
-            default_value = "https://console.cocore.dev"
-        )]
+        #[arg(long, env = "COCORE_CONSOLE", default_value = "https://cocore.dev")]
         console: String,
         /// Apply the safe fixes (kickstart the LaunchAgent if it's
         /// stopped or stale). Re-pair / update suggestions are
@@ -117,11 +109,7 @@ enum AgentCmd {
     /// kickstarts the LaunchAgent (macOS) so the daemon picks up the
     /// new binary.
     Update {
-        #[arg(
-            long,
-            env = "COCORE_CONSOLE",
-            default_value = "https://console.cocore.dev"
-        )]
+        #[arg(long, env = "COCORE_CONSOLE", default_value = "https://cocore.dev")]
         console: String,
         /// Print the latest version + comparison only; don't replace
         /// the installed binary.
@@ -2061,7 +2049,7 @@ fn build_engines(
                  so the configured model(s) [{}] could not load even after retrying. \
                  The machine is online but only serving the no-op `stub` engine, so \
                  it won't be matched to real inference jobs. Fix: re-run the installer \
-                 to (re)provision the environment — `curl -fsSL https://console.cocore.dev/agent | sh` \
+                 to (re)provision the environment — `curl -fsSL https://cocore.dev/agent | sh` \
                  — then start serving again.",
                 venv_python.display(),
                 failed.join(", "),

--- a/provider/src/mda_loader.rs
+++ b/provider/src/mda_loader.rs
@@ -104,7 +104,25 @@ pub const ENV_ATTEST_BINARY: &str = "COCORE_MDA_ATTEST_BINARY";
 /// `ENV_ATTEST_BINARY` (which yields a PEM MDA chain): this helper is invoked
 /// with the signing pubkey as argv[1] and emits JSON `{object, keyId}` for the
 /// App Attest path to hardware-attested. See `provider/spikes/app-attest`.
+///
+/// NOTE: App Attest is non-functional on macOS (DCAppAttestService.isSupported
+/// is false); this seam is retained for a future iOS companion. The live macOS
+/// path to hardware-attested is MDA option-B (the request below + freshness).
 pub const ENV_APPATTEST_BINARY: &str = "COCORE_APPATTEST_BINARY";
+
+/// Console endpoint that triggers a key-bound MDA option-B attestation
+/// (`POST /api/agent/mdm/request-attestation`). When set (with the serial +
+/// UDID below), the agent asks the coordinator to send an MDM DeviceInformation
+/// attestation with `DeviceAttestationNonce = sha256(pubkey)`, so the captured
+/// Apple chain's freshness OID commits to the signing key. The chain then
+/// arrives via `ENV_CHAIN_URL` as usual. See infra/mdm/RUNBOOK.md "Option-B".
+pub const ENV_REQUEST_URL: &str = "COCORE_MDA_REQUEST_URL";
+/// Device serial + NanoMDM enrollment UDID for the request above (set by the
+/// Secure Mode wizard / installer next to `ENV_REQUEST_URL`).
+pub const ENV_DEVICE_SERIAL: &str = "COCORE_MDA_DEVICE_SERIAL";
+pub const ENV_DEVICE_UDID: &str = "COCORE_MDA_DEVICE_UDID";
+/// Bearer API key the agent presents to the console.
+pub const ENV_CONSOLE_API_KEY: &str = "COCORE_API_KEY";
 
 /// Max time the attest-binary subprocess may run before we give
 /// up. Apple's DeviceCheck call typically resolves in well under
@@ -284,6 +302,78 @@ pub fn parse_appattest_json(stdout: &[u8]) -> Result<crate::attestation::AppAtte
         object: out.object,
         keyId: out.key_id,
     })
+}
+
+/// Build the JSON body for `POST /api/agent/mdm/request-attestation`. Pure so
+/// it's unit-tested; the coordinator computes the DeviceAttestationNonce as
+/// `sha256(publicKey)` from this `publicKey`.
+pub fn build_request_body(serial: &str, udid: &str, public_key_b64: &str) -> String {
+    serde_json::json!({
+        "serial": serial,
+        "udid": udid,
+        "publicKey": public_key_b64,
+    })
+    .to_string()
+}
+
+/// Trigger a key-bound MDA option-B attestation: ask the console coordinator to
+/// send the device an MDM DeviceInformation attestation whose nonce commits to
+/// `public_key_b64`. Best-effort and fail-soft — a failure just means no fresh
+/// chain is requested this boot; the agent stays self-attested and the next
+/// boot retries. Reads serial/UDID/console-key/URL from the environment; a
+/// no-op (returns `false`) unless all are configured.
+///
+/// Apple rate-limits DeviceInformation attestation to ~1/device/7 days, so the
+/// coordinator/device may ignore rapid repeats — that's fine, the previously
+/// captured chain remains valid and bound while the signing key is stable.
+pub fn request_attestation(public_key_b64: &str) -> bool {
+    let (Ok(url), Ok(serial), Ok(udid)) = (
+        std::env::var(ENV_REQUEST_URL),
+        std::env::var(ENV_DEVICE_SERIAL),
+        std::env::var(ENV_DEVICE_UDID),
+    ) else {
+        return false;
+    };
+    let api_key = std::env::var(ENV_CONSOLE_API_KEY).unwrap_or_default();
+    let body = build_request_body(&serial, &udid, public_key_b64);
+
+    use std::process::Command;
+    // Shell out to curl (matches load_from_url — boot is synchronous and the
+    // agent's reqwest is async-only). 20s ceiling; never blocks boot for long.
+    let mut args = vec![
+        "-fsS".to_string(),
+        "--max-time".to_string(),
+        "20".to_string(),
+        "-X".to_string(),
+        "POST".to_string(),
+        "-H".to_string(),
+        "content-type: application/json".to_string(),
+    ];
+    if !api_key.is_empty() {
+        args.push("-H".to_string());
+        args.push(format!("authorization: Bearer {api_key}"));
+    }
+    args.push("-d".to_string());
+    args.push(body);
+    args.push(url);
+
+    match Command::new("curl").args(&args).output() {
+        Ok(out) if out.status.success() => {
+            tracing::info!("requested key-bound MDA attestation (option-B) from coordinator");
+            true
+        }
+        Ok(out) => {
+            tracing::warn!(
+                status = %out.status,
+                "request-attestation call returned non-zero; staying self-attested this boot"
+            );
+            false
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "request-attestation curl failed; staying self-attested");
+            false
+        }
+    }
 }
 
 /// Read a PEM file and return one DER blob per CERTIFICATE block,
@@ -538,6 +628,15 @@ mod tests {
     fn load_from_file_errors_on_missing_path() {
         let err = load_from_file(Path::new("/nonexistent/path/xyz.pem")).unwrap_err();
         assert!(format!("{err}").contains("reading"));
+    }
+
+    #[test]
+    fn request_body_is_well_formed_json() {
+        let body = build_request_body("H2WHW38LQ6NV", "A1B2-UDID", "cHVia2V5");
+        let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(v["serial"], "H2WHW38LQ6NV");
+        assert_eq!(v["udid"], "A1B2-UDID");
+        assert_eq!(v["publicKey"], "cHVia2V5");
     }
 
     /// Make sure `try_load` returns empty (not an error) when no

--- a/provider/src/mda_loader.rs
+++ b/provider/src/mda_loader.rs
@@ -100,6 +100,12 @@ pub const ENV_CHAIN_PATH: &str = "COCORE_MDA_CERT_CHAIN_PATH";
 pub const ENV_CHAIN_URL: &str = "COCORE_MDA_CHAIN_URL";
 pub const ENV_ATTEST_BINARY: &str = "COCORE_MDA_ATTEST_BINARY";
 
+/// Path to the signed App Attest helper (`cocore-appattest`). Distinct from
+/// `ENV_ATTEST_BINARY` (which yields a PEM MDA chain): this helper is invoked
+/// with the signing pubkey as argv[1] and emits JSON `{object, keyId}` for the
+/// App Attest path to hardware-attested. See `provider/spikes/app-attest`.
+pub const ENV_APPATTEST_BINARY: &str = "COCORE_APPATTEST_BINARY";
+
 /// Max time the attest-binary subprocess may run before we give
 /// up. Apple's DeviceCheck call typically resolves in well under
 /// a second; a 10-second ceiling is generous-but-bounded so a
@@ -189,6 +195,95 @@ pub fn try_load() -> Vec<Vec<u8>> {
     }
 
     Vec::new()
+}
+
+/// Acquire Apple App Attest evidence bound to `signing_pubkey_b64`.
+///
+/// Runs the helper named by `COCORE_APPATTEST_BINARY` with the base64 signing
+/// public key as argv[1]; the helper sets `clientDataHash = sha256(pubkey)` and
+/// emits JSON `{ "object": "<b64 CBOR>", "keyId": "<b64>", ... }` on stdout.
+///
+/// Returns `None` when the env var is unset, the helper fails / times out, or
+/// the output is malformed — the agent stays self-attested on the App Attest
+/// path rather than refusing to boot (same fail-soft posture as `try_load`).
+/// Note the caller (`attestation::build`) still re-verifies the evidence
+/// locally before embedding it, so a buggy helper can never elevate trust.
+pub fn load_appattest(signing_pubkey_b64: &str) -> Option<crate::attestation::AppAttestEvidence> {
+    let bin = std::env::var(ENV_APPATTEST_BINARY).ok()?;
+    match run_appattest_binary(Path::new(&bin), signing_pubkey_b64) {
+        Ok(ev) => {
+            tracing::info!(binary = %bin, "acquired App Attest evidence");
+            Some(ev)
+        }
+        Err(e) => {
+            tracing::warn!(binary = %bin, error = %e, "App Attest helper invocation failed; staying self-attested");
+            None
+        }
+    }
+}
+
+/// Invoke the App Attest helper with the signing pubkey and parse its JSON.
+fn run_appattest_binary(
+    binary: &Path,
+    signing_pubkey_b64: &str,
+) -> Result<crate::attestation::AppAttestEvidence> {
+    use std::io::Read;
+    use std::process::{Command, Stdio};
+    use std::time::Instant;
+
+    let mut child = Command::new(binary)
+        .arg(signing_pubkey_b64)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped()) // captured but never logged (may carry device IDs)
+        .spawn()
+        .with_context(|| format!("spawning {}", binary.display()))?;
+
+    let deadline = Instant::now() + ATTEST_BINARY_TIMEOUT;
+    loop {
+        if let Some(status) = child.try_wait()? {
+            if !status.success() {
+                bail!("App Attest helper exited with {status}");
+            }
+            break;
+        }
+        if Instant::now() > deadline {
+            let _ = child.kill();
+            bail!(
+                "App Attest helper did not exit within {}s; killed",
+                ATTEST_BINARY_TIMEOUT.as_secs()
+            );
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+
+    let mut stdout_buf = Vec::new();
+    if let Some(mut s) = child.stdout.take() {
+        s.read_to_end(&mut stdout_buf)
+            .context("reading App Attest helper stdout")?;
+    }
+    parse_appattest_json(&stdout_buf)
+}
+
+/// Parse the helper's stdout JSON into an [`AppAttestEvidence`]. Only `object`
+/// and `keyId` are consumed; the helper's other fields (clientDataHashHex,
+/// appId, environment) are diagnostic and ignored here.
+pub fn parse_appattest_json(stdout: &[u8]) -> Result<crate::attestation::AppAttestEvidence> {
+    #[derive(serde::Deserialize)]
+    struct Out {
+        object: String,
+        #[serde(rename = "keyId")]
+        key_id: String,
+    }
+    let s = std::str::from_utf8(stdout).context("App Attest helper stdout is not UTF-8")?;
+    let out: Out = serde_json::from_str(s.trim()).context("parsing App Attest helper JSON")?;
+    if out.object.is_empty() || out.key_id.is_empty() {
+        bail!("App Attest helper returned empty object or keyId");
+    }
+    Ok(crate::attestation::AppAttestEvidence {
+        object: out.object,
+        keyId: out.key_id,
+    })
 }
 
 /// Read a PEM file and return one DER blob per CERTIFICATE block,

--- a/provider/tests/cross_lang_fixture.rs
+++ b/provider/tests/cross_lang_fixture.rs
@@ -310,6 +310,239 @@ fn writes_confidential_attestation_fixture() {
     eprintln!("wrote {}", path.display());
 }
 
+/// Synthesize an Apple App Attest attestation object bound to `signing_pubkey_raw`
+/// (the raw 64-byte P-256 X‖Y point published as `attestation.publicKey`).
+/// Mirrors the synthesis in `appattest.rs`'s unit tests, but here so the
+/// integration test (and the cross-language fixtures) can build one. Returns
+/// `(object_cbor, key_id, synthetic_root_der)`.
+fn synth_app_attest(signing_pubkey_raw: &[u8]) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+    use ciborium::value::Value;
+    use cocore_provider::appattest::{AAGUID_PRODUCTION, APP_ATTEST_APP_ID};
+    use sha2::{Digest, Sha256};
+    use x509_parser::prelude::{FromDer, SubjectPublicKeyInfo};
+
+    let now = time::OffsetDateTime::now_utc();
+    let nb = now - time::Duration::HOUR;
+    let na = now + time::Duration::days(365);
+
+    // Root (CA).
+    let mut root_params = CertificateParams::new(vec!["cocore AppAttest Test Root".into()]).unwrap();
+    root_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    root_params.not_before = nb;
+    root_params.not_after = na;
+    let root_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+    let root_cert = root_params.self_signed(&root_key).unwrap();
+
+    // Intermediate (CA, signed by root).
+    let mut int_params = CertificateParams::new(vec!["cocore AppAttest Test CA".into()]).unwrap();
+    int_params.is_ca = IsCa::Ca(BasicConstraints::Constrained(0));
+    int_params.not_before = nb;
+    int_params.not_after = na;
+    let int_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+    let int_cert = int_params.signed_by(&int_key, &root_cert, &root_key).unwrap();
+
+    // Leaf (credCert) key → credentialId.
+    let leaf_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+    let spki = leaf_key.public_key_der();
+    let (_, info) = SubjectPublicKeyInfo::from_der(&spki).unwrap();
+    let leaf_point = info.subject_public_key.data.to_vec(); // 65-byte 0x04‖X‖Y
+    let cred_id = Sha256::digest(&leaf_point).to_vec();
+
+    // authData = rpIdHash | flags(AT) | signCount=0 | aaguid | credIdLen | credId
+    let mut auth_data = Vec::new();
+    auth_data.extend_from_slice(Sha256::digest(APP_ATTEST_APP_ID.as_bytes()).as_slice());
+    auth_data.push(0x40);
+    auth_data.extend_from_slice(&0u32.to_be_bytes());
+    auth_data.extend_from_slice(AAGUID_PRODUCTION);
+    auth_data.extend_from_slice(&(cred_id.len() as u16).to_be_bytes());
+    auth_data.extend_from_slice(&cred_id);
+
+    // nonce = sha256(authData ‖ sha256(signing pubkey)) → credCert nonce ext.
+    let client_data_hash = Sha256::digest(signing_pubkey_raw);
+    let mut nonce_in = auth_data.clone();
+    nonce_in.extend_from_slice(&client_data_hash);
+    let nonce = Sha256::digest(&nonce_in).to_vec();
+    // DER: SEQUENCE { [1] EXPLICIT OCTET STRING <nonce> }
+    let mut os = vec![0x04, nonce.len() as u8];
+    os.extend_from_slice(&nonce);
+    let mut ctx = vec![0xA1, os.len() as u8];
+    ctx.extend_from_slice(&os);
+    let mut seq = vec![0x30, ctx.len() as u8];
+    seq.extend_from_slice(&ctx);
+
+    let mut leaf_params = CertificateParams::new(vec!["credCert".into()]).unwrap();
+    leaf_params.is_ca = IsCa::NoCa;
+    leaf_params.not_before = nb;
+    leaf_params.not_after = na;
+    let mut ext = CustomExtension::from_oid_content(&[1, 2, 840, 113635, 100, 8, 2], seq);
+    ext.set_criticality(false);
+    leaf_params.custom_extensions.push(ext);
+    let leaf_cert = leaf_params.signed_by(&leaf_key, &int_cert, &int_key).unwrap();
+
+    let obj = Value::Map(vec![
+        (Value::Text("fmt".into()), Value::Text("apple-appattest".into())),
+        (
+            Value::Text("attStmt".into()),
+            Value::Map(vec![
+                (
+                    Value::Text("x5c".into()),
+                    Value::Array(vec![
+                        Value::Bytes(leaf_cert.der().to_vec()),
+                        Value::Bytes(int_cert.der().to_vec()),
+                    ]),
+                ),
+                (Value::Text("receipt".into()), Value::Bytes(vec![])),
+            ]),
+        ),
+        (Value::Text("authData".into()), Value::Bytes(auth_data)),
+    ]);
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&obj, &mut buf).unwrap();
+    (buf, cred_id, root_cert.der().to_vec())
+}
+
+/// Standalone App Attest verifier parity fixture (mirrors the MDA one). The TS
+/// test in `packages/sdk/src/appattest.test.ts` verifies this object with the
+/// synthetic root and proves the wrong-root path rejects against Apple's real
+/// App Attest root.
+#[test]
+fn writes_appattest_cross_lang_fixture() {
+    use cocore_provider::appattest::{
+        verify_against, APPLE_APP_ATTEST_ROOT_CA_PEM, APP_ATTEST_APP_ID,
+    };
+
+    let signer = load_or_create_identity().unwrap();
+    let pubkey_b64 = signer.public_key_b64();
+    let pubkey_raw = signer.public_key_bytes().to_vec();
+    let (object, key_id, root_der) = synth_app_attest(&pubkey_raw);
+
+    // Self-test: prove the Rust verifier accepts what we built before asking TS.
+    let res = verify_against(
+        &object,
+        &key_id,
+        &pubkey_raw,
+        APP_ATTEST_APP_ID,
+        &root_der,
+        &chrono::Utc::now(),
+        false,
+    )
+    .expect("Rust must verify its own App Attest fixture");
+    assert!(res.valid && res.binds_signing_key);
+
+    let fixture = json!({
+        "objectB64": B64.encode(&object),
+        "keyIdB64": B64.encode(&key_id),
+        "publicKeyB64": pubkey_b64,
+        "appId": APP_ATTEST_APP_ID,
+        "rootDerB64": B64.encode(&root_der),
+        "appleRootPem": APPLE_APP_ATTEST_ROOT_CA_PEM,
+    });
+    let path = workspace_target_dir().join("appattest-cross-lang-fixture.json");
+    std::fs::write(&path, serde_json::to_vec_pretty(&fixture).unwrap())
+        .unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
+    eprintln!("wrote {}", path.display());
+}
+
+/// A COMPLETE confidential-tier attestation fixture whose hardware attestation
+/// comes from App Attest (not an MDA chain), proving the TS `verifyProviderForSeal`
+/// reaches `attested-confidential` via the MDM-free path. Same single-key
+/// discipline as `writes_confidential_attestation_fixture`.
+#[test]
+fn writes_confidential_appattest_fixture() {
+    use base64::engine::general_purpose::STANDARD as B64e;
+    use cocore_provider::canonical::to_canonical_bytes;
+    use cocore_provider::crypto::ProviderKeypair;
+    use p256::ecdsa::{signature::Signer, Signature, SigningKey};
+    use p256::elliptic_curve::sec1::ToEncodedPoint;
+    use p256::pkcs8::DecodePrivateKey;
+
+    // The signing key: a fresh P-256 key used as publicKey + selfSignature +
+    // session-key signer.
+    let leaf_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+    let secret = p256::SecretKey::from_pkcs8_pem(&leaf_key.serialize_pem()).unwrap();
+    let signing_key = SigningKey::from(&secret);
+    let pub_point = secret.public_key().to_encoded_point(false);
+    let pubkey_raw = pub_point.as_bytes()[1..].to_vec(); // drop 0x04 → 64 bytes
+    let public_key_b64 = B64e.encode(&pubkey_raw);
+
+    // App Attest object bound to that signing key, under a synthetic App Attest root.
+    let (aa_object, aa_key_id, aa_root_der) = synth_app_attest(&pubkey_raw);
+
+    let enc = ProviderKeypair::generate();
+    let cd_hash = "ab".repeat(20);
+    let metallib_hash = "cd".repeat(32);
+    let attested_at = chrono::Utc::now();
+    let expires_at = attested_at + chrono::Duration::hours(24);
+
+    let mut body = json!({
+        "publicKey": public_key_b64,
+        "encryptionPubKey": enc.public_key_b64(),
+        "chipName": "Apple M4 Max",
+        "hardwareModel": "Mac16,1",
+        "serialNumberHash": "0".repeat(64),
+        "osVersion": "macOS 26.0",
+        "binaryHash": "1".repeat(64),
+        "cdHash": cd_hash,
+        "teamId": "4L45P7CP9M",
+        "hardenedRuntime": true,
+        "libraryValidation": true,
+        "getTaskAllow": false,
+        "metallibHash": metallib_hash,
+        "engineLibHash": "ef".repeat(32),
+        "inProcessBackend": true,
+        "antiDebug": true,
+        "coreDumpsDisabled": true,
+        "envScrubbed": true,
+        "sipEnabled": true,
+        "secureBootEnabled": true,
+        "secureEnclaveAvailable": true,
+        "authenticatedRootEnabled": true,
+        "rdmaDisabled": true,
+        "appAttest": { "object": B64e.encode(&aa_object), "keyId": B64e.encode(&aa_key_id) },
+        "tier": "attested-confidential",
+        "attestedAt": attested_at.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        "expiresAt": expires_at.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+    });
+    let canonical = to_canonical_bytes(&body).unwrap();
+    let self_sig: Signature = signing_key.sign(&canonical);
+    body.as_object_mut().unwrap().insert(
+        "selfSignature".into(),
+        json!(B64e.encode(self_sig.to_der().as_bytes())),
+    );
+
+    let ephemeral = ProviderKeypair::generate();
+    let nonce = "f".repeat(32);
+    let attestation_cid = "bafyconfappattestcid";
+    let sk_msg = to_canonical_bytes(&json!({
+        "attestationCid": attestation_cid,
+        "ephemeralPubKey": ephemeral.public_key_b64(),
+        "nonce": nonce,
+    }))
+    .unwrap();
+    let sk_sig: Signature = signing_key.sign(&sk_msg);
+
+    let fixture = json!({
+        "attestation": body,
+        "appAttestRootDerB64": B64e.encode(&aa_root_der),
+        "knownGoodCdHash": "ab".repeat(20),
+        "knownGoodMetallibHash": "cd".repeat(32),
+        "knownGoodEngineLibHash": "ef".repeat(32),
+        "osFloor": "14.0.0",
+        "attestationCid": attestation_cid,
+        "nonce": nonce,
+        "sessionKey": {
+            "ephemeralPubKey": ephemeral.public_key_b64(),
+            "nonce": nonce,
+            "attestationCid": attestation_cid,
+            "signature": B64e.encode(sk_sig.to_der().as_bytes()),
+        },
+    });
+    let path = workspace_target_dir().join("confidential-appattest-fixture.json");
+    std::fs::write(&path, serde_json::to_vec_pretty(&fixture).unwrap())
+        .unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
+    eprintln!("wrote {}", path.display());
+}
+
 fn workspace_target_dir() -> std::path::PathBuf {
     // CARGO_TARGET_DIR or <workspace>/target. We want a stable path
     // under the workspace root so the TS test can find the fixture

--- a/provider/tests/cross_lang_fixture.rs
+++ b/provider/tests/cross_lang_fixture.rs
@@ -326,7 +326,8 @@ fn synth_app_attest(signing_pubkey_raw: &[u8]) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
     let na = now + time::Duration::days(365);
 
     // Root (CA).
-    let mut root_params = CertificateParams::new(vec!["cocore AppAttest Test Root".into()]).unwrap();
+    let mut root_params =
+        CertificateParams::new(vec!["cocore AppAttest Test Root".into()]).unwrap();
     root_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
     root_params.not_before = nb;
     root_params.not_after = na;
@@ -339,7 +340,9 @@ fn synth_app_attest(signing_pubkey_raw: &[u8]) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
     int_params.not_before = nb;
     int_params.not_after = na;
     let int_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
-    let int_cert = int_params.signed_by(&int_key, &root_cert, &root_key).unwrap();
+    let int_cert = int_params
+        .signed_by(&int_key, &root_cert, &root_key)
+        .unwrap();
 
     // Leaf (credCert) key → credentialId.
     let leaf_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
@@ -377,10 +380,15 @@ fn synth_app_attest(signing_pubkey_raw: &[u8]) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
     let mut ext = CustomExtension::from_oid_content(&[1, 2, 840, 113635, 100, 8, 2], seq);
     ext.set_criticality(false);
     leaf_params.custom_extensions.push(ext);
-    let leaf_cert = leaf_params.signed_by(&leaf_key, &int_cert, &int_key).unwrap();
+    let leaf_cert = leaf_params
+        .signed_by(&leaf_key, &int_cert, &int_key)
+        .unwrap();
 
     let obj = Value::Map(vec![
-        (Value::Text("fmt".into()), Value::Text("apple-appattest".into())),
+        (
+            Value::Text("fmt".into()),
+            Value::Text("apple-appattest".into()),
+        ),
         (
             Value::Text("attStmt".into()),
             Value::Map(vec![

--- a/scripts/inspect-mda-freshness.sh
+++ b/scripts/inspect-mda-freshness.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Inspect a captured Apple MDA attestation leaf and check whether its freshness
+# OID (1.2.840.113635.100.8.11.1) commits to a given P-256 signing pubkey —
+# i.e. confirm the option-B binding `freshness == sha256(publicKey)`.
+#
+#   ./inspect-mda-freshness.sh <leaf.pem|leaf.der> <publicKey-base64>
+#
+# `publicKey-base64` is the agent's raw 64-byte P-256 X‖Y key (what
+# `cocore agent pubkey` prints / what the attestation publishes as publicKey).
+#
+# Use this on the FIRST real DeviceInformation-attestation capture to confirm
+# the exact byte format Apple stores for DeviceAttestationNonce. If it prints
+# MATCH, the shipped verifiers (mda freshness_binds == sha256(publicKey)) accept
+# it as-is. If NO MATCH, compare the printed freshness bytes to sha256(pubkey)
+# and adjust the single freshness normalizer (provider/src/mda.rs
+# `freshness_binds`, mirrored in TS/py) accordingly — see infra/mdm/RUNBOOK.md
+# "Option-B".
+set -euo pipefail
+
+LEAF="${1:?usage: inspect-mda-freshness.sh <leaf.pem|leaf.der> <publicKey-base64>}"
+PUBKEY_B64="${2:?missing publicKey-base64}"
+
+PY="${COCORE_PY:-python3}"
+if ! "$PY" -c "import cryptography" 2>/dev/null; then
+  echo "error: needs Python 'cryptography' (pip install cryptography), or set COCORE_PY" >&2
+  exit 1
+fi
+
+"$PY" - "$LEAF" "$PUBKEY_B64" <<'PY'
+import base64, hashlib, sys
+from cryptography import x509
+
+leaf_path, pubkey_b64 = sys.argv[1], sys.argv[2]
+raw = open(leaf_path, "rb").read()
+leaf = (
+    x509.load_pem_x509_certificate(raw)
+    if raw.lstrip().startswith(b"-----BEGIN")
+    else x509.load_der_x509_certificate(raw)
+)
+
+OID = x509.ObjectIdentifier("1.2.840.113635.100.8.11.1")
+try:
+    ext = leaf.extensions.get_extension_for_oid(OID)
+except x509.ExtensionNotFound:
+    print("freshness OID 1.2.840.113635.100.8.11.1 NOT PRESENT in leaf"); sys.exit(2)
+
+val = getattr(ext.value, "value", None)
+if val is None:
+    print("freshness extension has no raw value"); sys.exit(2)
+
+# Tolerate the DER OCTET STRING wrapper (04 20 || 32) the verifiers also strip.
+inner = val[2:] if len(val) == 34 and val[0] == 0x04 and val[1] == 0x20 else val
+want = hashlib.sha256(base64.b64decode(pubkey_b64)).digest()
+
+print("freshness (raw)     :", val.hex())
+print("freshness (unwrapped):", inner.hex())
+print("sha256(publicKey)    :", want.hex())
+print("MATCH" if inner == want else "NO MATCH (adjust the freshness normalizer to fit these bytes)")
+PY

--- a/sdk/py/cocore/__init__.py
+++ b/sdk/py/cocore/__init__.py
@@ -4,6 +4,13 @@ Mirrors the TypeScript SDK's verification surface so ML practitioners can verify
 a provider's confidential-tier attestation (fail-closed) before sealing a prompt.
 """
 
+from .appattest import (
+    APP_ATTEST_APP_ID,
+    AppAttestError,
+    AppAttestResult,
+    verify_app_attest,
+    verify_app_attest_b64,
+)
 from .canonical import CanonicalError, canonical_bytes, canonicalize
 from .mda import MdaError, MdaResult, verify_chain, verify_chain_against
 from .p256 import verify_attestation_signature, verify_p256, verify_receipt_signature
@@ -18,6 +25,11 @@ __all__ = [
     "MdaResult",
     "verify_chain",
     "verify_chain_against",
+    "AppAttestError",
+    "AppAttestResult",
+    "verify_app_attest",
+    "verify_app_attest_b64",
+    "APP_ATTEST_APP_ID",
     "verify_p256",
     "verify_attestation_signature",
     "verify_receipt_signature",

--- a/sdk/py/cocore/appattest.py
+++ b/sdk/py/cocore/appattest.py
@@ -1,0 +1,368 @@
+"""Apple App Attest attestation verification.
+
+Mirror of provider/src/appattest.rs and packages/sdk/src/appattest.ts. Verifies
+an Apple App Attest *attestation object* (CBOR/WebAuthn-shaped) and confirms it
+is BOUND to the provider's receipt-signing key via the credential certificate's
+nonce extension — the MDM-free path to trustLevel "hardware-attested".
+
+Binding (by construction in the helper): clientDataHash = sha256(signingPubKey),
+so here: nonce == sha256(authData || sha256(signingPubKey)) == credCert ext
+1.2.840.113635.100.8.2.
+
+CBOR is decoded by a tiny built-in reader (no cbor2 dependency); x509 uses the
+`cryptography` lib already required by the SDK.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+from cryptography import x509
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+# Apple App Attest Root CA, P-384, valid 2020 -> 2045. Identical bytes to the
+# Rust embed in provider/src/appattest.rs and the TS embed in appattest.ts.
+APPLE_APP_ATTEST_ROOT_CA_PEM = (
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIICITCCAaegAwIBAgIQC/O+DvHN0uD7jG5yH2IXmDAKBggqhkjOPQQDAzBSMSYw\n"
+    "JAYDVQQDDB1BcHBsZSBBcHAgQXR0ZXN0YXRpb24gUm9vdCBDQTETMBEGA1UECgwK\n"
+    "QXBwbGUgSW5jLjETMBEGA1UECAwKQ2FsaWZvcm5pYTAeFw0yMDAzMTgxODMyNTNa\n"
+    "Fw00NTAzMTUwMDAwMDBaMFIxJjAkBgNVBAMMHUFwcGxlIEFwcCBBdHRlc3RhdGlv\n"
+    "biBSb290IENBMRMwEQYDVQQKDApBcHBsZSBJbmMuMRMwEQYDVQQIDApDYWxpZm9y\n"
+    "bmlhMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAERTHhmLW07ATaFQIEVwTtT4dyctdh\n"
+    "NbJhFs/Ii2FdCgAHGbpphY3+d8qjuDngIN3WVhQUBHAoMeQ/cLiP1sOUtgjqK9au\n"
+    "Yen1mMEvRq9Sk3Jm5X8U62H+xTD3FE9TgS41o0IwQDAPBgNVHRMBAf8EBTADAQH/\n"
+    "MB0GA1UdDgQWBBSskRBTM72+aEH/pwyp5frq5eWKoTAOBgNVHQ8BAf8EBAMCAQYw\n"
+    "CgYIKoZIzj0EAwMDaAAwZQIwQgFGnByvsiVbpTKwSga0kP0e8EeDS4+sQmTvb7vn\n"
+    "53O5+FRXgeLhpJ06ysC5PrOyAjEAp5U4xDgEgllF7En3VcE3iexZZtKeYnpqtijV\n"
+    "oyFraWVIyd/dganmrduC1bmTBGwD\n"
+    "-----END CERTIFICATE-----\n"
+)
+
+OID_APP_ATTEST_NONCE = "1.2.840.113635.100.8.2"
+
+# AAGUID for genuine production App Attest: ASCII "appattest" + 7 zero bytes.
+AAGUID_PRODUCTION = b"appattest" + b"\x00" * 7
+AAGUID_DEVELOPMENT = b"appattestdevelop"
+
+# The cocore provider App ID ("TEAMID.bundleID"). rpIdHash = sha256 of this.
+APP_ATTEST_APP_ID = "4L45P7CP9M.dev.cocore.provider"
+
+_FLAG_AT = 0x40
+
+
+class AppAttestError(Exception):
+    def __init__(self, code: str, message: str):
+        super().__init__(f"{code}: {message}")
+        self.code = code
+
+
+@dataclass
+class AppAttestResult:
+    valid: bool
+    attested_pubkey_uncompressed: bytes
+    key_id: bytes
+    aaguid: bytes
+    rp_id_hash: bytes
+    binds_signing_key: bool
+
+
+def verify_app_attest(
+    object_der: bytes,
+    key_id: bytes,
+    signing_pubkey_raw: bytes,
+    app_id: str,
+    *,
+    trust_anchor_der: Optional[bytes] = None,
+    now: Optional[datetime] = None,
+    allow_development: bool = False,
+) -> AppAttestResult:
+    """Verify an App Attest object. Raises AppAttestError on any failure."""
+    now = now or datetime.now(timezone.utc)
+    root = (
+        x509.load_der_x509_certificate(trust_anchor_der)
+        if trust_anchor_der is not None
+        else x509.load_pem_x509_certificate(APPLE_APP_ATTEST_ROOT_CA_PEM.encode("ascii"))
+    )
+
+    # 1. CBOR-decode.
+    obj = _decode_object(object_der)
+    if obj.fmt != "apple-appattest":
+        raise AppAttestError("bad-fmt", f"unexpected fmt {obj.fmt!r}")
+    if not obj.x5c:
+        raise AppAttestError("shape", "attStmt.x5c is empty")
+
+    # 2. Verify the x5c chain to the App Attest root.
+    certs = [x509.load_der_x509_certificate(d) for d in obj.x5c]
+
+    def in_window(c: x509.Certificate) -> bool:
+        return c.not_valid_before_utc <= now <= c.not_valid_after_utc
+
+    for i, c in enumerate(certs):
+        if not in_window(c):
+            raise AppAttestError("not-valid", f"cert {i} not valid at {now.isoformat()}")
+    if not in_window(root):
+        raise AppAttestError("not-valid", "trust anchor not valid")
+
+    for i in range(len(certs) - 1):
+        _verify_sig(certs[i], certs[i + 1], i)
+    _verify_sig(certs[-1], root, len(certs) - 1)
+
+    for i, c in enumerate(certs):
+        is_ca = _is_ca(c)
+        if i == 0 and is_ca:
+            raise AppAttestError("leaf-is-ca", "leaf (credCert) must be an end-entity, not a CA")
+        if i > 0 and not is_ca:
+            raise AppAttestError("non-ca-issuer", f"chain cert {i} is not a CA but signs cert {i - 1}")
+
+    cred_cert = certs[0]
+
+    # 3. Recompute nonce; check the credCert nonce extension.
+    client_data_hash = hashlib.sha256(signing_pubkey_raw).digest()
+    expected_nonce = hashlib.sha256(obj.auth_data + client_data_hash).digest()
+    got_nonce = _parse_nonce_extension(cred_cert)
+    if got_nonce is None:
+        raise AppAttestError("no-nonce-extension", "credCert has no usable nonce extension")
+    if not hmac.compare_digest(got_nonce, expected_nonce):
+        raise AppAttestError(
+            "nonce-mismatch", "attestation is not bound to the signing key (nonce mismatch)"
+        )
+
+    # 4. credCert pubkey -> credentialId, cross-check authData + keyId.
+    pub = cred_cert.public_key()
+    if not (isinstance(pub, ec.EllipticCurvePublicKey) and isinstance(pub.curve, ec.SECP256R1)):
+        raise AppAttestError("shape", "credCert public key is not P-256")
+    attested_pubkey = pub.public_bytes(Encoding.X962, PublicFormat.UncompressedPoint)  # 0x04||X||Y
+    pubkey_hash = hashlib.sha256(attested_pubkey).digest()
+
+    # 5. Parse authData; validate rpIdHash / AAGUID / credentialId.
+    ad = _parse_auth_data(obj.auth_data)
+    if not hmac.compare_digest(ad.rp_id_hash, hashlib.sha256(app_id.encode("utf-8")).digest()):
+        raise AppAttestError("shape", "rpIdHash != sha256(appId)")
+    aaguid_ok = ad.aaguid == AAGUID_PRODUCTION or (
+        allow_development and ad.aaguid == AAGUID_DEVELOPMENT
+    )
+    if not aaguid_ok:
+        raise AppAttestError("bad-aaguid", f"unrecognized AAGUID {ad.aaguid.hex()}")
+    if not hmac.compare_digest(ad.credential_id, pubkey_hash):
+        raise AppAttestError("cred-id-mismatch", "credentialId != sha256(attested pubkey)")
+    if not hmac.compare_digest(key_id, pubkey_hash):
+        raise AppAttestError("key-id-mismatch", "keyId != credentialId")
+
+    return AppAttestResult(
+        valid=True,
+        attested_pubkey_uncompressed=attested_pubkey,
+        key_id=pubkey_hash,
+        aaguid=ad.aaguid,
+        rp_id_hash=ad.rp_id_hash,
+        binds_signing_key=True,
+    )
+
+
+def verify_app_attest_b64(
+    object_b64: str,
+    key_id_b64: str,
+    public_key_b64: str,
+    app_id: str,
+    *,
+    trust_anchor_der: Optional[bytes] = None,
+    now: Optional[datetime] = None,
+    allow_development: bool = False,
+) -> bool:
+    """Decode base64 and verify; returns True iff valid AND bound. Never raises
+    AppAttestError (returns False instead)."""
+    try:
+        res = verify_app_attest(
+            base64.b64decode(object_b64),
+            base64.b64decode(key_id_b64),
+            base64.b64decode(public_key_b64),
+            app_id,
+            trust_anchor_der=trust_anchor_der,
+            now=now,
+            allow_development=allow_development,
+        )
+        return res.valid and res.binds_signing_key
+    except AppAttestError:
+        return False
+
+
+# ---- internals -------------------------------------------------------
+
+
+def _verify_sig(cert: x509.Certificate, issuer: x509.Certificate, idx: int) -> None:
+    issuer_pub = issuer.public_key()
+    if not isinstance(issuer_pub, ec.EllipticCurvePublicKey):
+        raise AppAttestError("bad-signature", f"unsupported issuer key for cert {idx}")
+    try:
+        issuer_pub.verify(
+            cert.signature, cert.tbs_certificate_bytes, ec.ECDSA(cert.signature_hash_algorithm)
+        )
+    except InvalidSignature as exc:
+        raise AppAttestError("bad-signature", f"signature on cert {idx} doesn't verify") from exc
+
+
+def _is_ca(cert: x509.Certificate) -> bool:
+    try:
+        return bool(cert.extensions.get_extension_for_class(x509.BasicConstraints).value.ca)
+    except x509.ExtensionNotFound:
+        return False
+
+
+def _parse_nonce_extension(cert: x509.Certificate) -> Optional[bytes]:
+    """extnValue is DER: SEQUENCE { [1] EXPLICIT OCTET STRING <nonce> }."""
+    try:
+        ext = cert.extensions.get_extension_for_oid(x509.ObjectIdentifier(OID_APP_ATTEST_NONCE))
+    except x509.ExtensionNotFound:
+        return None
+    raw = getattr(ext.value, "value", None)
+    if raw is None:
+        return None
+    seq = _read_tlv(raw)
+    if seq is None or seq[0] != 0x30:
+        return None
+    ctx = _read_tlv(seq[1])
+    if ctx is None or ctx[0] != 0xA1:
+        return None
+    octets = _read_tlv(ctx[1])
+    if octets is None or octets[0] != 0x04 or len(octets[1]) != 32:
+        return None
+    return octets[1]
+
+
+def _read_tlv(data: bytes) -> Optional[tuple[int, bytes, bytes]]:
+    """Minimal strict DER TLV reader. Returns (tag, value, rest)."""
+    if len(data) < 2:
+        return None
+    tag = data[0]
+    first = data[1]
+    if first & 0x80 == 0:
+        length = first
+        header = 2
+    else:
+        n = first & 0x7F
+        if n == 0 or n > 4 or len(data) < 2 + n:
+            return None
+        length = int.from_bytes(data[2 : 2 + n], "big")
+        header = 2 + n
+    end = header + length
+    if end > len(data):
+        return None
+    return tag, data[header:end], data[end:]
+
+
+@dataclass
+class _AuthData:
+    rp_id_hash: bytes
+    aaguid: bytes
+    credential_id: bytes
+
+
+def _parse_auth_data(ad: bytes) -> _AuthData:
+    # rpIdHash(32)|flags(1)|signCount(4)|aaguid(16)|credIdLen(2)|credId(L)|cose...
+    if len(ad) < 37:
+        raise AppAttestError("short-auth-data", f"authData too short ({len(ad)} bytes)")
+    rp_id_hash = ad[0:32]
+    if ad[32] & _FLAG_AT == 0:
+        raise AppAttestError("no-attested-credential-data", "AT flag not set in authData")
+    if len(ad) < 55:
+        raise AppAttestError("short-auth-data", f"authData too short ({len(ad)} bytes)")
+    aaguid = ad[37:53]
+    cred_id_len = int.from_bytes(ad[53:55], "big")
+    end = 55 + cred_id_len
+    if end > len(ad):
+        raise AppAttestError("short-auth-data", f"authData too short for credId ({len(ad)} bytes)")
+    return _AuthData(rp_id_hash=rp_id_hash, aaguid=aaguid, credential_id=ad[55:end])
+
+
+@dataclass
+class _Object:
+    fmt: str
+    x5c: list
+    auth_data: bytes
+
+
+def _decode_object(object_der: bytes) -> _Object:
+    top, _ = _cbor_read(object_der, 0)
+    if not isinstance(top, dict):
+        raise AppAttestError("cbor", "top-level is not a CBOR map")
+    fmt = top.get("fmt")
+    if not isinstance(fmt, str):
+        raise AppAttestError("cbor", "missing fmt")
+    att_stmt = top.get("attStmt")
+    if not isinstance(att_stmt, dict):
+        raise AppAttestError("cbor", "missing attStmt")
+    x5c = att_stmt.get("x5c")
+    if not isinstance(x5c, list) or not all(isinstance(c, (bytes, bytearray)) for c in x5c):
+        raise AppAttestError("cbor", "missing/invalid attStmt.x5c")
+    auth_data = top.get("authData")
+    if not isinstance(auth_data, (bytes, bytearray)):
+        raise AppAttestError("cbor", "missing authData")
+    return _Object(fmt=fmt, x5c=[bytes(c) for c in x5c], auth_data=bytes(auth_data))
+
+
+def _cbor_read(buf: bytes, pos: int):
+    """Minimal CBOR decoder: major types 0/1 (int), 2 (bytes), 3 (text),
+    4 (array), 5 (map with text keys). Definite lengths only. Returns
+    (value, new_pos)."""
+    if pos >= len(buf):
+        raise AppAttestError("cbor", "unexpected end of CBOR")
+    b = buf[pos]
+    pos += 1
+    major = b >> 5
+    info = b & 0x1F
+    arg, pos = _cbor_arg(buf, pos, info)
+    if major == 0:
+        return arg, pos
+    if major == 1:
+        return -1 - arg, pos
+    if major == 2:
+        if pos + arg > len(buf):
+            raise AppAttestError("cbor", "truncated byte string")
+        return buf[pos : pos + arg], pos + arg
+    if major == 3:
+        if pos + arg > len(buf):
+            raise AppAttestError("cbor", "truncated text string")
+        return buf[pos : pos + arg].decode("utf-8"), pos + arg
+    if major == 4:
+        out = []
+        for _ in range(arg):
+            v, pos = _cbor_read(buf, pos)
+            out.append(v)
+        return out, pos
+    if major == 5:
+        out = {}
+        for _ in range(arg):
+            k, pos = _cbor_read(buf, pos)
+            v, pos = _cbor_read(buf, pos)
+            if not isinstance(k, str):
+                raise AppAttestError("cbor", "non-text CBOR map key")
+            out[k] = v
+        return out, pos
+    raise AppAttestError("cbor", f"unsupported CBOR major type {major}")
+
+
+def _cbor_arg(buf: bytes, pos: int, info: int):
+    if info < 24:
+        return info, pos
+    if info == 24:
+        if pos + 1 > len(buf):
+            raise AppAttestError("cbor", "truncated CBOR arg")
+        return buf[pos], pos + 1
+    if info == 25:
+        if pos + 2 > len(buf):
+            raise AppAttestError("cbor", "truncated CBOR arg")
+        return int.from_bytes(buf[pos : pos + 2], "big"), pos + 2
+    if info == 26:
+        if pos + 4 > len(buf):
+            raise AppAttestError("cbor", "truncated CBOR arg")
+        return int.from_bytes(buf[pos : pos + 4], "big"), pos + 4
+    if info == 27:
+        raise AppAttestError("cbor", "CBOR 64-bit lengths not supported")
+    raise AppAttestError("cbor", f"unsupported CBOR additional-info {info}")

--- a/sdk/py/cocore/verify.py
+++ b/sdk/py/cocore/verify.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Iterable, Mapping, Optional
 
+from .appattest import APP_ATTEST_APP_ID, verify_app_attest_b64
 from .canonical import canonical_bytes
 from .mda import MdaError, verify_chain, verify_chain_against
 from .p256 import verify_attestation_signature, verify_p256
@@ -69,6 +70,8 @@ def verify_provider_for_seal(
     # AMFI-gated push is the one leg an operator can't forge). Mirrors the TS SDK.
     require_code_attested: bool = True,
     trust_anchor_der: Optional[bytes] = None,
+    app_attest_trust_anchor_der: Optional[bytes] = None,
+    allow_development_app_attest: bool = False,
     now: Optional[datetime] = None,
 ) -> VerifyResult:
     now = now or datetime.now(timezone.utc)
@@ -88,10 +91,36 @@ def verify_provider_for_seal(
             "attestation.selfSignature did not verify against attestation.publicKey",
         )
 
-    # 1+2. MDA chain present, verifies, bound to the signing key.
+    # 1+2. Hardware attestation: a bound App Attest object OR a bound MDA chain.
+    # App Attest (attestation["appAttest"]) is the MDM-free path: a verifying
+    # object is bound to the signing key by construction (clientDataHash =
+    # sha256(publicKey)). If present and bound it SATISFIES the requirement and
+    # the MDA gate is skipped; otherwise we fall back to the MDA chain as before.
     mda = None
-    if not mda_chain:
-        block("no-mda-chain", "attestation carries no MDA certificate chain")
+    pub_b64 = attestation.get("publicKey", "")
+    aa = attestation.get("appAttest")
+    app_attest_binds = bool(
+        aa
+        and aa.get("object")
+        and aa.get("keyId")
+        and verify_app_attest_b64(
+            aa["object"],
+            aa["keyId"],
+            pub_b64,
+            APP_ATTEST_APP_ID,
+            trust_anchor_der=app_attest_trust_anchor_der,
+            allow_development=allow_development_app_attest,
+            now=now,
+        )
+    )
+
+    if app_attest_binds:
+        pass  # hardware-attested via App Attest; no MDA chain required
+    elif not mda_chain:
+        block(
+            "no-mda-chain",
+            "attestation carries no MDA certificate chain and no valid bound App Attest object",
+        )
     else:
         chain_der = [base64.b64decode(c) for c in mda_chain]
         try:
@@ -108,7 +137,6 @@ def verify_provider_for_seal(
             # BINDING (parity with verify-provider.ts): bind to the signing key
             # via (A) leaf == publicKey, OR (B) freshness-code commits to it
             # (freshness == sha256(publicKey)). Fail-closed if neither holds.
-            pub_b64 = attestation.get("publicKey")
             leaf_binds = bool(mda.leaf_public_key) and mda.leaf_public_key == pub_b64
             fresh_binds = _freshness_binds_key(mda.freshness_code, pub_b64)
             if not leaf_binds and not fresh_binds:

--- a/sdk/py/tests/test_appattest.py
+++ b/sdk/py/tests/test_appattest.py
@@ -1,0 +1,168 @@
+"""Cross-language parity tests for the Python App Attest verifier.
+
+Loads the SAME Rust-generated fixtures the TS suite uses
+(target/appattest-cross-lang-fixture.json + confidential-appattest-fixture.json,
+written by the provider's cross_lang_fixture test) and asserts the Python
+verifier agrees — proving Rust producer ↔ Python verifier parity on the
+MDM-free hardware-attested path.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+from datetime import datetime, timezone
+
+import pytest
+
+from cocore import verify_provider_for_seal
+from cocore.appattest import (
+    APPLE_APP_ATTEST_ROOT_CA_PEM,
+    AppAttestError,
+    verify_app_attest,
+    verify_app_attest_b64,
+)
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+AA_FIXTURE = os.path.join(REPO, "target", "appattest-cross-lang-fixture.json")
+CONF_AA_FIXTURE = os.path.join(REPO, "target", "confidential-appattest-fixture.json")
+
+
+def _pem_to_der(pem: str) -> bytes:
+    body = "".join(
+        line for line in pem.splitlines() if line and not line.startswith("-----")
+    )
+    return base64.b64decode(body)
+
+
+@pytest.mark.skipif(not os.path.exists(AA_FIXTURE), reason="Rust fixture not generated")
+def test_cross_language_app_attest_pass():
+    with open(AA_FIXTURE) as fh:
+        f = json.load(fh)
+    root_der = base64.b64decode(f["rootDerB64"])
+
+    res = verify_app_attest(
+        base64.b64decode(f["objectB64"]),
+        base64.b64decode(f["keyIdB64"]),
+        base64.b64decode(f["publicKeyB64"]),
+        f["appId"],
+        trust_anchor_der=root_der,
+    )
+    assert res.valid and res.binds_signing_key
+    assert len(res.key_id) == 32
+    assert base64.b64encode(res.key_id).decode() == f["keyIdB64"]
+
+
+@pytest.mark.skipif(not os.path.exists(AA_FIXTURE), reason="Rust fixture not generated")
+def test_app_attest_unbound_key_rejected():
+    with open(AA_FIXTURE) as fh:
+        f = json.load(fh)
+    root_der = base64.b64decode(f["rootDerB64"])
+    other = b"\x09" * 64
+    with pytest.raises(AppAttestError) as ei:
+        verify_app_attest(
+            base64.b64decode(f["objectB64"]),
+            base64.b64decode(f["keyIdB64"]),
+            other,
+            f["appId"],
+            trust_anchor_der=root_der,
+        )
+    assert ei.value.code == "nonce-mismatch"
+
+
+@pytest.mark.skipif(not os.path.exists(AA_FIXTURE), reason="Rust fixture not generated")
+def test_app_attest_real_apple_root_rejects_synthetic():
+    with open(AA_FIXTURE) as fh:
+        f = json.load(fh)
+    with pytest.raises(AppAttestError) as ei:
+        verify_app_attest(
+            base64.b64decode(f["objectB64"]),
+            base64.b64decode(f["keyIdB64"]),
+            base64.b64decode(f["publicKeyB64"]),
+            f["appId"],
+            trust_anchor_der=_pem_to_der(f["appleRootPem"]),
+        )
+    assert ei.value.code == "bad-signature"
+
+
+@pytest.mark.skipif(not os.path.exists(AA_FIXTURE), reason="Rust fixture not generated")
+def test_app_attest_wrong_app_id_rejected():
+    with open(AA_FIXTURE) as fh:
+        f = json.load(fh)
+    root_der = base64.b64decode(f["rootDerB64"])
+    with pytest.raises(AppAttestError) as ei:
+        verify_app_attest(
+            base64.b64decode(f["objectB64"]),
+            base64.b64decode(f["keyIdB64"]),
+            base64.b64decode(f["publicKeyB64"]),
+            "4L45P7CP9M.com.evil.fork",
+            trust_anchor_der=root_der,
+        )
+    assert ei.value.code == "shape"
+
+
+def test_embedded_apple_app_attest_root_matches_rust():
+    # The fixture's appleRootPem is the Rust constant; a mismatch means drift.
+    if not os.path.exists(AA_FIXTURE):
+        pytest.skip("Rust fixture not generated")
+    with open(AA_FIXTURE) as fh:
+        f = json.load(fh)
+    assert APPLE_APP_ATTEST_ROOT_CA_PEM == f["appleRootPem"]
+
+
+@pytest.mark.skipif(not os.path.exists(AA_FIXTURE), reason="Rust fixture not generated")
+def test_verify_b64_true_then_false_on_garbage():
+    with open(AA_FIXTURE) as fh:
+        f = json.load(fh)
+    root_der = base64.b64decode(f["rootDerB64"])
+    assert verify_app_attest_b64(
+        f["objectB64"], f["keyIdB64"], f["publicKeyB64"], f["appId"], trust_anchor_der=root_der
+    )
+    assert not verify_app_attest_b64(
+        base64.b64encode(b"not-cbor").decode(),
+        f["keyIdB64"],
+        f["publicKeyB64"],
+        f["appId"],
+        trust_anchor_der=root_der,
+    )
+
+
+@pytest.mark.skipif(not os.path.exists(CONF_AA_FIXTURE), reason="Rust fixture not generated")
+def test_cross_language_confidential_via_app_attest():
+    with open(CONF_AA_FIXTURE) as fh:
+        f = json.load(fh)
+    att = f["attestation"]
+    aa_root = base64.b64decode(f["appAttestRootDerB64"])
+    now = datetime.now(timezone.utc)
+
+    # No MDA chain — hardware attestation is solely App Attest.
+    res = verify_provider_for_seal(
+        att,
+        None,
+        require_confidential=True,
+        require_code_attested=False,
+        known_good_cdhashes=[f["knownGoodCdHash"]],
+        known_good_metallib_hashes=[f["knownGoodMetallibHash"]],
+        known_good_engine_lib_hashes=[f["knownGoodEngineLibHash"]],
+        os_floor=f["osFloor"],
+        app_attest_trust_anchor_der=aa_root,
+        now=now,
+    )
+    assert res.tier == "attested-confidential", res.findings
+    assert res.ok
+    assert res.seal_to_key == att["encryptionPubKey"]
+
+    # App Attest is load-bearing: against the real Apple root it doesn't verify,
+    # and with no MDA fallback the result drops to best-effort.
+    downgraded = verify_provider_for_seal(
+        att,
+        None,
+        require_confidential=False,
+        require_code_attested=False,
+        known_good_cdhashes=[f["knownGoodCdHash"]],
+        now=now,
+    )
+    assert downgraded.tier == "best-effort"
+    assert "no-mda-chain" in downgraded.codes()
+    assert "attestation-signature-invalid" not in downgraded.codes()


### PR DESCRIPTION
## Summary

Builds the **macOS path to `trustLevel: hardware-attested`** — a genuine, key-bound Apple hardware attestation tied to the provider's P-256 receipt-signing key. Verifier side (all four implementations) was already in place; this adds the producer + coordinator, plus the cross-language App Attest infrastructure built en route.

The investigation ruled out two approaches before landing on the viable one:

1. **App Attest** — `DCAppAttestService.isSupported` returns **false on native macOS** (confirmed on M1 / macOS 26.4.1; it's iOS/iPadOS/tvOS/watchOS only). Verifiers built anyway and retained for a future iOS companion; the lexicon field is additive/harmless.
2. **MDA option-A (adopt the attested key)** — the `device-attest-01` payload attests an **OS-managed, P-384, non-extractable** key; cocore signs P-256 and can't sign receipts with it. Blocked.
3. **MDA option-B (key-bound freshness) — shipped.** Apple's security guide: for MDM `DeviceInformation` attestation, the leaf's freshness OID = the requester-supplied `DeviceAttestationNonce`. Setting `DeviceAttestationNonce = sha256(agentPubKey)` makes freshness commit to the signing key — exactly the option-B check the verifiers already implement. No App Attest, no forked step-ca.

## What's in here

**Lexicon**
- Additive optional `appAttest: { object, keyId }` on the attestation record; documents `hardware-attested` = bound `mdaCertChain` OR valid bound App Attest. Regenerated `types.gen.ts` + `types.ts`.

**Verifiers (Rust / TS / Python / AppView)**
- App Attest verifiers (`provider/src/appattest.rs`, `packages/sdk/src/appattest.ts`, `sdk/py/cocore/appattest.py`): CBOR decode → x5c chain to the embedded Apple App Attest Root CA → nonce-extension binding → authData/AAGUID/credentialId checks.
- `verify-provider.ts` / `verify.py` accept a bound App Attest object as an alternative to the MDA chain (short-circuit; all existing blocker codes preserved).
- **AppView `verifyReceipt` fix:** now honors App Attest **and** the MDA option-B freshness binding (previously only leaf-key/option-A — option-B chains were wrongly reported self-attested).

**MDA option-B producer + coordinator (the live macOS path)**
- Coordinator (`mdm-coordinator.server.ts`): `attestationNonceBytes`, `buildDeviceInformationAttestationCommand`, `requestDeviceInformationAttestation` (NanoMDM enqueue+push), `parseNanomdmAttestationWebhook`, `authenticateNanomdmWebhook`.
- New routes: `POST /api/agent/mdm/request-attestation`, `POST /api/agent/mdm/nanomdm-webhook`.
- Agent: `mda_loader::request_attestation` (env-gated `COCORE_MDA_REQUEST_URL`/`_DEVICE_SERIAL`/`_DEVICE_UDID`, best-effort, fail-soft) wired into serve; `cocore agent pubkey`; trustLevel derived from actually-embedded evidence.
- App Attest helper + spike under `provider/spikes/app-attest/` (macOS-inert; iOS-future).

**Ops**
- `scripts/inspect-mda-freshness.sh` to confirm `freshness == sha256(pubkey)` on the first live capture.
- `infra/mdm/RUNBOOK.md` "Option-B" section: flow, NanoMDM `-webhook-url` + `COCORE_NANOMDM_WEBHOOK_KEY`, agent env, the ~1/device/7-day rate limit, and the confirm-bytes step.

## Tests

- Rust: 110 lib + 5 cross-language fixture tests.
- TS SDK: 101 tests (incl. App Attest parity + confidential-via-App-Attest e2e).
- Python: 13 tests (App Attest parity + confidential e2e).
- Console coordinator: 15 unit tests; `tsc` clean.

## Caveats / remaining ops (cannot be done from code)

- The coordinator/NanoMDM integration is unit-tested on its pure logic but **not end-to-end tested** without the live MDM stack + a real device. Two live-validated unknowns, both clearly flagged in code + RUNBOOK: the NanoMDM webhook field layout, and the exact byte format Apple stores for `DeviceAttestationNonce` (we send a base64 string; verifiers expect raw 32-byte `sha256(pubkey)`, wrapper-tolerant — if it differs, one freshness-normalizer to adjust).
- Remaining ops: NanoMDM `-webhook-url` + `COCORE_NANOMDM_WEBHOOK_KEY`, agent env wiring, MDM stack bring-up (RUNBOOK steps 1–3), and the one-capture freshness confirmation.
- The AppView vitest suite is red in CI-like local runs due to an unbuilt `better-sqlite3` native binding — pre-existing and unrelated; `tsc` is clean.

Per CLAUDE.md the lexicon ideally lands as its own PR first; the lexicon + regenerated types are isolated in the first commit (`a17ef22`) if you'd prefer to split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)