### PR TITLE
test: de-flake load_from_binary_captures_stdout_pem (ETXTBSY on Linux CI)

### DIFF
--- a/provider/src/mda_loader.rs
+++ b/provider/src/mda_loader.rs
@@ -687,6 +687,9 @@ mod tests {
             for line in pem.lines() {
                 writeln!(f, "printf '%s\\n' {}", shell_escape(line)).unwrap();
             }
+            // Flush + fsync so the bytes are on disk and this write fd is fully
+            // released before we exec — shrinks the ETXTBSY window on Linux.
+            f.sync_all().unwrap();
         }
         let script_path = script.into_temp_path();
 
@@ -696,7 +699,34 @@ mod tests {
         perms.set_mode(0o755);
         std::fs::set_permissions(&script_path, perms).unwrap();
 
-        let chain = load_from_binary(&script_path).unwrap();
+        // Linux can transiently return ETXTBSY ("Text file busy") when exec'ing
+        // a file whose write fd the kernel only just released — even after the
+        // sync + drop above. `load_from_binary` surfaces that as an `Err` (from
+        // `Command::spawn`), so retry a few times to keep the test hermetic on
+        // CI. Normally succeeds on the first attempt; the loop only spins on the
+        // rare race (≤ ~0.5s worst case).
+        let chain = {
+            let mut got = None;
+            let mut last_err = None;
+            for _ in 0..25 {
+                match load_from_binary(&script_path) {
+                    Ok(c) => {
+                        got = Some(c);
+                        break;
+                    }
+                    Err(e) => {
+                        last_err = Some(e);
+                        std::thread::sleep(std::time::Duration::from_millis(20));
+                    }
+                }
+            }
+            got.unwrap_or_else(|| {
+                panic!(
+                    "load_from_binary failed after retries: {:#}",
+                    last_err.unwrap()
+                )
+            })
+        };
         assert_eq!(chain.len(), 1);
         assert_eq!(chain[0], bodies[0]);
     }


### PR DESCRIPTION
## Summary

`mda_loader::tests::load_from_binary_captures_stdout_pem` flakes on Linux CI (the `static-analysis` job's `cargo test`). It writes a temp shell script, chmods +x, then `load_from_binary` execs it and reads stdout. On Linux, `exec()` of a just-written file whose write fd the kernel only just released returns **ETXTBSY** ("Text file busy"), so `load_from_binary(&script_path).unwrap()` panics intermittently — observed on PR #63: **passed on the first run, failed on a re-run** at `src/mda_loader.rs`.

Production `load_from_binary` is **unchanged**; this is purely test reliability.

## Fix (test-only)
- `f.sync_all()` before dropping the write handle, so the bytes are on disk and the fd is fully released before exec — shrinks the ETXTBSY window.
- Retry the exec a few times (≤25 × 20ms) on the transient spawn error. Normally succeeds first try; the loop only spins on the rare race (≤ ~0.5s worst case).

## Verification
- Ran the test **10× locally** — 10/10 pass.
- `cargo fmt --check` clean, `cargo clippy --all-features -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)