### PR TITLE
fix(secure-mode): serve attestation chain as PEM so the agent can parse it

### DIFF
--- a/packages/console/src/routes/api/agent.mdm.attestation-chain.ts
+++ b/packages/console/src/routes/api/agent.mdm.attestation-chain.ts
@@ -29,6 +29,19 @@ import {
   mdmJson,
 } from "@/lib/mdm-coordinator.server.ts";
 
+// We STORE the chain as base64 DER (the ingest contract below), but the agent's
+// reader runs every entry through a PEM block parser — so a base64-DER entry
+// yields ZERO certs and the agent, despite a 200 with a real chain, parses
+// nothing, never embeds it, and stays self-attested. Wrap each cert in PEM
+// markers on the way out so the agent's PEM parser sees real certificates.
+// (The wizard's reader only checks the array is non-empty, so it's unaffected.)
+function derB64ToPem(entry: string): string {
+  if (entry.includes("-----BEGIN")) return entry; // already PEM
+  const b64 = entry.replace(/\s+/g, "");
+  const wrapped = b64.match(/.{1,64}/g)?.join("\n") ?? b64;
+  return `-----BEGIN CERTIFICATE-----\n${wrapped}\n-----END CERTIFICATE-----`;
+}
+
 export const Route = createFileRoute("/api/agent/mdm/attestation-chain")({
   server: {
     handlers: {
@@ -43,7 +56,8 @@ export const Route = createFileRoute("/api/agent/mdm/attestation-chain")({
 
         const result = await fetchAttestationChain(serial);
         const status = result.status === "error" ? 502 : 200;
-        return mdmJson(result, status);
+        const chain = result.chain ? result.chain.map(derB64ToPem) : result.chain;
+        return mdmJson({ ...result, chain }, status);
       },
 
       POST: async ({ request }) => {


### PR DESCRIPTION
## THE root cause of hardware-attested never turning on

The 0.9.27 instrumented build finally showed it:
```
MDA auto: fetching captured chain  serial=…  authed=true
MDA chain GET 200 but no chain captured yet  authed=true
```
The agent authenticates fine and the console returns **200 with a real chain** — but the agent parses **zero certs**. Why: the chain is stored + served as **base64 DER** (`MIIDXjCC…`, no PEM header), but the agent's reader (`mda_loader::parse_chain_response`) runs each JSON-array entry through a **PEM block parser**. No `-----BEGIN-----` markers → zero certs → never embeds → stuck `self-attested`. Not infra, not auth, not the session saga — a format mismatch that's been there all along.

## Fix

PEM-wrap each cert at the GET boundary. The agent's PEM parser then sees real certificates and embeds the Apple-rooted, key-bound chain → `hardware-attested`.

- **Console-only — fixes the already-installed 0.9.27 agent on deploy. No agent release, no cdHash re-register.**
- Only consumers of this GET are the agent (PEM-capable) and the wizard (checks array non-empty) — both fine.
- Follow-up (non-blocking): also teach `parse_chain_response` to accept base64 DER so the contract is symmetric.

typecheck / oxfmt / oxlint clean.

Note: `configure` preview-env check may fail (the recurring per-PR Railway clone flake) — infra-only; admin-merge like #74/#75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)