### PR TITLE
secure-mode: fix option-B DeviceInformation command (nonce <data> + serial query) for real-device capture

### DIFF
--- a/infra/mdm/RUNBOOK.md
+++ b/infra/mdm/RUNBOOK.md
@@ -266,3 +266,68 @@ scripts/inspect-mda-freshness.sh leaf.pem "$(cocore agent pubkey)"
   verifiers (all 4), and `inspect-mda-freshness.sh`.
 - ⏳ **Infra/ops (you):** NanoMDM `-webhook-url` + `COCORE_NANOMDM_WEBHOOK_KEY`,
   the agent env wiring, and the one-capture freshness-bytes confirmation above.
+
+---
+
+## Option-B bring-up — corrected procedure (live-validated 2026-06-22)
+
+Standing up the MDM backend durably surfaced several gotchas. This is the
+working sequence; it supersedes the optimistic notes above.
+
+**A. step-ca must be DURABLE + REMOTE-MANAGED.** The throwaway ephemeral
+instance re-inits a new root + admin password on every redeploy and has no
+admin API (`/admin/*` → 404), so provisioners can't be managed. On
+`cocore-step-ca`: attach the volume at `/home/step` and set
+`DOCKER_STEPCA_INIT_REMOTE_MANAGEMENT=true`, `RAILWAY_RUN_UID=0`,
+`DOCKER_STEPCA_INIT_DNS_NAMES=reseau.proxy.rlwy.net,cocore-step-ca-production.up.railway.app,localhost`.
+First boot prints the **root fingerprint** + **admin password** (capture both,
+once). Bootstrap a context: `step ca bootstrap --ca-url <CA> --fingerprint <fp>`.
+
+**B. SCEP needs an RSA decrypter (EC CA can't do SCEP key transport).** Symptom:
+macOS profile install fails _"Unable to generate certificate signing request for
+SCEP server"_; `GetCACert` returns the bare EC intermediate. Fix: an RSA
+recipient cert the device encrypts the pkcsPKIEnvelope to.
+
+```sh
+openssl req -x509 -newkey rsa:2048 -keyout decrypter.key -out decrypter.crt -days 3650 -nodes \
+  -subj "/CN=cocore-scep-decrypter" -addext "keyUsage=critical,keyEncipherment,digitalSignature"
+ADMIN=(--admin-provisioner admin --admin-subject step --admin-password-file admin-pw.txt --ca-url <CA> --root root.pem)
+step ca provisioner add cocore-attest --type ACME --challenge device-attest-01 --attestation-format apple "${ADMIN[@]}"
+step ca provisioner add cocore-scep --type SCEP --challenge "$(cat scep-challenge.txt)" \
+  --encryption-algorithm-identifier 2 --include-root \
+  --scep-decrypter-certificate-file decrypter.crt --scep-decrypter-key-file decrypter.key "${ADMIN[@]}"
+```
+
+Verify: `GetCACert` now returns a 3-cert bundle led by `CN=cocore-scep-decrypter`
+(key=RSA). ACME routes mount at runtime, but the **SCEP route only mounts at
+boot — RESTART step-ca** after adding `cocore-scep` (a plain restart; the volume
+means no re-init, root preserved).
+
+**C. Re-sync the (new) root everywhere.** A fresh init mints a new root, so:
+Client env `COCORE_MDM_ROOT_CA_PEM` + `COCORE_MDM_INTERMEDIATE_CA_PEM` = new
+PEMs (redeploy Client); and re-bake NanoMDM `-ca` = intermediate+root
+(`nanomdm-deploy/ca.pem`, then `railway up`). NanoMDM uses **file storage**
+(ephemeral) — every redeploy wipes the push cert + enrollments, so **re-upload
+the push cert after any NanoMDM deploy** (`…/v1/pushcert`) and enroll only after.
+(Persist NanoMDM on Postgres — Step 2 — to stop this churn.)
+
+**D. NanoMDM webhook.** `-webhook-url 'https://cocore.dev/api/agent/mdm/nanomdm-webhook?key=<SECRET>'`
+
+- Client env `COCORE_NANOMDM_WEBHOOK_KEY=<SECRET>`. NanoMDM POSTs the URL
+  verbatim (no query mangling), so the `?key=` secret survives; the event shape is
+  `{topic, acknowledge_event:{udid, raw_payload:<base64 plist>}}`.
+
+**E. The DeviceInformation command (the binding).** `DeviceAttestationNonce` is
+`<data>` (raw 32 bytes = sha256(pubkey)); `Queries` must include BOTH
+`DevicePropertiesAttestation` (the leaf chain) AND `SerialNumber` (the event only
+carries the UDID, but the chain store is keyed by serial). Apple rate-limits this
+to ~1/device/7 days.
+
+**F. End-to-end (proven up to enrollment 2026-06-22).** `enroll-profile`
+(use the Hardware UUID as the udid) → install the profile (Touch ID; SCEP now
+succeeds) → `request-attestation {serial, udid, publicKey}` → NanoMDM pushes →
+device returns the attestation → webhook stores by serial → agent polls
+`attestation-chain?serial=…` → `scripts/inspect-mda-freshness.sh` confirms
+`freshness == sha256(pubkey)`. Debug seam: set `COCORE_MDM_WEBHOOK_DEBUG=1` on
+the Client and read the raw webhook payload via
+`GET attestation-chain?serial=zzwebhookdebuglast`.

--- a/packages/console/src/lib/mdm-coordinator.server.test.ts
+++ b/packages/console/src/lib/mdm-coordinator.server.test.ts
@@ -34,8 +34,8 @@ const SCEP_KEYS = [
 ];
 
 const SERIAL = "H2WHW38LQ6NV";
-const UDID = "00008103-001869192E20801E"; // not a valid UDID_RE form on its own
-const REAL_UDID = "A1B2C3D4-1111-2222-3333-444455556666";
+const UDID = "00008103-001869192E20801E"; // Apple-silicon Provisioning UDID (8hex-16hex)
+const REAL_UDID = "A1B2C3D4-1111-2222-3333-444455556666"; // Hardware UUID form
 
 function clearEnv(): void {
   for (const k of SCEP_KEYS) delete process.env[k];
@@ -67,11 +67,14 @@ afterEach(() => {
 });
 
 describe("validation", () => {
-  it("accepts real Apple serials and UUID-form UDIDs, rejects garbage", () => {
+  it("accepts real Apple serials + UUID and Apple-silicon UDID forms, rejects garbage", () => {
     expect(isValidSerial(SERIAL)).toBe(true);
     expect(isValidSerial("no-dashes-allowed")).toBe(false);
-    expect(isValidUdid(REAL_UDID)).toBe(true);
-    expect(isValidUdid(UDID)).toBe(false); // hyphenated but wrong group sizes
+    expect(isValidUdid(REAL_UDID)).toBe(true); // Hardware UUID form
+    expect(isValidUdid(UDID)).toBe(true); // Apple-silicon Provisioning UDID (8hex-16hex)
+    expect(isValidUdid("0123456789abcdef0123456789abcdef01234567")).toBe(true); // 40-hex legacy
+    expect(isValidUdid("not-a-udid")).toBe(false);
+    expect(isValidUdid("00008103-ZZZZ69192E20801E")).toBe(false); // non-hex
   });
 });
 
@@ -192,7 +195,7 @@ describe("option-B DeviceInformation attestation (freshness binding)", () => {
     expect(nonce.equals(expected)).toBe(true);
   });
 
-  it("builds a DeviceInformation command carrying DevicePropertiesAttestation + the nonce", () => {
+  it("builds a DeviceInformation command: nonce as <data>, queries attestation + serial", () => {
     const nonce = attestationNonceBytes(PUBKEY_B64);
     const cmd = buildDeviceInformationAttestationCommand(
       "ABCDEF01-2345-6789-ABCD-EF0123456789",
@@ -200,9 +203,15 @@ describe("option-B DeviceInformation attestation (freshness binding)", () => {
     );
     expect(cmd).toContain("<string>DeviceInformation</string>");
     expect(cmd).toContain("<string>DevicePropertiesAttestation</string>");
-    expect(cmd).toContain("<key>DeviceAttestationNonce</key>");
-    // The nonce rides as base64 in the command.
-    expect(cmd).toContain(nonce.toString("base64"));
+    // Must query SerialNumber too — the webhook event has only the UDID, and the
+    // chain store is keyed by serial, so the response must carry the serial.
+    expect(cmd).toContain("<string>SerialNumber</string>");
+    // DeviceAttestationNonce MUST be <data> (Apple schema), carrying the raw
+    // 32-byte sha256(pubkey) as base64 — so freshness == sha256(pubkey) exactly.
+    expect(cmd).toContain(
+      `<key>DeviceAttestationNonce</key>\n    <data>${nonce.toString("base64")}</data>`,
+    );
+    expect(cmd).not.toContain(`<string>${nonce.toString("base64")}</string>`);
   });
 
   it("requestDeviceInformationAttestation errors without an MDM target", async () => {
@@ -256,26 +265,33 @@ describe("option-B DeviceInformation attestation (freshness binding)", () => {
     expect(parseNanomdmAttestationWebhook("nope")).toBeNull();
   });
 
-  it("parses a NanoMDM acknowledge_event.raw_payload (the live webhook shape)", () => {
-    const responsePlist = `<?xml version="1.0"?>
+  it("parses the REAL NanoMDM event: acknowledge_event.raw_payload, serial from QueryResponses", () => {
+    // Mirrors micromdm/nanomdm testdata/DeviceInformation.1.json: the event has
+    // NO top-level serial (only acknowledge_event.udid); the queried SerialNumber
+    // + DevicePropertiesAttestation land inside the response's QueryResponses.
+    const responsePlist = `<?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0"><dict>
-  <key>SerialNumber</key><string>H2WHW38LQ6NV</string>
+  <key>CommandUUID</key><string>76eda240-5488-4989-8339-f2ae160113c4</string>
   <key>QueryResponses</key><dict>
     <key>DevicePropertiesAttestation</key>
     <array><data>bGVhZg==</data><data>aW50ZXI=</data></array>
+    <key>SerialNumber</key><string>H2WHW38LQ6NV</string>
   </dict>
+  <key>Status</key><string>Acknowledged</string>
 </dict></plist>`;
     const payload = {
       topic: "mdm.Connect",
+      event_id: "e1",
       acknowledge_event: {
-        udid: "00008103-001869192E20801E",
+        command_uuid: "76eda240-5488-4989-8339-f2ae160113c4",
+        udid: "376AF848-8EC9-5336-AB51-0801857F726D",
         status: "Acknowledged",
         raw_payload: Buffer.from(responsePlist, "utf8").toString("base64"),
       },
     };
     const parsed = parseNanomdmAttestationWebhook(payload);
     expect(parsed).not.toBeNull();
-    expect(parsed!.serial).toBe("H2WHW38LQ6NV");
+    expect(parsed!.serial).toBe("H2WHW38LQ6NV"); // pulled from the plist, not the event
     expect(parsed!.chain).toEqual(["bGVhZg==", "aW50ZXI="]);
   });
 

--- a/packages/console/src/lib/mdm-coordinator.server.ts
+++ b/packages/console/src/lib/mdm-coordinator.server.ts
@@ -911,7 +911,7 @@ function extractSerialFromPlist(plistXml: string): string | null {
  *  `chain` field holds `[base64(rawBody)]`). Alphanumeric so it passes
  *  isValidSerial. Leave the env UNSET in production — MDM payloads carry device
  *  info; this is a debug-only seam for bringing up a new device. */
-export const WEBHOOK_DEBUG_SERIAL = "zzwebhookdebuglast";
+const WEBHOOK_DEBUG_SERIAL = "zzwebhookdebuglast";
 
 /** Persist the raw webhook body for inspection when COCORE_MDM_WEBHOOK_DEBUG is
  *  set; no-op otherwise. Returns whether it stashed. */

--- a/packages/console/src/lib/mdm-coordinator.server.ts
+++ b/packages/console/src/lib/mdm-coordinator.server.ts
@@ -121,10 +121,13 @@ export function authenticateChainIngest(request: Request): boolean {
  *  profile. */
 const SERIAL_RE = /^[A-Za-z0-9]{8,24}$/;
 
-/** A UDID is a 40-hex string (legacy) or a UUID-shaped string on newer
- *  hardware. Accept both forms. */
+/** A UDID is one of: a 40-hex string (legacy); a UUID-shaped string (the
+ *  Hardware UUID macOS reports as its MDM enrollment id); or the Apple-silicon
+ *  Provisioning-UDID form `8hex-16hex` (e.g. 00008103-001869192E20801E). Accept
+ *  all three — the 8-16 form was previously rejected, which blocked real M-series
+ *  devices from enroll-profile / request-attestation. */
 const UDID_RE =
-  /^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$/;
+  /^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{8}-[0-9a-fA-F]{16})$/;
 
 export function isValidSerial(v: unknown): v is string {
   return typeof v === "string" && SERIAL_RE.test(v);
@@ -682,14 +685,23 @@ export function attestationNonceBytes(publicKeyB64: string): Buffer {
 }
 
 /** Build the MDM `DeviceInformation` command that requests a fresh hardware
- *  attestation bound to `nonceBytes`. `Queries: [DevicePropertiesAttestation]`
- *  asks for the attestation; `DeviceAttestationNonce` forces a fresh one whose
- *  freshness OID equals the nonce. */
+ *  attestation bound to `nonceBytes`.
+ *
+ *  Per Apple's device-management schema (mdm/commands/information.device.yaml):
+ *   - `DeviceAttestationNonce` is type **`<data>`** (NOT `<string>`) — the raw
+ *     nonce bytes; sending a string makes the command malformed and the device
+ *     returns no attestation. Because we carry the 32 raw bytes here, the leaf's
+ *     freshness OID equals exactly `sha256(pubkey)` — what the verifiers check.
+ *   - `Queries` requests `DevicePropertiesAttestation` (the attestation, an
+ *     array of DER certs in the response) AND `SerialNumber` — the response only
+ *     includes fields you query, and the NanoMDM webhook event identifies the
+ *     device by UDID, so we need the serial in the response to key the chain
+ *     store (which the agent polls by serial). */
 export function buildDeviceInformationAttestationCommand(
   commandUuid: string,
   nonceBytes: Buffer,
 ): string {
-  const nonceB64 = nonceBytes.toString("base64");
+  const nonceB64 = nonceBytes.toString("base64"); // plist <data> content is base64
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -703,9 +715,10 @@ export function buildDeviceInformationAttestationCommand(
     <key>Queries</key>
     <array>
       <string>DevicePropertiesAttestation</string>
+      <string>SerialNumber</string>
     </array>
     <key>DeviceAttestationNonce</key>
-    <string>${nonceB64}</string>
+    <data>${nonceB64}</data>
   </dict>
 </dict>
 </plist>
@@ -890,4 +903,28 @@ function extractDevicePropertiesAttestation(plistXml: string): string[] | null {
 function extractSerialFromPlist(plistXml: string): string | null {
   const m = plistXml.match(/<key>\s*SerialNumber\s*<\/key>\s*<string>([^<]+)<\/string>/i);
   return m ? m[1]!.trim() : null;
+}
+
+/** A reserved serial under which the webhook stashes the last raw payload when
+ *  COCORE_MDM_WEBHOOK_DEBUG is set, so an operator can inspect exactly what
+ *  NanoMDM posts via `GET attestation-chain?serial=zzwebhookdebuglast` (the
+ *  `chain` field holds `[base64(rawBody)]`). Alphanumeric so it passes
+ *  isValidSerial. Leave the env UNSET in production — MDM payloads carry device
+ *  info; this is a debug-only seam for bringing up a new device. */
+export const WEBHOOK_DEBUG_SERIAL = "zzwebhookdebuglast";
+
+/** Persist the raw webhook body for inspection when COCORE_MDM_WEBHOOK_DEBUG is
+ *  set; no-op otherwise. Returns whether it stashed. */
+export function maybeStashWebhookDebug(rawBody: string, nowIso: string): boolean {
+  if (!env("COCORE_MDM_WEBHOOK_DEBUG")) return false;
+  try {
+    putAttestationChain(
+      WEBHOOK_DEBUG_SERIAL,
+      [Buffer.from(rawBody, "utf8").toString("base64")],
+      nowIso,
+    );
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/packages/console/src/routes/api/agent.mdm.nanomdm-webhook.ts
+++ b/packages/console/src/routes/api/agent.mdm.nanomdm-webhook.ts
@@ -21,6 +21,7 @@ import {
   authenticateNanomdmWebhook,
   ingestAttestationChain,
   isValidSerial,
+  maybeStashWebhookDebug,
   mdmJson,
   parseNanomdmAttestationWebhook,
 } from "@/lib/mdm-coordinator.server.ts";
@@ -32,9 +33,14 @@ export const Route = createFileRoute("/api/agent/mdm/nanomdm-webhook")({
         if (!authenticateNanomdmWebhook(request)) {
           return mdmJson({ error: "invalid or missing nanomdm-webhook bearer" }, 401);
         }
+        const rawBody = await request.text();
+        // Debug seam (COCORE_MDM_WEBHOOK_DEBUG): stash the raw payload so a new
+        // device's exact webhook shape is inspectable via
+        // GET attestation-chain?serial=zzwebhookdebuglast. No-op in prod.
+        maybeStashWebhookDebug(rawBody, new Date().toISOString());
         let body: unknown;
         try {
-          body = await request.json();
+          body = JSON.parse(rawBody);
         } catch {
           return mdmJson({ error: "body must be JSON" }, 400);
         }


### PR DESCRIPTION
## Summary

Follow-up to #57. Brought the MDA **option-B** (key-bound `hardware-attested`) path up end-to-end on a real Apple-silicon Mac and fixed the bugs that blocked it. The Mac now enrolls cleanly and `request-attestation` queues + pushes the `DeviceInformation` command; these changes fix the command/keying so the attestation is actually captured.

## Bugs fixed (both silent — device enrolled + command queued, but no chain landed)

1. **`DeviceAttestationNonce` must be `<data>`, not `<string>`.** Apple's published schema (`mdm/commands/information.device.yaml`) types it as `<data>`. A wrong-typed command is malformed, so the device produced no attestation. Emitting `<data>` (raw 32-byte `sha256(pubkey)`) also makes the leaf freshness OID equal `sha256(pubkey)` **exactly** — matching all four verifiers with no normalizer change.
2. **Must also query `SerialNumber`.** The NanoMDM webhook event identifies the device by **UDID**, and a `DeviceInformation` response only returns *queried* fields — so there was no serial to key the chain store by (the agent polls by serial). Now queries `DevicePropertiesAttestation` **and** `SerialNumber`.

## Also
- `isValidUdid` accepts the Apple-silicon Provisioning-UDID form (`8hex-16hex`, e.g. `00008103-001869192E20801E`) — previously rejected, which blocked real M-series devices at `enroll-profile` / `request-attestation`.
- `nanomdm-webhook`: gated raw-payload capture (`COCORE_MDM_WEBHOOK_DEBUG`) → inspect the exact webhook shape via `GET attestation-chain?serial=zzwebhookdebuglast`, so a new device is diagnosable without console-log access.
- Tests updated to the authoritative shapes (verified against `micromdm/nanomdm` webhook testdata): nonce `<data>` + `SerialNumber` query, and the real `acknowledge_event.raw_payload` event with the serial pulled from the response `QueryResponses`. 17 coordinator tests; `tsc`/oxlint/oxfmt clean.
- **RUNBOOK**: the corrected, live-validated option-B bring-up — durable + remote-managed step-ca, the **SCEP RSA decrypter** (EC CAs can't do SCEP key transport), the SCEP-route-needs-restart quirk, root re-sync to Client + NanoMDM, push-cert re-upload, the command shape, and the debug seam.

## Verified live (2026-06-22)
- step-ca made durable + remote-managed; provisioners re-added **with an RSA decrypter** → `GetCACert` returns the RSA recipient (the macOS SCEP blocker is gone).
- Mac **enrolled** ("supervised and managed by: co/core", User Approved).
- `request-attestation` builds + enqueues the `DeviceInformation` command and NanoMDM pushes it (no error).

The capture step is exactly what this PR's command/keying fixes unblock; it needs the Client redeployed with these changes, then one `request-attestation` + `inspect-mda-freshness.sh` to confirm `freshness == sha256(pubkey)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)