### PR TITLE
fix(secure-mode): agent can read its own attestation chain back

### DIFF
--- a/provider/src/mda_loader.rs
+++ b/provider/src/mda_loader.rs
@@ -430,11 +430,25 @@ pub fn acquire_auto(console_base: &str, api_key: &str, public_key_b64: &str) -> 
         urlencode(&serial)
     );
     // Try the already-captured chain first (reused across refreshes; rate-limit
-    // friendly — we never re-request once we have a bound chain).
-    if let Ok(chain) = load_from_url(&chain_url) {
+    // friendly — we never re-request once we have a bound chain). The endpoint
+    // is bearer-gated, so we MUST present the api_key (a keyless GET 401s).
+    if let Ok(chain) = load_from_url_with_key(&chain_url, api_key) {
         if !chain.is_empty() {
-            tracing::info!(certs = chain.len(), "MDA auto: loaded captured chain");
-            return chain;
+            // Only trust a chain that actually binds THIS signing key. After a
+            // key rotation (fresh install → new Secure Enclave key) the
+            // coordinator may still hold a chain bound to the OLD key; embedding
+            // it would never verify, and — worse — would mask the need to
+            // re-request. A non-binding chain is treated as "no chain".
+            if chain_binds_key(&chain, public_key_b64) {
+                tracing::info!(
+                    certs = chain.len(),
+                    "MDA auto: loaded captured chain (binds key)"
+                );
+                return chain;
+            }
+            tracing::warn!(
+                "MDA auto: captured chain does not bind the current signing key (rotated?); re-requesting"
+            );
         }
     }
     // No chain yet → request one (cooldown-gated), then return empty for now.
@@ -452,6 +466,20 @@ pub fn acquire_auto(console_base: &str, api_key: &str, public_key_b64: &str) -> 
         tracing::debug!("MDA auto: within request cooldown; not re-requesting this boot");
     }
     Vec::new()
+}
+
+/// True iff `chain` (DER, leaf-first) verifies and is bound to the
+/// base64-encoded P-256 signing key `public_key_b64` — by the leaf key itself
+/// or by the freshness nonce (`sha256(pubkey)`), per `MdaResult::binds_key`.
+/// Fail-closed: any decode/verify error → false (treat as not bound).
+fn chain_binds_key(chain: &[Vec<u8>], public_key_b64: &str) -> bool {
+    use base64::{engine::general_purpose::STANDARD as B64, Engine};
+    let Ok(raw) = B64.decode(public_key_b64) else {
+        return false;
+    };
+    crate::mda::verify_chain(chain)
+        .map(|r| r.binds_key(&raw))
+        .unwrap_or(false)
 }
 
 /// Is this Mac currently MDM-enrolled? Reads `profiles status -type enrollment`
@@ -616,10 +644,27 @@ pub fn load_from_binary(binary: &Path) -> Result<Vec<Vec<u8>>> {
 /// `try_load` runs synchronously at boot and the agent's `reqwest` is
 /// async-only; this mirrors the attest-binary strategy's subprocess shape.
 pub fn load_from_url(url: &str) -> Result<Vec<Vec<u8>>> {
+    load_from_url_with_key(url, "")
+}
+
+/// Like `load_from_url`, but presents the agent's bearer key. The
+/// `/api/agent/mdm/attestation-chain` endpoint is `authenticateAgent`-gated, so
+/// a keyless GET 401s (curl `-f` → exit 56) — which is why the auto path could
+/// request an attestation but never read the captured chain back. `acquire_auto`
+/// always has the key, so it must use this.
+pub fn load_from_url_with_key(url: &str, api_key: &str) -> Result<Vec<Vec<u8>>> {
     use std::process::Command;
 
+    let mut args = vec!["-fsSL", "--max-time", "20"];
+    let auth;
+    if !api_key.is_empty() {
+        auth = format!("authorization: Bearer {api_key}");
+        args.push("-H");
+        args.push(&auth);
+    }
+    args.push(url);
     let out = Command::new("curl")
-        .args(["-fsSL", "--max-time", "20", url])
+        .args(&args)
         .output()
         .with_context(|| format!("invoking curl for {url}"))?;
     if !out.status.success() {


### PR DESCRIPTION
## Why Secure Mode never turned on

On a fresh install I attested the Mac, the chain landed bound to the new key — but the tray stayed **Off — self-attested**. Root cause, proven on the box:

\`acquire_auto\` fetches the captured chain with \`curl -fsSL <url>\` and **no Authorization header**. But \`/api/agent/mdm/attestation-chain\` is \`authenticateAgent\`-gated, so the keyless GET returns **401** → curl \`-f\` exits 56 → \`acquire_auto\` falls through and re-requests. Every boot. The agent could *request* an attestation (that call passes the key) but could **never read the resulting chain back**, so it never flipped to hardware-attested.

```
$ curl -fsSL '.../attestation-chain?serial=...'              # what the agent did
curl: (56) The requested URL returned error: 401
$ curl -fsSL '...' -H 'authorization: Bearer <key>'          # with the key
200  → {"status":"captured","chain":[...]}
```

## Fix

- `load_from_url_with_key` — curl with `authorization: Bearer`, used by `acquire_auto` (which always has the api_key). `load_from_url` keeps the keyless behavior for the env-configured URL path.
- **Key-binding gate**: only trust a chain that actually binds *this* signing key (`mda::verify_chain` + `binds_key`). After a key rotation (fresh install → new Secure Enclave key) the coordinator may still hold a chain bound to the **old** key — embedding it would never verify and, worse, would mask the need to re-request. A non-binding chain is now treated as "no chain" → re-request. (This is exactly the case that bit me: stale `401ec177…` chain vs. new `b016a7c3…` key.)

## Verification

- Reproduced the 401/exit-56 vs 200-with-bearer above.
- `cargo build`, `cargo clippy`, `cargo fmt --check` clean; 111 lib tests pass.

Ships in the next agent release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)