### PR TITLE
chore(release): bump to 0.9.26

### DIFF
--- a/provider-shell/Sources/CoCoreShell/Resources/Info.plist
+++ b/provider-shell/Sources/CoCoreShell/Resources/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleName</key>
 	<string>co/core</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.25</string>
+	<string>0.9.26</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -22,7 +22,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>925</string>
+	<string>926</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/provider/Cargo.lock
+++ b/provider/Cargo.lock
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "cocore-provider"
-version = "0.9.25"
+version = "0.9.26"
 dependencies = [
  "anyhow",
  "asn1-rs",

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cocore-provider"
-version = "0.9.25"
+version = "0.9.26"
 edition = "2021"
 description = "co/core provider agent: runs hardened compute and publishes signed receipts to AT Protocol."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Release bump for 0.9.26. Bumps \`provider/Cargo.toml\`, \`Cargo.lock\`, and Info.plist \`CFBundleShortVersionString\`/\`CFBundleVersion\` (0.9.25/925 → 0.9.26/926).

Carries:
- **#71** — Secure Mode fix: the agent fetches its attestation chain *with* the bearer key (was 401ing) and only trusts a chain bound to the current signing key. → `hardware-attested` works.
- **Confidential restored** — this release is cut with `COCORE_BUILD_APNS=1`, nesting the signed/measured `CoCoreProvider.app` worker (native in-process MLX). 0.9.24/0.9.25 were cut without the flag and dropped it.

After merge: tag `v0.9.26` → CI tarball → publish notarized `cocore.app.zip` (18.6MB, includes the worker) + `SHA256SUMS`. **Ops:** set `COCORE_KNOWN_GOOD_CDHASHES=da3ea9334d1deb2eb93ad5f9ec7f570968f5e1ad` on the advisor so the confidential worker flips eligible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)