### PR TITLE
chore(release): bump to 0.9.27

### DIFF
--- a/provider-shell/Sources/CoCoreShell/Resources/Info.plist
+++ b/provider-shell/Sources/CoCoreShell/Resources/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleName</key>
 	<string>co/core</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.26</string>
+	<string>0.9.27</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -22,7 +22,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>926</string>
+	<string>927</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/provider/Cargo.lock
+++ b/provider/Cargo.lock
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "cocore-provider"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "anyhow",
  "asn1-rs",

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cocore-provider"
-version = "0.9.26"
+version = "0.9.27"
 edition = "2021"
 description = "co/core provider agent: runs hardened compute and publishes signed receipts to AT Protocol."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Release bump for 0.9.27. Bumps \`Cargo.toml\`, \`Cargo.lock\`, Info.plist \`CFBundleShortVersionString\`/\`CFBundleVersion\` (0.9.26/926 → 0.9.27/927).

Carries **#74** — instrumented MDA chain load (logs the chain GET's HTTP status + whether the bearer was sent + a body snippet) so the next boot reveals why the worker's chain read-back comes back empty.

Cut **with `COCORE_BUILD_APNS=1`** (confidential worker nested + notarized; app.zip ~18.7MB).

**Ops after merge:** new worker cdHash is `72be23c6efc81fa043a4affaf47dabcd256cba66` — update \`COCORE_KNOWN_GOOD_CDHASHES\` on the advisor to this (replaces the stale \`da3ea933…\`).

Note: the \`configure\` preview-env check may fail (the recurring per-PR Railway clone missing \`ATPROTO_PRIVATE_KEY_JWK\`) — infra-only, unrelated to the release; admin-merge past it like #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)