### PR TITLE
fix(secure-mode): grant Device Information AccessRights (bit 16) so the attestation actually returns

### DIFF
--- a/packages/console/src/lib/mdm-coordinator.server.test.ts
+++ b/packages/console/src/lib/mdm-coordinator.server.test.ts
@@ -124,7 +124,9 @@ describe("buildEnrollmentProfile", () => {
 
     // MDM payload, least-privilege + signed check-ins.
     expect(p).toContain("com.apple.mdm");
-    expect(p).toContain("<key>AccessRights</key><integer>3</integer>");
+    // 19 = 1|2|16: profile inspect/install + Device Information query (bit 16),
+    // which DevicePropertiesAttestation requires. No lock/erase/app rights.
+    expect(p).toContain("<key>AccessRights</key><integer>19</integer>");
     expect(p).toContain("<key>SignMessage</key><true/>");
     // Newer macOS requires the MDM payload to advertise the user channel.
     expect(p).toContain("com.apple.mdm.per-user-connections");

--- a/packages/console/src/lib/mdm-coordinator.server.ts
+++ b/packages/console/src/lib/mdm-coordinator.server.ts
@@ -13,7 +13,7 @@
 //   2. enrolls a device identity via SCEP against step-ca's `cocore-scep`
 //      provisioner (each device generates its own key; no CA-issuing
 //      secret ever lives in the console, no PKCS12 packing),
-//   3. enrolls the Mac into NanoMDM (`com.apple.mdm`, AccessRights=3,
+//   3. enrolls the Mac into NanoMDM (`com.apple.mdm`, AccessRights=19 —
 //      SignMessage=true — the device signs check-ins via Mdm-Signature
 //      since Railway's TLS-terminating edge strips client certs), and
 //   4. (when COCORE_MDM_ACME_URL is set) runs ACME `device-attest-01`
@@ -307,7 +307,14 @@ function mdmPayload(
       <key>Topic</key><string>${xmlEscape(c.topic)}</string>
       <key>ServerURL</key><string>${xmlEscape(c.mdmServerUrl)}</string>
       <key>CheckInURL</key><string>${xmlEscape(c.checkInUrl)}</string>
-      <key>AccessRights</key><integer>3</integer>
+      <!-- AccessRights bitmask: 1 (inspect config profiles) + 2 (install/remove
+           config profiles) + 16 (query Device Information). Bit 16 is REQUIRED
+           for the DeviceInformation attestation — without it the device
+           Acknowledges the command but silently omits DevicePropertiesAttestation
+           (and even SerialNumber), returning only UDID. We intentionally do NOT
+           grant device-lock/erase/app-management rights: cocore's MDM only needs
+           to query the device for its hardware attestation. -->
+      <key>AccessRights</key><integer>19</integer>
       <key>SignMessage</key><true/>
       <key>CheckOutWhenRemoved</key><true/>
       <!-- Newer macOS rejects an MDM payload that doesn't declare it supports


### PR DESCRIPTION
## Root cause (found via live debugging on a real Mac)

The DeviceInformation attestation was never captured because the enrollment MDM payload set **`AccessRights=3`** (config-profile inspect/install only). Apple's `DeviceInformation` attestation requires the **Device Information query right — bit 16**. Without it, the device *Acknowledges* the command but **silently omits `DevicePropertiesAttestation`** (and even `SerialNumber`), returning only `UDID`.

Captured live (with the debug ring from #65), the device's response to our command was:
```xml
<key>QueryResponses</key><dict><key>UDID</key><string>376AF848-…</string></dict>
<key>Status</key><string>Acknowledged</string>
```
— Acknowledged, no attestation, no serial. Classic missing-AccessRights signature.

## Fix
`AccessRights = 19` (`1|2|16`): keep config-profile rights + add Device Information query. **Deliberately not** granting device-lock / erase / app-management — cocore's MDM only needs to *query* the device for its hardware attestation, so a provider's Mac doesn't hand cocore broad control.

## Notes
- This was **never the 7-day rate limit** — the device never *generated* an attestation (it lacked the right), so the quota is intact.
- Requires **re-enrolling** the device with the new profile (AccessRights is set at enrollment).
- 17 coordinator tests; tsc/oxfmt/oxlint/knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)