### PR TITLE
fix(secure-mode): instrument MDA chain load to pin the silent-empty bug

### DIFF
--- a/provider/src/mda_loader.rs
+++ b/provider/src/mda_loader.rs
@@ -429,6 +429,12 @@ pub fn acquire_auto(console_base: &str, api_key: &str, public_key_b64: &str) -> 
         "{base}/api/agent/mdm/attestation-chain?serial={}",
         urlencode(&serial)
     );
+    tracing::info!(
+        serial = %serial,
+        base = %base,
+        api_key_len = api_key.len(),
+        "MDA auto: fetching captured chain"
+    );
     // Try the already-captured chain first (reused across refreshes; rate-limit
     // friendly — we never re-request once we have a bound chain). The endpoint
     // is bearer-gated, so we MUST present the api_key (a keyless GET 401s).
@@ -655,10 +661,20 @@ pub fn load_from_url(url: &str) -> Result<Vec<Vec<u8>>> {
 pub fn load_from_url_with_key(url: &str, api_key: &str) -> Result<Vec<Vec<u8>>> {
     use std::process::Command;
 
-    let mut args = vec!["-fsSL", "--max-time", "20"];
-    let auth;
-    if !api_key.is_empty() {
-        auth = format!("authorization: Bearer {api_key}");
+    // Deliberately NOT `-f`: on a non-2xx we want to SEE the status + body, not
+    // have curl collapse it into a bare non-zero exit. `-w` appends the HTTP
+    // status after the body behind a marker so we can split it back out. This
+    // is the diagnostic that pins why the in-process worker's chain GET can
+    // come back empty while an identical manual GET returns the chain.
+    const MARKER: &str = "\n__COCORE_HTTP__";
+    let wfmt = format!("{MARKER}%{{http_code}}");
+    let auth = if api_key.is_empty() {
+        String::new()
+    } else {
+        format!("authorization: Bearer {api_key}")
+    };
+    let mut args: Vec<&str> = vec!["-sSL", "--max-time", "20", "-w", &wfmt];
+    if !auth.is_empty() {
         args.push("-H");
         args.push(&auth);
     }
@@ -668,10 +684,28 @@ pub fn load_from_url_with_key(url: &str, api_key: &str) -> Result<Vec<Vec<u8>>> 
         .output()
         .with_context(|| format!("invoking curl for {url}"))?;
     if !out.status.success() {
-        bail!("curl for MDA chain URL exited with {}", out.status);
+        bail!("curl for MDA chain URL failed to run: {}", out.status);
     }
-    let body = String::from_utf8(out.stdout).context("MDA chain URL response is not UTF-8")?;
-    parse_chain_response(&body)
+    let raw = String::from_utf8(out.stdout).context("MDA chain URL response is not UTF-8")?;
+    let (body, status) = raw.rsplit_once(MARKER).unwrap_or((raw.as_str(), "?"));
+    let status = status.trim();
+    if status != "200" {
+        tracing::warn!(
+            http_status = status,
+            authed = !auth.is_empty(),
+            body = %body.chars().take(200).collect::<String>(),
+            "MDA chain GET returned non-200; treating as no chain this refresh"
+        );
+        return Ok(Vec::new());
+    }
+    let chain = parse_chain_response(body)?;
+    if chain.is_empty() {
+        tracing::info!(
+            authed = !auth.is_empty(),
+            "MDA chain GET 200 but no chain captured yet"
+        );
+    }
+    Ok(chain)
 }
 
 /// Accept either a raw PEM chain or the console's JSON shape


### PR DESCRIPTION
## Why

On the canary, the agent (0.9.26) requests + captures a key-bound attestation chain correctly, but its read-*back* (`acquire_auto` → `load_from_url_with_key`) returns **empty inside the worker process** — while the *identical* authed `curl` from a shell returns the chain. So it never embeds the chain and stays `self-attested`, with **no log** saying why.

Ruled out black-box: chain present, key valid (the worker's POST to `request-attestation` with the same key succeeds), URL/serial correct, binary has the auth fix, device enrolled. The blindness is because `load_from_url_with_key` used `curl -fsSL` — any non-2xx collapsed into a bare non-zero exit, and within the request cooldown the fallthrough only logs at `debug`.

## What

- Drop `-f`; capture the HTTP status via `-w` and **log it on any non-200**, including whether the bearer was actually sent (`authed=`) and a 200-char body snippet. This distinguishes `401-with-key` vs `401-without-key` vs `200-but-pending` — exactly what we couldn't tell before.
- `acquire_auto` logs the `serial` / `base` / `api_key_len` it's fetching with.
- Non-200 now returns `Ok(empty)` (not `Err`), so runtime behavior is unchanged — only visibility improves.

Ships in 0.9.27 (cut **with `COCORE_BUILD_APNS=1`** to keep the confidential worker). The next boot's logs will name the cause; expected follow-up is a one-line fix once we see it.

`cargo build`/`clippy`/`fmt` clean; 111 lib tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)