### PR TITLE
fix(console): surface the OAuth restore-failure reason (was swallowed to null)

### DIFF
--- a/packages/console/src/integrations/auth/atproto.server.ts
+++ b/packages/console/src/integrations/auth/atproto.server.ts
@@ -226,9 +226,33 @@ function oauthRestoreSessionEffect(did: Did): Effect.Effect<RestoredSession, unk
   });
 }
 
+// DIAGNOSTIC: restore historically swallowed ANY error into `null`, so a dead
+// session was indistinguishable from a refresh-failure / store-miss / DPoP
+// problem. Capture the last failure reason per DID (logged + surfaced in the
+// 401 body) so we can finally see WHY a freshly-authed session won't restore.
+const lastRestoreErrorByDid = new Map<string, string>();
+
+export function lastRestoreError(did: string): string | undefined {
+  return lastRestoreErrorByDid.get(did);
+}
+
 export const restoreAtprotoSessionEffect = (did: Did): Effect.Effect<RestoredSession | null> =>
   Effect.gen(function* () {
     const outcome = yield* Effect.either(oauthRestoreSessionEffect(did));
-    if (Either.isLeft(outcome)) return null;
+    if (Either.isLeft(outcome)) {
+      const reason =
+        outcome.left instanceof Error
+          ? `${outcome.left.name}: ${outcome.left.message}`
+          : String(outcome.left);
+      lastRestoreErrorByDid.set(did, reason.slice(0, 300));
+      console.error(`[atproto.restore] FAILED did=${did} reason=${reason}`);
+      return null;
+    }
+    if (outcome.right == null) {
+      lastRestoreErrorByDid.set(did, "restore returned null (no stored session)");
+      console.error(`[atproto.restore] null session did=${did} (no stored session)`);
+      return null;
+    }
+    lastRestoreErrorByDid.delete(did);
     return outcome.right;
   });

--- a/packages/console/src/lib/pds-write.server.ts
+++ b/packages/console/src/lib/pds-write.server.ts
@@ -19,7 +19,10 @@ import { Duration, Effect, Schedule } from "effect";
 
 import { runTraced } from "@/lib/o11y.server.ts";
 
-import { restoreAtprotoSessionEffect } from "@/integrations/auth/atproto.server.ts";
+import {
+  lastRestoreError,
+  restoreAtprotoSessionEffect,
+} from "@/integrations/auth/atproto.server.ts";
 import { resolveBearerKey } from "@/lib/api-keys.server.ts";
 import { forwardPdsWrite, isAppviewForwardConfigured } from "@/lib/appview-pds-forward.server.ts";
 import { cocoreConfig } from "@/lib/cocore-config.ts";
@@ -117,7 +120,14 @@ function resolveCallerDid(request: Request): { did: Did } | Response {
 async function restoreSessionOr401(did: Did) {
   const session = await runTraced("auth.restoreSession", restoreAtprotoSessionEffect(did));
   if (!session) {
-    return jsonError(401, "underlying ATProto session no longer valid; re-authenticate");
+    // DIAGNOSTIC: include the captured restore-failure reason so the cause is
+    // visible without server log access (refresh invalid_grant vs no stored
+    // session vs DPoP/keyset mismatch). See atproto.server.ts lastRestoreError.
+    const reason = lastRestoreError(did) ?? "unknown";
+    return jsonError(
+      401,
+      `underlying ATProto session no longer valid; re-authenticate (${reason})`,
+    );
   }
   return session;
 }


### PR DESCRIPTION
## Why

We're stuck: the agent now loads + binds the attestation chain (the #76 parse fix works — `MDA auto: loaded captured chain (binds key) certs=2`), but every publish 401s with *"underlying ATProto session no longer valid"* — and **re-auth no longer revives it**. `restoreAtprotoSessionEffect` swallows **any** error into `null`, so we can't tell a refresh `invalid_grant` from a missing stored session from a DPoP/keyset mismatch. (My `needsReauth` probe is also unreliable — it reports `false` while writes 401, because the swallow hides the real state.)

## What

- Capture the last restore-failure reason per DID, `console.error` it, and expose `lastRestoreError(did)`.
- The write-path 401 now includes the reason inline, e.g. `…re-authenticate (TokenRefreshError: invalid_grant)` — readable via a plain curl, no Railway log access required.

Pure diagnostic; happy path unchanged. typecheck / oxfmt / oxlint clean.

Next: merge + deploy, then one `deleteRecord` curl prints the real reason and I fix the session bug for good (it's the last blocker — the chain pipeline is proven working).

Note: `configure` preview-env check may fail (recurring per-PR Railway clone flake) — infra-only; admin-merge like #74/#75/#76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)