### PR TITLE
feat(secure-mode): gate attestation on a live publish session

### DIFF
--- a/packages/console/src/routes/api/agent.status.ts
+++ b/packages/console/src/routes/api/agent.status.ts
@@ -9,11 +9,13 @@
 // income lands as `receipt-in` ledger events (see
 // packages/exchange/src/token-balance.ts).
 
+import type { Did } from "@atcute/lexicons";
 import { createFileRoute } from "@tanstack/react-router";
 
 import { runTraced } from "@/lib/o11y.server.ts";
 
 import { appviewListProvidersEffect } from "@/integrations/appview/appview.server.ts";
+import { restoreAtprotoSessionEffect } from "@/integrations/auth/atproto.server.ts";
 import { resolveBearerKey } from "@/lib/api-keys.server.ts";
 import { cocoreConfig } from "@/lib/cocore-config.ts";
 import { sumReceiptInSince } from "@/lib/earnings.ts";
@@ -73,13 +75,23 @@ export const Route = createFileRoute("/api/agent/status")({
         const since = Date.now() - 24 * 60 * 60 * 1000;
         // All three degrade gracefully so a single backend hiccup yields
         // partial data the menu can still render, not a 500.
-        const [balance, events, providers, confidential] = await Promise.all([
+        const [balance, events, providers, confidential, session] = await Promise.all([
           getBalance(did).catch(() => null),
           listEvents(did, EVENT_LIMIT).catch(() => ({ events: [] })),
           runTraced("appview.listProviders", appviewListProvidersEffect).catch(() => ({
             providers: [],
           })),
           fetchConfidentialEligible(did),
+          // The authoritative "can this agent publish right now?" probe: the
+          // same DPoP session restore every putRecord depends on. A null means
+          // the OAuth session is dead (refresh token expired/revoked) and the
+          // agent is silently failing all publishes — so the menu can prompt a
+          // re-sign-in instead of leaving a stale record on screen. We do NOT
+          // surface a transient probe error as needsReauth (don't nag): only a
+          // definitive null counts.
+          runTraced("auth.sessionProbe", restoreAtprotoSessionEffect(did as Did))
+            .then((s) => s === null)
+            .catch(() => false),
         ]);
 
         const earned24h = sumReceiptInSince(events.events, since);
@@ -96,6 +108,7 @@ export const Route = createFileRoute("/api/agent/status")({
             trustLevel: body.trustLevel ?? null,
             confidential,
             agentVersion: body.binaryVersion ?? null,
+            needsReauth: session,
           }),
           { status: 200, headers: { "content-type": "application/json" } },
         );

--- a/provider-shell/Sources/CoCoreShell/CocoreShellApp.swift
+++ b/provider-shell/Sources/CoCoreShell/CocoreShellApp.swift
@@ -95,6 +95,12 @@ final class AppState: ObservableObject {
     @Published var balanceCredits: Int?
     @Published var agentVersion: String?
     @Published var serving: Bool = false
+    /// The agent's ATProto publish session is dead (refresh token expired or
+    /// revoked) — every record publish is 401ing, so trustLevel/receipts are
+    /// silently stuck. The UI surfaces a "Sign in again" prompt and the Secure
+    /// Mode wizard refuses to attest until it clears (attesting is pointless
+    /// when the result can't be published).
+    @Published var needsReauth: Bool = false
     @Published var lastError: String?
 
     private enum CacheKey {
@@ -124,6 +130,7 @@ final class AppState: ObservableObject {
         let trustLevel: String?
         let confidential: Bool?
         let agentVersion: String?
+        let needsReauth: Bool?
     }
 
     func refreshStatus() async {
@@ -153,6 +160,7 @@ final class AppState: ObservableObject {
             if let bal = e.balance { d.set(bal, forKey: CacheKey.balance) }
             if let raw = e.trustLevel, let t = TrustLevel(rawValue: raw) { self.trustLevel = t }
             self.confidential = e.confidential ?? false
+            self.needsReauth = e.needsReauth ?? false
             if let v = e.agentVersion {
                 self.agentVersion = v
                 d.set(v, forKey: CacheKey.agentVersion)

--- a/provider-shell/Sources/CoCoreShell/MainTabView.swift
+++ b/provider-shell/Sources/CoCoreShell/MainTabView.swift
@@ -33,6 +33,7 @@ final class MainWindowController {
     private let onSignOut: () -> Void
     private let onEnableSecureMode: () -> Void
     private let onSetConfidential: (Bool) -> Void
+    private let onReauth: () -> Void
     private let onSendBugReport: () -> Void
     private let onCheckUpdates: () -> Void
     private let onInstallUpdate: () -> Void
@@ -48,6 +49,7 @@ final class MainWindowController {
         onSignOut: @escaping () -> Void,
         onEnableSecureMode: @escaping () -> Void,
         onSetConfidential: @escaping (Bool) -> Void,
+        onReauth: @escaping () -> Void,
         onSendBugReport: @escaping () -> Void,
         onCheckUpdates: @escaping () -> Void,
         onInstallUpdate: @escaping () -> Void,
@@ -62,6 +64,7 @@ final class MainWindowController {
         self.onSignOut = onSignOut
         self.onEnableSecureMode = onEnableSecureMode
         self.onSetConfidential = onSetConfidential
+        self.onReauth = onReauth
         self.onSendBugReport = onSendBugReport
         self.onCheckUpdates = onCheckUpdates
         self.onInstallUpdate = onInstallUpdate
@@ -79,7 +82,8 @@ final class MainWindowController {
                         onOpenSetupGuide: onOpenSetupGuide,
                         onSignOut: onSignOut,
                         onEnableSecureMode: onEnableSecureMode,
-                        onSetConfidential: onSetConfidential)),
+                        onSetConfidential: onSetConfidential,
+                        onReauth: onReauth)),
                 tab("Models", "cpu", ModelsView(manager: modelManager)),
                 tab("Settings", "gearshape", PreferencesView(supervisor: supervisor)),
                 tab("About", "info.circle",
@@ -149,11 +153,15 @@ private struct StatusTab: View {
     let onSignOut: () -> Void
     let onEnableSecureMode: () -> Void
     let onSetConfidential: (Bool) -> Void
+    let onReauth: () -> Void
     @EnvironmentObject private var state: AppState
 
     var body: some View {
         Form {
-            StatusRows(onEnableSecureMode: onEnableSecureMode, onSetConfidential: onSetConfidential)
+            StatusRows(
+                onEnableSecureMode: onEnableSecureMode,
+                onSetConfidential: onSetConfidential,
+                onReauth: onReauth)
             Section {
                 Button("View my profile on console", action: onOpenProfile)
                     .disabled(state.session == nil)

--- a/provider-shell/Sources/CoCoreShell/MenuBarController.swift
+++ b/provider-shell/Sources/CoCoreShell/MenuBarController.swift
@@ -605,9 +605,7 @@ final class MenuBarController {
     /// no longer a top-level tray item.
     private lazy var secureModeWizard: SecureModeWizardController = SecureModeWizardController(
         state: state,
-        supervisor: supervisor,
         updater: updater,
-        modelManager: modelManager,
         onReauth: { [weak self] in self?.signIn() }
     )
 

--- a/provider-shell/Sources/CoCoreShell/MenuBarController.swift
+++ b/provider-shell/Sources/CoCoreShell/MenuBarController.swift
@@ -590,6 +590,7 @@ final class MenuBarController {
         onSignOut: { [weak self] in self?.signOut() },
         onEnableSecureMode: { [weak self] in self?.secureModeWizard.show() },
         onSetConfidential: { [weak self] on in self?.setConfidential(on) },
+        onReauth: { [weak self] in self?.signIn() },
         onSendBugReport: { [weak self] in self?.sendBugReport() },
         onCheckUpdates: { [weak self] in self?.checkUpdates() },
         onInstallUpdate: { [weak self] in self?.installUpdate() },
@@ -606,7 +607,8 @@ final class MenuBarController {
         state: state,
         supervisor: supervisor,
         updater: updater,
-        modelManager: modelManager
+        modelManager: modelManager,
+        onReauth: { [weak self] in self?.signIn() }
     )
 
     /// Public entry point so the AppDelegate can surface the main window when

--- a/provider-shell/Sources/CoCoreShell/SecureModeWizard.swift
+++ b/provider-shell/Sources/CoCoreShell/SecureModeWizard.swift
@@ -16,22 +16,16 @@ import SwiftUI
 final class SecureModeWizardController {
     private var window: NSWindow?
     private let state: AppState
-    private let supervisor: AgentSupervisor
     private let updater: Updater
-    private let modelManager: ModelManager
     private let onReauth: () -> Void
 
     init(
         state: AppState,
-        supervisor: AgentSupervisor,
         updater: Updater,
-        modelManager: ModelManager,
         onReauth: @escaping () -> Void
     ) {
         self.state = state
-        self.supervisor = supervisor
         self.updater = updater
-        self.modelManager = modelManager
         self.onReauth = onReauth
     }
 
@@ -39,9 +33,7 @@ final class SecureModeWizardController {
         if window == nil {
             let view = SecureModeWizardView(
                 state: state,
-                supervisor: supervisor,
                 updater: updater,
-                modelManager: modelManager,
                 close: { [weak self] in self?.window?.close() },
                 onReauth: { [weak self] in
                     self?.window?.close()
@@ -159,9 +151,7 @@ enum EnrollmentProbe {
 
 struct SecureModeWizardView: View {
     @ObservedObject var state: AppState
-    let supervisor: AgentSupervisor
     @ObservedObject var updater: Updater
-    @ObservedObject var modelManager: ModelManager
     let close: () -> Void
     /// Route to the sign-in flow. Used when the agent's publish session is
     /// dead — attesting is pointless until it's restored.
@@ -170,7 +160,7 @@ struct SecureModeWizardView: View {
     /// The wizard's explicit state machine. Every step is reachable, and
     /// every step is skippable (→ Secure Mode stays best-effort).
     enum Step: Int {
-        case intro, updating, enroll, attesting, models, done
+        case intro, updating, enroll, attesting, done
     }
 
     @State private var step: Step = .intro
@@ -186,12 +176,6 @@ struct SecureModeWizardView: View {
     @State private var enrollmentId: String?
     @State private var serial: String = HardwareID.serial()
     @State private var udid: String = HardwareID.udid()
-
-    // Models step state (WS-D recommended set + WS-E meter).
-    @State private var recommended: [ModelManager.CatalogEntry] =
-        ModelManager.recommendedCatalog
-    @State private var schedules: [String: ModelManager.Window] = [:]
-    @State private var pinning = false
 
     /// Active poll task, cancelled when the user skips/closes a step.
     @State private var pollTask: Task<Void, Never>?
@@ -275,7 +259,6 @@ struct SecureModeWizardView: View {
         case .updating: updatingStep
         case .enroll: enrollStep
         case .attesting: attestingStep
-        case .models: modelsStep
         case .done: doneStep
         }
     }
@@ -385,94 +368,6 @@ struct SecureModeWizardView: View {
                         .disabled(working)
                     Button("Retry") { startAttestingStep() }
                         .disabled(working)
-                }
-            }
-        }
-    }
-
-    private var modelsStep: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Pin the recommended models")
-                .font(.title3).bold().foregroundStyle(Brand.accentText)
-            Text(
-                "Now that this Mac is attested, pin the latest-&-greatest models so it serves "
-                    + "the best mix it can run."
-            )
-            .fixedSize(horizontal: false, vertical: true)
-
-            // WS-E meter, computed over the recommended set we'd pin.
-            secureBudgetMeter
-
-            // The recommended set (WS-D), each marked fits/too-big.
-            VStack(alignment: .leading, spacing: 6) {
-                ForEach(recommended, id: \.nsid) { item in
-                    let fits = ModelManager.fitsDevice(item.minRamGB)
-                    HStack(spacing: 8) {
-                        Image(systemName: fits ? "checkmark.circle.fill" : "exclamationmark.triangle")
-                            .foregroundStyle(fits ? AnyShapeStyle(Brand.success) : AnyShapeStyle(.orange))
-                        VStack(alignment: .leading, spacing: 1) {
-                            Text(item.label).font(.caption).fontWeight(.medium)
-                            Text(
-                                fits
-                                    ? "needs ~\(item.minRamGB)GB · fits this Mac"
-                                    : "needs ~\(item.minRamGB)GB — more than this Mac"
-                            )
-                            .font(.caption2).foregroundStyle(.secondary)
-                        }
-                        Spacer()
-                    }
-                    .opacity(fits ? 1 : 0.6)
-                }
-            }
-
-            HStack(spacing: 10) {
-                Button(pinning ? "Pinning…" : "Pin recommended (latest & greatest)") {
-                    pinRecommended()
-                }
-                .buttonStyle(.borderedProminent).controlSize(.large)
-                .disabled(pinning)
-                Button("Keep my current selection") { advance(to: .done) }
-            }
-        }
-        .task {
-            // Refresh the recommended set live (WS-D), falling back to mirror.
-            recommended = await ModelManager.fetchRecommended()
-            schedules = ModelManager.loadSchedules()
-        }
-    }
-
-    /// The WS-E meter, computed over the recommended set this step would pin
-    /// (so the owner sees the budget BEFORE committing).
-    @ViewBuilder private var secureBudgetMeter: some View {
-        if ModelManager.deviceRamGB > 0 {
-            let fitting = recommended.filter { ModelManager.fitsDevice($0.minRamGB) }.map { $0.nsid }
-            let report = ModelManager.budgetReport(models: fitting, schedules: schedules)
-            let (color, title): (Color, String) = {
-                switch report.status {
-                case .comfortable: return (Brand.success, "Comfortable")
-                case .tight: return (.orange, "Tight")
-                case .oversubscribed: return (.red, "Oversubscribed")
-                }
-            }()
-            VStack(alignment: .leading, spacing: 6) {
-                GeometryReader { geo in
-                    let w = geo.size.width
-                    let denom = CGFloat(max(report.totalGB, max(report.usedGB, 1)))
-                    let usedW = min(w, w * CGFloat(report.usedGB) / denom)
-                    ZStack(alignment: .leading) {
-                        RoundedRectangle(cornerRadius: 5).fill(Color.secondary.opacity(0.18))
-                        RoundedRectangle(cornerRadius: 5).fill(color.opacity(0.85))
-                            .frame(width: max(0, usedW))
-                    }
-                }
-                .frame(height: 12)
-                Text(
-                    "Pinned \(report.usedGB) GB · Reserved for you \(report.reserveGB) GB · This Mac \(report.totalGB) GB"
-                )
-                .font(.caption2).foregroundStyle(.secondary)
-                HStack(spacing: 6) {
-                    Circle().fill(color).frame(width: 8, height: 8)
-                    Text(title).font(.caption.weight(.semibold)).foregroundStyle(color)
                 }
             }
         }
@@ -682,7 +577,7 @@ struct SecureModeWizardView: View {
                     hasChain(data) {
                     working = false
                     progress = nil
-                    advance(to: .models)
+                    advance(to: .done)
                     return
                 }
                 try? await Task.sleep(nanoseconds: 4_000_000_000)
@@ -706,27 +601,6 @@ struct SecureModeWizardView: View {
             if let chain = obj["chain"] as? String { return !chain.isEmpty }
         }
         return false
-    }
-
-    // MARK: step 5 — models
-
-    private func pinRecommended() {
-        pinning = true
-        Task {
-            // Pin the recommended models that fit this Mac, via the existing
-            // model-set path (which bounces the agent). We use the manager's
-            // add() so it goes through the same CLI/UserDefaults logic the
-            // Models window uses.
-            let fitting = recommended.filter { ModelManager.fitsDevice($0.minRamGB) }
-            for item in fitting where !modelManager.models.contains(item.nsid) {
-                await modelManager.add(item.nsid)
-            }
-            // Bounce the agent so it re-reads the new set.
-            await supervisor.stop()
-            await supervisor.start()
-            pinning = false
-            advance(to: .done)
-        }
     }
 
     // MARK: helpers

--- a/provider-shell/Sources/CoCoreShell/SecureModeWizard.swift
+++ b/provider-shell/Sources/CoCoreShell/SecureModeWizard.swift
@@ -19,12 +19,20 @@ final class SecureModeWizardController {
     private let supervisor: AgentSupervisor
     private let updater: Updater
     private let modelManager: ModelManager
+    private let onReauth: () -> Void
 
-    init(state: AppState, supervisor: AgentSupervisor, updater: Updater, modelManager: ModelManager) {
+    init(
+        state: AppState,
+        supervisor: AgentSupervisor,
+        updater: Updater,
+        modelManager: ModelManager,
+        onReauth: @escaping () -> Void
+    ) {
         self.state = state
         self.supervisor = supervisor
         self.updater = updater
         self.modelManager = modelManager
+        self.onReauth = onReauth
     }
 
     func show() {
@@ -34,7 +42,11 @@ final class SecureModeWizardController {
                 supervisor: supervisor,
                 updater: updater,
                 modelManager: modelManager,
-                close: { [weak self] in self?.window?.close() }
+                close: { [weak self] in self?.window?.close() },
+                onReauth: { [weak self] in
+                    self?.window?.close()
+                    self?.onReauth()
+                }
             )
             let w = NSWindow(contentViewController: NSHostingController(rootView: view))
             w.title = "co/core — Secure Mode"
@@ -151,6 +163,9 @@ struct SecureModeWizardView: View {
     @ObservedObject var updater: Updater
     @ObservedObject var modelManager: ModelManager
     let close: () -> Void
+    /// Route to the sign-in flow. Used when the agent's publish session is
+    /// dead — attesting is pointless until it's restored.
+    let onReauth: () -> Void
 
     /// The wizard's explicit state machine. Every step is reachable, and
     /// every step is skippable (→ Secure Mode stays best-effort).
@@ -344,17 +359,33 @@ struct SecureModeWizardView: View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Attesting your hardware")
                 .font(.title3).bold().foregroundStyle(Brand.accentText)
-            Text(
-                "Your Mac is enrolled. We're now asking it to attest its hardware identity and "
-                    + "building the attestation chain. This can take a moment."
-            )
-            .fixedSize(horizontal: false, vertical: true)
-            HStack(spacing: 10) {
-                Button("Attest now") { startAttestingStep() }
+            if state.needsReauth {
+                // Attesting writes a provider record. If the agent's publish
+                // session is dead, that write 401s and the attestation never
+                // lands — the silent dead-end this guard exists to prevent. So
+                // we refuse to attest and route to sign-in first.
+                Label(
+                    "Your co/core session expired, so this Mac can't publish its attestation "
+                        + "yet. Sign in again, then come back to Secure Mode.",
+                    systemImage: "exclamationmark.triangle.fill"
+                )
+                .foregroundStyle(.orange)
+                .fixedSize(horizontal: false, vertical: true)
+                Button("Sign in again") { onReauth() }
                     .buttonStyle(.borderedProminent).controlSize(.large)
-                    .disabled(working)
-                Button("Retry") { startAttestingStep() }
-                    .disabled(working)
+            } else {
+                Text(
+                    "Your Mac is enrolled. We're now asking it to attest its hardware identity and "
+                        + "building the attestation chain. This can take a moment."
+                )
+                .fixedSize(horizontal: false, vertical: true)
+                HStack(spacing: 10) {
+                    Button("Attest now") { startAttestingStep() }
+                        .buttonStyle(.borderedProminent).controlSize(.large)
+                        .disabled(working)
+                    Button("Retry") { startAttestingStep() }
+                        .disabled(working)
+                }
             }
         }
     }
@@ -586,6 +617,15 @@ struct SecureModeWizardView: View {
         working = true
         progress = "Requesting a hardware attestation…"
         Task {
+            // Confirm the agent can actually publish before we attest — a fresh
+            // status probe sets state.needsReauth. Attesting with a dead session
+            // produces a chain the agent can never publish (the silent dead-end).
+            await state.refreshStatus()
+            if state.needsReauth {
+                working = false
+                progress = nil
+                return  // attestingStep now renders the "Sign in again" panel
+            }
             do {
                 try await pushAttestation()
                 progress = "Building the attestation chain…"

--- a/provider-shell/Sources/CoCoreShell/StatusView.swift
+++ b/provider-shell/Sources/CoCoreShell/StatusView.swift
@@ -22,6 +22,11 @@ struct StatusRows: View {
     /// (true = enable). Left `nil` to hide the control (read-only contexts).
     var onSetConfidential: ((Bool) -> Void)? = nil
 
+    /// When provided, a "Sign in again" action shown while the agent's publish
+    /// session is dead (`state.needsReauth`). Routes to the sign-in flow. Left
+    /// `nil` in read-only contexts (the banner still warns, just no button).
+    var onReauth: (() -> Void)? = nil
+
     var body: some View {
         Section("Identity") {
             if let s = state.session {
@@ -32,6 +37,24 @@ struct StatusRows: View {
                 }
             } else {
                 Text("Not signed in.")
+            }
+        }
+        // A dead publish session is the one failure that silently freezes
+        // everything downstream — trustLevel, receipts, the machine listing —
+        // while the agent still looks like it's "Serving". Surface it loudly,
+        // above the rest, with a one-click path back to sign-in.
+        if state.needsReauth, state.session != nil {
+            Section {
+                Label(
+                    "Your co/core session expired. The agent can't publish "
+                        + "records — receipts and Secure Mode are paused until you sign in again.",
+                    systemImage: "exclamationmark.triangle.fill"
+                )
+                .foregroundStyle(.orange)
+                .fixedSize(horizontal: false, vertical: true)
+                if let onReauth {
+                    Button("Sign in again", action: onReauth)
+                }
             }
         }
         Section("Serving") {
@@ -70,7 +93,11 @@ struct StatusRows: View {
             // need this agent's bearer key (session.apiKey/apiBase), so there's
             // nothing to enable until pairing completes. Mirrors the Identity
             // section's signed-in / "Not signed in" split above.
-            if state.trustLevel != .hardwareAttested, state.session != nil,
+            // Don't offer to enable Secure Mode while the publish session is
+            // dead: the wizard would attest, then fail to publish the result
+            // (exactly the silent dead-end this guard exists to prevent). The
+            // re-auth banner above is the actionable step until it clears.
+            if state.trustLevel != .hardwareAttested, state.session != nil, !state.needsReauth,
                 let enable = onEnableSecureMode {
                 Button("Enable Secure Mode…", action: enable)
             }


### PR DESCRIPTION
## Why

You ran the Secure Mode wizard to completion, but Status still said **Off — self-attested**. The attestation itself was fine (genuine Apple Enterprise Attestation chain, freshness OID == `sha256(agent pubkey)`). The real problem: the agent's **ATProto publish session was dead** — every `putRecord` was 401ing with `AuthRequired: underlying ATProto session no longer valid; re-authenticate` (since ~06:28 local, likely from the `cocore.dev` host/`client_id` cutover invalidating the refresh token).

So the agent couldn't write its provider record. The console kept serving the last record it *did* manage to publish (this morning's `0.9.23` / self-attested one), and the tray reads `trustLevel` straight from that frozen record. Same dead session also **disabled receipts** — while the tray still showed "Serving."

Attesting while the publish session is dead is wasted work. This makes the wizard refuse to do it, and surfaces the dead session everywhere.

## What

- **console** — `/api/agent/status` now returns `needsReauth`, computed from the same DPoP session restore (`restoreAtprotoSessionEffect`) that every `putRecord` depends on. A definitive `null` (session truly dead) → `true`; a transient probe error never nags. Ships on deploy, no app rebuild.
- **tray Status** — a prominent "session expired — sign in again" banner (one-click sign-in) when `needsReauth`, and we stop offering "Enable Secure Mode…" while it's set.
- **Secure Mode wizard** — the attest step refreshes status first and, if the session is dead, shows **"Sign in again"** instead of attesting — no more attesting into a record that can't be published.

## Verification

- `packages/console` typecheck / oxfmt / oxlint clean.
- `swift build` of the tray clean (all callback wiring through `MainWindowController` → `StatusTab` → `StatusRows` and `SecureModeWizardController` → `SecureModeWizardView`).

The console half lands on deploy and immediately fixes the diagnosis gap. The tray half (banner + wizard gate) ships in the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)