### PR TITLE
fix(console): serialize ATProto session restore per DID (refresh-token race)

### DIFF
--- a/packages/console/src/integrations/auth/atproto.server.ts
+++ b/packages/console/src/integrations/auth/atproto.server.ts
@@ -192,14 +192,37 @@ export function atprotoOAuthCallbackEffect(
 
 type RestoredSession = Awaited<ReturnType<OAuthClient["restore"]>>;
 
+// Per-DID single-flight around OAuthClient.restore(). When an access token has
+// expired, restore() refreshes it — and the DPoP refresh token is SINGLE-USE
+// (rotated on every refresh). The agent writes a burst of records (provisioning
+// provider + provider + attestation) as separate concurrent requests; without
+// coalescing, each restore refreshes in parallel, races on the same refresh
+// token, and all but one fail with invalid_grant — which the client treats as a
+// dead session and deletes, so EVERY subsequent write 401s ("underlying ATProto
+// session no longer valid") until re-auth… whereupon the next burst kills it
+// again. `@atcute/oauth-node-client` has no built-in request lock, so we
+// serialize per DID here: the first caller refreshes once, the rest await it and
+// reuse the freshly-rotated session.
+const restoreInFlight = new Map<string, Promise<RestoredSession>>();
+
+function restoreSessionOnce(did: Did): Promise<RestoredSession> {
+  const existing = restoreInFlight.get(did);
+  if (existing) return existing;
+  const p = getAtprotoOAuth()
+    .restore(did)
+    .finally(() => {
+      restoreInFlight.delete(did);
+    });
+  restoreInFlight.set(did, p);
+  return p;
+}
+
 function oauthRestoreSessionEffect(did: Did): Effect.Effect<RestoredSession, unknown> {
   return Effect.async((resume) => {
-    void getAtprotoOAuth()
-      .restore(did)
-      .then(
-        (r) => resume(Effect.succeed(r)),
-        (e) => resume(Effect.fail(e)),
-      );
+    void restoreSessionOnce(did).then(
+      (r) => resume(Effect.succeed(r)),
+      (e) => resume(Effect.fail(e)),
+    );
   });
 }
 


### PR DESCRIPTION
## The recurring "session keeps dying" — root cause

The agent writes **three** records in a burst (provisioning provider, provider, attestation) as separate concurrent HTTP requests. Each handler calls `restoreSessionOr401` → `OAuthClient.restore(did)`, which **refreshes** the access token when it's expired. The DPoP refresh token is **single-use** (rotated on every refresh), and `@atcute/oauth-node-client` is constructed with **no request lock** — so the three refreshes run in parallel, race on the same refresh token, and all but one fail with `invalid_grant`. The client treats that as a dead session and deletes it → every subsequent write `401`s with *"underlying ATProto session no longer valid; re-authenticate"*… and re-auth only helps until the next burst burns the fresh token again.

This is exactly the observed flapping: the agent's 3-write bursts all 401, while a **single** restore (`/api/agent/status`'s `needsReauth` probe) returns valid every time.

## Fix

A per-DID single-flight `Map` around `restore()`: the first caller refreshes once; concurrent callers for the same DID await it and reuse the freshly-rotated session. No more parallel refreshes cannibalizing the rotating token.

## Impact

Console-only — ships on deploy, no agent release. Unblocks publishing (provider record + receipts) and therefore both `hardware-attested` (the chain is captured + key-bound) and `attested-confidential` (the 0.9.26 worker is already code-attesting) on the affected Mac.

typecheck / oxfmt / oxlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)