### PR TITLE
fix(secure-mode): push-attestation no longer 502s the wizard

### DIFF
--- a/packages/console/src/routes/api/agent.mdm.push-attestation.ts
+++ b/packages/console/src/routes/api/agent.mdm.push-attestation.ts
@@ -41,20 +41,24 @@ export const Route = createFileRoute("/api/agent/mdm/push-attestation")({
         }
 
         // The NanoMDM enqueue target is the device's enrollment id — its
-        // UDID — when a real push (refresh) is wanted. The guided wizard
-        // sends neither (initial attestation runs from the enrollment
-        // profile), so a missing target is NOT an error: pushAttestation
-        // ACKs and the device attests on install. enrollmentId is kept as
-        // a fallback target for older callers.
-        const target = isValidUdid(body.udid)
-          ? body.udid
-          : typeof body.enrollmentId === "string" && body.enrollmentId.length > 0
-            ? body.enrollmentId
-            : null;
+        // UDID — when a real push (refresh) is wanted. Only a genuine device
+        // UDID is a valid NanoMDM enqueue target. The guided wizard sends
+        // `enrollmentId` (a pairing artifact, NOT the device's UDID); pushing
+        // to it FK-violates NanoMDM's enrollment_queue (enqueue 500). So we no
+        // longer treat enrollmentId as a target — a missing UDID means initial
+        // attestation runs from the enrollment profile (ACME device-attest-01
+        // on install), which is exactly the wizard's case.
+        const target = isValidUdid(body.udid) ? body.udid : null;
 
         const result = await pushAttestationCommand(body.serial, target);
-        const status = result.status === "error" ? 502 : 200;
-        return mdmJson(result, status);
+
+        // The push is ADVISORY. The attestation chain is produced by the
+        // device-attest-01 at profile-install and read back via
+        // /attestation-chain (which the wizard polls with its own timeout). A
+        // NanoMDM enqueue/push failure therefore must NOT dead-end the wizard
+        // with a 502 — surface the reason in the body and let the poll decide
+        // readiness. Auth/validation problems above are still hard errors.
+        return mdmJson(result, 200);
       },
     },
   },


### PR DESCRIPTION
## What

The Secure Mode wizard's **"Attest now"** step was failing with **HTTP 502** even though the device enrolls correctly and a valid attestation chain is produced.

## Root cause

The wizard POSTs `{serial, enrollmentId}` to `/api/agent/mdm/push-attestation`. The route treated `enrollmentId` as a NanoMDM enqueue target — but it's a pairing artifact, **not** the device's UDID. With NanoMDM now backed by Postgres, enqueuing to a non-enrollment id fails with:

```
pq: insert or update on table "enrollment_queue" violates foreign key
constraint "enrollment_queue_id_fkey"  (enqueue 500)
```

The route mapped that NanoMDM error to **502**, dead-ending the wizard.

## Fix

- **Only a genuine device UDID is a valid NanoMDM target.** Stop using `enrollmentId` as a fallback target. No UDID → initial attestation runs from the enrollment profile (ACME `device-attest-01` on install), which is exactly the wizard's case.
- **The push is advisory.** The attestation chain is produced at profile-install and read back via `/attestation-chain` (the wizard polls it with its own 180s timeout). A NanoMDM push failure now returns **200** with the reason in the body instead of 502, so the poll decides readiness.

The agent's `request-attestation` path is unaffected — it resolves the real UDID from the serial and carries the pubkey freshness nonce.

## Verification

- Reproduced: `{serial, enrollmentId:"…"}` → 502 (FK violation); `{serial}` → 200 bundled.
- On the affected Mac, the stored chain is a genuine Apple Enterprise Attestation chain whose freshness OID `1.2.840.113635.100.8.11.1` == `sha256(agent pubkey)` — i.e. the attestation underneath was always correct; only the advisory-push UI step was broken.
- `typecheck`, `oxfmt --check`, `oxlint`, `knip` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)