### PR TITLE
fix+feat(auth): finish single-owner OAuth cutover (no more session cannibalization) + cocore.dev domain patch

### DIFF
--- a/infra/services/src/main.ts
+++ b/infra/services/src/main.ts
@@ -75,7 +75,7 @@ const CONFIG = Effect.runSync(
     ),
     exchangeApiKey: secretOption("COCORE_EXCHANGE_API_KEY"),
     exchangeApiBase: Config.string("COCORE_EXCHANGE_API_BASE").pipe(
-      Config.withDefault("https://console.cocore.dev"),
+      Config.withDefault("https://cocore.dev"),
     ),
     exchangePrivateJwk: secretOption("COCORE_EXCHANGE_PRIVATE_KEY_JWK"),
     feeBps: Config.integer("COCORE_FEE_BPS").pipe(Config.withDefault(500)),
@@ -258,7 +258,7 @@ const TERMS_URI =
   Option.getOrUndefined(CONFIG.termsUri) ??
   (CONSOLE_PUBLIC_URL
     ? `${CONSOLE_PUBLIC_URL.replace(/\/$/, "")}/terms`
-    : "https://console.cocore.dev/terms");
+    : "https://cocore.dev/terms");
 
 // Shared secret used to authenticate the bridge's internal write path.
 // Kept Redacted; unwrapped only where buildAppviewSplit consumes it.

--- a/packages/appview/src/pds/write.ts
+++ b/packages/appview/src/pds/write.ts
@@ -40,7 +40,7 @@ import {
   type RestoredSession,
   restoreSession,
 } from "../auth/oauth-client.ts";
-import { bearer, err, header, jsonBody, ok } from "../api/http-app.ts";
+import { bearer, err, header, jsonBody, ok, searchParams } from "../api/http-app.ts";
 
 const COLLECTION_PREFIX = "dev.cocore.";
 
@@ -484,6 +484,166 @@ function internalRoute<A extends { collection: string }>(
   }).pipe(Effect.withSpan(`appview.internal.pds.${op}`));
 }
 
+// ---- internal single-owner session proxy ----------------------------
+//
+// At login the console hands every user OAuth session here, making the
+// AppView the SOLE owner/refresher (refresh tokens are single-use; two
+// refreshers cannibalize one token — see the module header). But the
+// console UI still needs to read/write the user's PDS (profile, provider
+// records, friends, terms, avatar) and mint service-auth JWTs. Rather than
+// the console holding a live session and refreshing in parallel, it wraps a
+// thin `AppviewBackedSession` whose every `.handle()` lands here. We
+// restore the owned session and replay the exact request, returning the
+// upstream status + body verbatim — so the console refreshes NOTHING.
+//
+// The path is allowlisted to the operations the console legitimately
+// performs as the user: `com.atproto.repo.*` (record CRUD + uploadBlob)
+// and `com.atproto.server.getServiceAuth` (scoped service-auth minting).
+// The internal secret is the trust boundary (private-network only), same
+// as the write endpoints; the allowlist keeps this from becoming a
+// god-mode XRPC proxy.
+
+const ALLOWED_PROXY_PREFIXES = [
+  "/xrpc/com.atproto.repo.",
+  "/xrpc/com.atproto.server.getServiceAuth",
+];
+
+function isAllowedProxyPath(p: string): boolean {
+  return ALLOWED_PROXY_PREFIXES.some((pre) => p.startsWith(pre));
+}
+
+interface ProxyEnvelope {
+  did: string;
+  path: string;
+  method: string;
+  /** Request body forwarded verbatim (already serialized by the console).
+   *  Mutually exclusive with `blobB64`. */
+  bodyText?: string;
+  /** base64 request body for binary ops (uploadBlob). */
+  blobB64?: string;
+  /** Upstream Content-Type for the request body. */
+  contentType?: string;
+}
+
+function parseProxy(b: Record<string, unknown>): ProxyEnvelope | string {
+  if (typeof b.did !== "string" || !b.did.startsWith("did:")) return "did required";
+  if (typeof b.path !== "string") return "path required";
+  if (!isAllowedProxyPath(b.path)) return "path not allowed";
+  const method = typeof b.method === "string" ? b.method.toUpperCase() : "GET";
+  if (b.bodyText !== undefined && typeof b.bodyText !== "string") return "bodyText must be a string";
+  if (b.blobB64 !== undefined && typeof b.blobB64 !== "string") return "blobB64 must be a string";
+  if (b.contentType !== undefined && typeof b.contentType !== "string")
+    return "contentType must be a string";
+  return {
+    did: b.did,
+    path: b.path,
+    method,
+    ...(typeof b.bodyText === "string" ? { bodyText: b.bodyText } : {}),
+    ...(typeof b.blobB64 === "string" ? { blobB64: b.blobB64 } : {}),
+    ...(typeof b.contentType === "string" ? { contentType: b.contentType } : {}),
+  };
+}
+
+/** `POST /internal/pds/proxy` — replay a single allowlisted XRPC call using
+ *  the AppView-owned session for the asserted DID. The response is an
+ *  internal-200 envelope `{ status, bodyText, contentType }` carrying the
+ *  UPSTREAM PDS status, so the console shim can reconstruct the exact
+ *  `Response` the local session would have produced (incl. a 401 for a dead
+ *  session). A restore throw — not an upstream 4xx/5xx — is the only thing
+ *  that surfaces as an internal non-2xx. */
+function internalProxyRoute(ctx: PdsWriteContext, secret: string) {
+  return Effect.gen(function* () {
+    if (yield* methodNotPost) return err(405, { error: "MethodNotAllowed" });
+
+    const presented = yield* header("x-cocore-internal-secret");
+    if (typeof presented !== "string" || !secretEquals(presented, secret))
+      return err(403, { error: "Forbidden" });
+
+    const parsed = yield* Effect.either(jsonBody);
+    if (parsed._tag === "Left")
+      return err(400, { error: "InvalidRequest", message: parsed.left.message });
+    const a = parseProxy(parsed.right as Record<string, unknown>);
+    if (typeof a === "string") return err(400, { error: "InvalidRequest", message: a });
+
+    const restored = yield* Effect.tryPromise({
+      try: () => restoreSession(ctx.oauth, a.did as Did),
+      catch: (e) => e,
+    }).pipe(Effect.either);
+    if (restored._tag === "Left") {
+      const e = restored.left;
+      return err(502, {
+        error: "SessionRestoreFailed",
+        message: `restore session for ${a.did}: ${e instanceof Error ? e.message : String(e)}`,
+      });
+    }
+    if (!restored.right)
+      return ok({
+        status: 401,
+        bodyText: JSON.stringify({
+          error: "AuthRequired",
+          message: "underlying ATProto session no longer valid; re-authenticate",
+        }),
+        contentType: "application/json",
+      });
+    const session = restored.right;
+
+    yield* Effect.annotateCurrentSpan("pds.did", a.did);
+    const meta: PdsMeta = {};
+    return yield* runCore("proxy", meta, async () => {
+      const init = {
+        method: a.method,
+        headers: a.contentType ? { "content-type": a.contentType } : {},
+        body:
+          a.blobB64 !== undefined
+            ? Buffer.from(a.blobB64, "base64")
+            : a.bodyText !== undefined
+              ? a.bodyText
+              : undefined,
+      } as Parameters<RestoredSession["handle"]>[1];
+      const r = await pdsCall(session, a.path, init, meta);
+      const bodyText = await r.text().catch(() => "");
+      return ok({
+        status: r.status,
+        bodyText,
+        contentType: r.headers?.get?.("content-type") ?? "application/json",
+      });
+    });
+  }).pipe(Effect.withSpan("appview.internal.pds.proxy"));
+}
+
+/** `GET /internal/pds/session-info?did=` — NON-refreshing read of the owned
+ *  session blob. `present` is true only when a stored session still carries
+ *  a refresh token (the honest "is the user logged in" signal without
+ *  rotating anything); `aud` is the user's PDS URL for display. Lets the
+ *  console decide auth without ever calling restore(). */
+function internalSessionInfoRoute(ctx: PdsWriteContext, secret: string) {
+  return Effect.gen(function* () {
+    const presented = yield* header("x-cocore-internal-secret");
+    if (typeof presented !== "string" || !secretEquals(presented, secret))
+      return err(403, { error: "Forbidden" });
+
+    const sp = yield* searchParams;
+    const did = sp.get("did");
+    if (!did || !did.startsWith("did:"))
+      return err(400, { error: "InvalidRequest", message: "did required" });
+
+    const raw = ctx.accounts.getOAuthSession(did);
+    if (!raw) return ok({ present: false, aud: null });
+    let aud: string | null = null;
+    let hasRefresh = false;
+    try {
+      const parsed = JSON.parse(raw) as {
+        tokenSet?: { aud?: string; refresh_token?: string };
+      };
+      aud = typeof parsed.tokenSet?.aud === "string" ? parsed.tokenSet.aud : null;
+      hasRefresh = Boolean(parsed.tokenSet?.refresh_token);
+    } catch {
+      /* malformed blob → treat as absent */
+    }
+    return ok({ present: hasRefresh, aud });
+  }).pipe(Effect.withSpan("appview.internal.pds.sessionInfo"));
+}
+
 // ---- router builders ------------------------------------------------
 
 /** Public, bearer-key-authed `/pds/*` write endpoints. Canonical paths
@@ -547,5 +707,10 @@ export function buildInternalPdsRouter(
       "/internal/pds/deleteRecord",
       internalRoute(ctx, secret, "deleteRecord", parseDelete, doDelete),
     ),
+    // Single-owner session proxy + non-refreshing liveness read: let the
+    // console run its UI/inference PDS ops and check session liveness
+    // through the AppView's owned session, so it never refreshes itself.
+    HttpRouter.all("/internal/pds/proxy", internalProxyRoute(ctx, secret)),
+    HttpRouter.get("/internal/pds/session-info", internalSessionInfoRoute(ctx, secret)),
   );
 }

--- a/packages/appview/src/pds/write.ts
+++ b/packages/appview/src/pds/write.ts
@@ -530,7 +530,8 @@ function parseProxy(b: Record<string, unknown>): ProxyEnvelope | string {
   if (typeof b.path !== "string") return "path required";
   if (!isAllowedProxyPath(b.path)) return "path not allowed";
   const method = typeof b.method === "string" ? b.method.toUpperCase() : "GET";
-  if (b.bodyText !== undefined && typeof b.bodyText !== "string") return "bodyText must be a string";
+  if (b.bodyText !== undefined && typeof b.bodyText !== "string")
+    return "bodyText must be a string";
   if (b.blobB64 !== undefined && typeof b.blobB64 !== "string") return "blobB64 must be a string";
   if (b.contentType !== undefined && typeof b.contentType !== "string")
     return "contentType must be a string";

--- a/packages/console/agent-install.sh
+++ b/packages/console/agent-install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # cocore agent installer — the curl-pipe-sh entrypoint.
 #
-# Hosted at https://console.cocore.dev/agent. v0.6.0 collapsed the
+# Hosted at https://cocore.dev/agent. v0.6.0 collapsed the
 # previous stub vs. inference variants into a single install path
 # (see the doc-comment on `release.yml` for the dyld-crash that
 # motivated it). Every install now:
@@ -22,10 +22,10 @@
 #      "your machine is registered and serving."
 #
 # Usage:
-#   curl -fsSL https://console.cocore.dev/agent | sh
+#   curl -fsSL https://cocore.dev/agent | sh
 #
 #   # skip the picker by pre-setting the env var:
-#   curl -fsSL https://console.cocore.dev/agent | \
+#   curl -fsSL https://cocore.dev/agent | \
 #     COCORE_INFERENCE_MODELS=mlx-community/Qwen2.5-3B-Instruct-4bit sh
 #
 # ## Why the script prompts before downloading
@@ -47,7 +47,7 @@
 #   COCORE_PREFIX            install prefix    (default: $HOME/.local)
 #   COCORE_RELEASE_TAG       pin a release tag (default: latest)
 #   COCORE_INSTALL_BASE      override console-side base URL
-#                            (default: https://console.cocore.dev/agent)
+#                            (default: https://cocore.dev/agent)
 #   COCORE_INFERENCE_MODELS  comma-separated HF model ids
 #                            (default: picked interactively from /dev/tty,
 #                            or the largest catalog entry that fits if
@@ -67,7 +67,7 @@
 set -euo pipefail
 
 COCORE_PREFIX="${COCORE_PREFIX:-$HOME/.local}"
-COCORE_INSTALL_BASE="${COCORE_INSTALL_BASE:-https://console.cocore.dev/agent}"
+COCORE_INSTALL_BASE="${COCORE_INSTALL_BASE:-https://cocore.dev/agent}"
 COCORE_RELEASE_TAG="${COCORE_RELEASE_TAG:-}"
 COCORE_SKIP_PICKER="${COCORE_SKIP_PICKER:-0}"
 # Capture the user's pair intent BEFORE we override
@@ -351,7 +351,7 @@ fi
 phase "pair this machine"
 note "Open the URL below in any browser signed into the cocore console."
 note "Once you approve there, this script will block until your machine"
-note "appears on console.cocore.dev/machines, then print 'done'."
+note "appears on cocore.dev/machines, then print 'done'."
 note ""
 
 # Run pair. The binary prints the URL + polls. We don't capture stdout
@@ -386,7 +386,7 @@ if [[ -f "$HOME/.cocore/session.json" ]]; then
 fi
 if [[ -z "$session_did" ]]; then
   warn "could not read DID from $HOME/.cocore/session.json; skipping registration wait."
-  note "Open console.cocore.dev/machines in a few seconds to check status."
+  note "Open cocore.dev/machines in a few seconds to check status."
   exit 0
 fi
 note "your DID: $session_did"
@@ -420,8 +420,8 @@ if (( registered == 1 )); then
   note "Model: $chosen_model"
   note "DID:   $session_did"
   note ""
-  note "  console.cocore.dev/machines  — your machines"
-  note "  console.cocore.dev/models    — the model directory"
+  note "  cocore.dev/machines  — your machines"
+  note "  cocore.dev/models    — the model directory"
   note ""
   note "Day-to-day: use the cocore icon in your menu bar (updates,"
   note "model toggles, re-pair, restart). No more terminal needed."
@@ -436,5 +436,5 @@ else
   warn "longer on first boot if the model is still downloading from HF."
   note "Watch the log to see what's happening:"
   note "  tail -f $LOG_DIR/stderr.log"
-  note "Then refresh console.cocore.dev/machines."
+  note "Then refresh cocore.dev/machines."
 fi

--- a/packages/console/agent-uninstall.sh
+++ b/packages/console/agent-uninstall.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # cocore agent uninstaller — the curl | sh entrypoint.
 #
-# Hosted at https://console.cocore.dev/agent/uninstall. Removes
+# Hosted at https://cocore.dev/agent/uninstall. Removes
 # every artifact a cocore install leaves on disk:
 #
 #   1. Bounces the LaunchAgent and removes it from launchd's
@@ -41,9 +41,9 @@
 #     via /account or an operator-side wipe.
 #
 # Usage:
-#   curl -fsSL https://console.cocore.dev/agent/uninstall | sh
-#   curl -fsSL https://console.cocore.dev/agent/uninstall | sh -s -- --unpair
-#   curl -fsSL https://console.cocore.dev/agent/uninstall | COCORE_UNPAIR=1 sh
+#   curl -fsSL https://cocore.dev/agent/uninstall | sh
+#   curl -fsSL https://cocore.dev/agent/uninstall | sh -s -- --unpair
+#   curl -fsSL https://cocore.dev/agent/uninstall | COCORE_UNPAIR=1 sh
 #
 # Env knobs (all optional):
 #   COCORE_PREFIX     install prefix to clean (default: $HOME/.local)
@@ -213,15 +213,15 @@ unpair_pds() {
     return 0
   fi
   if [[ ! -f "$STATE_DIR/identity.pem" ]]; then
-    warn "no $STATE_DIR/identity.pem — this looks like a Secure-Enclave build (the private key isn't on disk). Skipping PDS-side unpair; finish at https://console.cocore.dev/machines."
+    warn "no $STATE_DIR/identity.pem — this looks like a Secure-Enclave build (the private key isn't on disk). Skipping PDS-side unpair; finish at https://cocore.dev/machines."
     return 0
   fi
   if ! command -v openssl >/dev/null 2>&1; then
-    warn "openssl not found in PATH — cannot derive attestationPubKey. Finish at https://console.cocore.dev/machines."
+    warn "openssl not found in PATH — cannot derive attestationPubKey. Finish at https://cocore.dev/machines."
     return 0
   fi
   if ! command -v python3 >/dev/null 2>&1; then
-    warn "python3 not found in PATH — cannot parse PDS listRecords response. Finish at https://console.cocore.dev/machines."
+    warn "python3 not found in PATH — cannot parse PDS listRecords response. Finish at https://cocore.dev/machines."
     return 0
   fi
 
@@ -248,14 +248,14 @@ print(s.get("apiKey", ""))
 print(s.get("apiBase", ""))
 ' "$STATE_DIR/session.json" 2>/dev/null || true)"
   if [[ -z "$session_blob" ]]; then
-    warn "could not parse $STATE_DIR/session.json. Finish at https://console.cocore.dev/machines."
+    warn "could not parse $STATE_DIR/session.json. Finish at https://cocore.dev/machines."
     return 0
   fi
   did="$(printf '%s\n' "$session_blob" | sed -n '1p')"
   api_key="$(printf '%s\n' "$session_blob" | sed -n '2p')"
   api_base="$(printf '%s\n' "$session_blob" | sed -n '3p')"
   if [[ -z "$did" || -z "$api_key" || -z "$api_base" ]]; then
-    warn "$STATE_DIR/session.json missing did/apiKey/apiBase. Finish at https://console.cocore.dev/machines."
+    warn "$STATE_DIR/session.json missing did/apiKey/apiBase. Finish at https://cocore.dev/machines."
     return 0
   fi
 
@@ -275,7 +275,7 @@ print(s.get("apiBase", ""))
   pubkey="$(openssl pkey -in "$STATE_DIR/identity.pem" -pubout -outform DER 2>/dev/null \
             | tail -c 64 | base64 | tr -d '\n ' || true)"
   if [[ -z "$pubkey" ]]; then
-    warn "could not extract pubkey from $STATE_DIR/identity.pem. Finish at https://console.cocore.dev/machines."
+    warn "could not extract pubkey from $STATE_DIR/identity.pem. Finish at https://cocore.dev/machines."
     return 0
   fi
 
@@ -287,7 +287,7 @@ print(s.get("apiBase", ""))
     did:plc:*)
       local plc_doc
       if ! plc_doc="$(curl -fsSL "https://plc.directory/$did" 2>/dev/null)"; then
-        warn "could not resolve $did via plc.directory. Finish at https://console.cocore.dev/machines."
+        warn "could not resolve $did via plc.directory. Finish at https://cocore.dev/machines."
         return 0
       fi
       pds="$(printf '%s' "$plc_doc" | python3 -c '
@@ -303,12 +303,12 @@ for s in d.get("service", []) or []:
       pds="https://${did#did:web:}"
       ;;
     *)
-      warn "unsupported DID method on session ($did). Finish at https://console.cocore.dev/machines."
+      warn "unsupported DID method on session ($did). Finish at https://cocore.dev/machines."
       return 0
       ;;
   esac
   if [[ -z "$pds" ]]; then
-    warn "could not find atproto_pds service for $did. Finish at https://console.cocore.dev/machines."
+    warn "could not find atproto_pds service for $did. Finish at https://cocore.dev/machines."
     return 0
   fi
 
@@ -325,7 +325,7 @@ for s in d.get("service", []) or []:
     fi
     local body
     if ! body="$(curl -fsSL "$url" 2>/dev/null)"; then
-      warn "PDS listRecords failed. Finish at https://console.cocore.dev/machines."
+      warn "PDS listRecords failed. Finish at https://cocore.dev/machines."
       return 0
     fi
     local found
@@ -376,7 +376,7 @@ print("cursor", data.get("cursor") or "")
       -d "{\"collection\":\"dev.cocore.compute.provider\",\"rkey\":\"$rkey\"}" \
       "$api_base/api/xrpc/dev.cocore.proxy.deleteRecord" 2>&1)" || {
     warn "deleteRecord rejected: ${del_resp:0:240}"
-    warn "finish manually at https://console.cocore.dev/machines."
+    warn "finish manually at https://cocore.dev/machines."
     return 0
   }
   note "deleted provider record $rkey from PDS for $did."
@@ -446,7 +446,7 @@ else
     note "there, or re-run this script with --unpair (or COCORE_UNPAIR=1)."
   fi
   note "to remove ALL identity-level state, use 'Wipe my data' at"
-  note "https://console.cocore.dev/account."
+  note "https://cocore.dev/account."
   note ""
-  note "to reinstall: curl -fsSL https://console.cocore.dev/agent | sh"
+  note "to reinstall: curl -fsSL https://cocore.dev/agent | sh"
 fi

--- a/packages/console/playwright.config.ts
+++ b/packages/console/playwright.config.ts
@@ -20,7 +20,7 @@
 // without a paired test PDS. That's a follow-up.
 //
 // CI runs against `vite preview` (a static build) on port 4173, so
-// the tests don't need network access to console.cocore.dev or any
+// the tests don't need network access to cocore.dev or any
 // upstream services. Anything that hits an external host (bsky
 // firehose, advisor, etc.) is mocked away by the lack of those env
 // vars in CI.

--- a/packages/console/public/openapi.yaml
+++ b/packages/console/public/openapi.yaml
@@ -10,16 +10,16 @@ info:
     served, and bearer-key authed agent status.
 
     To use an OpenAI-compatible client, set its base URL to
-    `https://console.cocore.dev/v1` (the client appends `/chat/completions`,
+    `https://cocore.dev/v1` (the client appends `/chat/completions`,
     `/models`, … exactly as it does for `https://api.openai.com/v1`) and swap
     in a cocore API key. The legacy `/api/v1/*` paths are kept as aliases and
-    behave identically. Pointing a client at `https://console.cocore.dev`
+    behave identically. Pointing a client at `https://cocore.dev`
     alone (no version segment) hits the console web app and returns HTML, not
     the API.
   license:
     name: MIT OR Apache-2.0
 servers:
-  - url: https://console.cocore.dev
+  - url: https://cocore.dev
     description: Production
 tags:
   - name: Inference

--- a/packages/console/src/components/machines/cli-snippets.ts
+++ b/packages/console/src/components/machines/cli-snippets.ts
@@ -7,5 +7,5 @@
 // step a follow-up only when the user opted out of pair via
 // COCORE_SKIP_PAIR=1.
 
-export const CLI_LINES_INSTALL = `curl -fsSL console.cocore.dev/agent | sh`;
-export const CLI_ONE_LINER_INSTALL = "curl -fsSL console.cocore.dev/agent | sh";
+export const CLI_LINES_INSTALL = `curl -fsSL cocore.dev/agent | sh`;
+export const CLI_ONE_LINER_INSTALL = "curl -fsSL cocore.dev/agent | sh";

--- a/packages/console/src/components/start/StartGuide.tsx
+++ b/packages/console/src/components/start/StartGuide.tsx
@@ -177,9 +177,7 @@ export function StartGuide() {
   }, [directory.data]);
 
   const baseUrl =
-    typeof window !== "undefined"
-      ? `${window.location.origin}/v1`
-      : "https://cocore.dev/v1";
+    typeof window !== "undefined" ? `${window.location.origin}/v1` : "https://cocore.dev/v1";
   const snippet = useMemo(
     () => buildSnippet(REQUESTER_SNIPPET_LANG, baseUrl, model),
     [baseUrl, model],
@@ -271,8 +269,8 @@ export function StartGuide() {
                     style={styles.cliCopy}
                   />
                   <div>
-                    <span {...stylex.props(styles.cliPrompt)}>$</span>curl -fsSL
-                    cocore.dev/agent | sh
+                    <span {...stylex.props(styles.cliPrompt)}>$</span>curl -fsSL cocore.dev/agent |
+                    sh
                   </div>
                 </div>
 

--- a/packages/console/src/components/start/StartGuide.tsx
+++ b/packages/console/src/components/start/StartGuide.tsx
@@ -179,7 +179,7 @@ export function StartGuide() {
   const baseUrl =
     typeof window !== "undefined"
       ? `${window.location.origin}/v1`
-      : "https://console.cocore.dev/v1";
+      : "https://cocore.dev/v1";
   const snippet = useMemo(
     () => buildSnippet(REQUESTER_SNIPPET_LANG, baseUrl, model),
     [baseUrl, model],
@@ -267,12 +267,12 @@ export function StartGuide() {
                 </Body>
                 <div {...stylex.props(styles.cliBox)}>
                   <CopyToClipboardButton
-                    text="curl -fsSL console.cocore.dev/agent | sh"
+                    text="curl -fsSL cocore.dev/agent | sh"
                     style={styles.cliCopy}
                   />
                   <div>
                     <span {...stylex.props(styles.cliPrompt)}>$</span>curl -fsSL
-                    console.cocore.dev/agent | sh
+                    cocore.dev/agent | sh
                   </div>
                 </div>
 

--- a/packages/console/src/integrations/auth/atproto.server.ts
+++ b/packages/console/src/integrations/auth/atproto.server.ts
@@ -236,6 +236,26 @@ export function lastRestoreError(did: string): string | undefined {
   return lastRestoreErrorByDid.get(did);
 }
 
+/** Non-refreshing liveness check for a stored OAuth session.
+ *
+ * Reads the persisted blob straight from the session store and reports
+ * whether the user must re-authenticate — WITHOUT calling `restore()`.
+ * `restore()` refreshes an expired access token, which rotates the
+ * SINGLE-USE DPoP refresh token and writes the new one back; using it as a
+ * status probe therefore actively cannibalizes the very session it claims
+ * to observe (the AppView is the designated single refresher — see
+ * packages/appview/src/pds/write.ts — so the console must never rotate the
+ * token in parallel). A session is still restorable as long as a blob
+ * exists and carries a refresh token; only a missing blob (deleted after
+ * an `invalid_grant`) or a refresh-token-less blob means re-auth is
+ * actually required. This is honest (no false "all good" once the session
+ * is gone) and inert (no rotation), unlike the old restore-based probe. */
+export function sessionNeedsReauth(did: Did): boolean {
+  const stored = sessionStore.get(did);
+  if (!stored) return true;
+  return !stored.tokenSet?.refresh_token;
+}
+
 export const restoreAtprotoSessionEffect = (did: Did): Effect.Effect<RestoredSession | null> =>
   Effect.gen(function* () {
     const outcome = yield* Effect.either(oauthRestoreSessionEffect(did));

--- a/packages/console/src/lib/appview-backed-session.server.ts
+++ b/packages/console/src/lib/appview-backed-session.server.ts
@@ -1,0 +1,147 @@
+// A stand-in for an @atcute `OAuthSession` whose PDS calls are executed by
+// the AppView instead of by a live, locally-refreshed session.
+//
+// THE point of the cutover: refresh tokens are single-use, so exactly one
+// process may refresh a given session. The AppView is that owner (the
+// console hands the session off at login). If the console ALSO restored +
+// refreshed locally — which `OAuthClient.restore()` does whenever the
+// access token is stale — the two would rotate the same token in parallel
+// and cannibalize it (`invalid_grant` → dead session → write 401s). So
+// when forwarding is configured, the console's auth entry points return
+// THIS object instead of a restored session. Every `.handle()` it makes is
+// replayed by the AppView's owned session via `/internal/pds/proxy`; the
+// console refreshes nothing.
+//
+// The console's PDS helpers consume a session through exactly three
+// members — `.did`, `.handle(path, init)`, and `.getTokenInfo().aud` — so
+// this implements those and is handed back through the same `OAuthSession`
+// type (a structural cast at the factory). It is gated on the same
+// COCORE_APPVIEW_INTERNAL_URL + COCORE_INTERNAL_SECRET as the write
+// forward; with them unset the entry points keep using the legacy local
+// session and nothing here runs.
+
+import type { Did } from "@atcute/lexicons";
+import type { OAuthSession } from "@atcute/oauth-node-client";
+
+function base(): string | null {
+  return process.env["COCORE_APPVIEW_INTERNAL_URL"]?.replace(/\/$/, "") || null;
+}
+function secret(): string | null {
+  return process.env["COCORE_INTERNAL_SECRET"] || null;
+}
+
+/** Read a header value off the loose `HeadersInit` shapes the helpers pass
+ *  (`Headers`, array of tuples, or a plain record). Case-insensitive. */
+function headerValue(headers: HeadersInit | undefined, name: string): string | undefined {
+  if (!headers) return undefined;
+  const lower = name.toLowerCase();
+  if (headers instanceof Headers) return headers.get(name) ?? undefined;
+  if (Array.isArray(headers)) {
+    for (const [k, v] of headers) if (k.toLowerCase() === lower) return v;
+    return undefined;
+  }
+  for (const [k, v] of Object.entries(headers)) if (k.toLowerCase() === lower) return v;
+  return undefined;
+}
+
+interface ProxyResult {
+  status: number;
+  bodyText: string;
+  contentType?: string;
+}
+
+type HandleInit = { method?: string; headers?: HeadersInit; body?: BodyInit };
+
+class AppviewBackedSession {
+  readonly did: Did;
+
+  constructor(did: Did) {
+    this.did = did;
+  }
+
+  /** Replay an XRPC call through the AppView's owned session. Returns a real
+   *  `Response` rebuilt from the upstream status + body, so the console's
+   *  helpers (`r.ok` / `r.status` / `r.json()` / `r.text()`) behave exactly
+   *  as they did against a local session — including a 404 for a missing
+   *  record or a 401 for a dead session. */
+  async handle(path: string, init?: HandleInit): Promise<Response> {
+    const b = base();
+    const s = secret();
+    if (!b || !s) throw new Error("AppView forward not configured");
+
+    const method = (init?.method ?? "GET").toUpperCase();
+    const contentType = headerValue(init?.headers, "content-type");
+    let bodyText: string | undefined;
+    let blobB64: string | undefined;
+    const body = init?.body;
+    if (body != null && method !== "GET" && method !== "HEAD") {
+      if (typeof body === "string") bodyText = body;
+      else if (body instanceof Uint8Array) blobB64 = Buffer.from(body).toString("base64");
+      else if (body instanceof ArrayBuffer)
+        blobB64 = Buffer.from(new Uint8Array(body)).toString("base64");
+      else bodyText = String(body);
+    }
+
+    const res = await fetch(`${b}/internal/pds/proxy`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-cocore-internal-secret": s },
+      body: JSON.stringify({
+        did: this.did,
+        path,
+        method,
+        ...(bodyText !== undefined ? { bodyText } : {}),
+        ...(blobB64 !== undefined ? { blobB64 } : {}),
+        ...(contentType ? { contentType } : {}),
+      }),
+    });
+    if (!res.ok) {
+      // Internal-layer failure (403 secret / 502 restore-threw / network):
+      // a real transport problem, not an upstream PDS status. Throw so the
+      // helpers' catch / `!r.ok` paths treat it like a local session throw.
+      const t = await res.text().catch(() => "");
+      throw new Error(`appview proxy ${path} internal ${res.status}: ${t.slice(0, 200)}`);
+    }
+    const out = (await res.json()) as ProxyResult;
+    return new Response(out.bodyText, {
+      status: out.status,
+      headers: { "content-type": out.contentType ?? "application/json" },
+    });
+  }
+
+  /** Only `.aud` is consumed by callers (to render the PDS URL). Served by
+   *  the AppView's non-refreshing session-info read. */
+  async getTokenInfo(): Promise<{ aud: string }> {
+    const info = await appviewSessionInfo(this.did);
+    if (!info.aud) throw new Error("AppView session-info missing aud");
+    return { aud: info.aud };
+  }
+}
+
+/** Liveness + PDS-URL for a DID, read from the AppView's owned session
+ *  WITHOUT refreshing. `checked` distinguishes a definitive answer (the
+ *  AppView responded) from "couldn't reach the AppView" — callers must only
+ *  log a user out on `checked && !present`, never on a transient blip. */
+export async function appviewSessionInfo(
+  did: string,
+): Promise<{ checked: boolean; present: boolean; aud: string | null }> {
+  const b = base();
+  const s = secret();
+  if (!b || !s) return { checked: false, present: false, aud: null };
+  try {
+    const res = await fetch(`${b}/internal/pds/session-info?did=${encodeURIComponent(did)}`, {
+      headers: { "x-cocore-internal-secret": s },
+    });
+    if (!res.ok) return { checked: false, present: false, aud: null };
+    const body = (await res.json()) as { present?: boolean; aud?: string | null };
+    return { checked: true, present: body.present === true, aud: body.aud ?? null };
+  } catch {
+    return { checked: false, present: false, aud: null };
+  }
+}
+
+/** Build an AppView-backed session for `did`. Structurally implements the
+ *  subset of `OAuthSession` the console's PDS helpers use (`.did`,
+ *  `.handle`, `.getTokenInfo`); the cast asserts that contract. */
+export function appviewBackedSession(did: Did): OAuthSession {
+  return new AppviewBackedSession(did) as unknown as OAuthSession;
+}

--- a/packages/console/src/lib/appview-backed-session.test.ts
+++ b/packages/console/src/lib/appview-backed-session.test.ts
@@ -1,0 +1,146 @@
+// Unit tests for the AppView-backed session shim. Pure (mocked fetch) — no
+// SQLite — so it validates the console half of the single-owner cutover:
+// the proxy envelope it builds, the Response it reconstructs, and the
+// session-info liveness signal. The integration path (real AppView owning
+// the session) is covered by the appview package's internal-pds tests.
+
+import type { Did } from "@atcute/lexicons";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { appviewBackedSession, appviewSessionInfo } from "./appview-backed-session.server.ts";
+
+const DID = "did:plc:abc123" as Did;
+const BASE = "http://appview.internal:8081";
+const SECRET = "shh";
+
+type ShimLike = {
+  did: string;
+  handle: (path: string, init?: { method?: string; headers?: HeadersInit; body?: BodyInit }) => Promise<Response>;
+  getTokenInfo: () => Promise<{ aud: string }>;
+};
+
+function shim(): ShimLike {
+  return appviewBackedSession(DID) as unknown as ShimLike;
+}
+
+/** Capture the single fetch call + return a canned proxy/session-info reply. */
+function mockFetch(reply: { ok?: boolean; status?: number; json: unknown }) {
+  const calls: Array<{ url: string; init: RequestInit | undefined }> = [];
+  const fn = vi.fn(async (url: string, init?: RequestInit) => {
+    calls.push({ url, init });
+    return {
+      ok: reply.ok ?? true,
+      status: reply.status ?? 200,
+      json: async () => reply.json,
+      text: async () => JSON.stringify(reply.json),
+    } as unknown as Response;
+  });
+  vi.stubGlobal("fetch", fn);
+  return calls;
+}
+
+beforeEach(() => {
+  process.env["COCORE_APPVIEW_INTERNAL_URL"] = BASE;
+  process.env["COCORE_INTERNAL_SECRET"] = SECRET;
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env["COCORE_APPVIEW_INTERNAL_URL"];
+  delete process.env["COCORE_INTERNAL_SECRET"];
+});
+
+describe("AppviewBackedSession.handle", () => {
+  it("forwards a JSON write as a bodyText envelope and rebuilds the upstream Response", async () => {
+    const calls = mockFetch({ json: { status: 200, bodyText: JSON.stringify({ uri: "at://x" }) } });
+
+    const body = JSON.stringify({ repo: DID, collection: "dev.cocore.account.profile" });
+    const res = await shim().handle("/xrpc/com.atproto.repo.putRecord", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+    });
+
+    // One proxy call, secret + did + verbatim body in the envelope.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe(`${BASE}/internal/pds/proxy`);
+    expect((calls[0]!.init!.headers as Record<string, string>)["x-cocore-internal-secret"]).toBe(SECRET);
+    const env = JSON.parse(calls[0]!.init!.body as string);
+    expect(env).toMatchObject({
+      did: DID,
+      path: "/xrpc/com.atproto.repo.putRecord",
+      method: "POST",
+      bodyText: body,
+      contentType: "application/json",
+    });
+    expect(env.blobB64).toBeUndefined();
+
+    // Reconstructed Response carries the UPSTREAM status + body.
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ uri: "at://x" });
+  });
+
+  it("base64-encodes a binary uploadBlob body", async () => {
+    const calls = mockFetch({ json: { status: 200, bodyText: "{}" } });
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+
+    await shim().handle("/xrpc/com.atproto.repo.uploadBlob", {
+      method: "POST",
+      headers: { "Content-Type": "image/png" },
+      body: bytes as BodyInit,
+    });
+
+    const env = JSON.parse(calls[0]!.init!.body as string);
+    expect(env.blobB64).toBe(Buffer.from(bytes).toString("base64"));
+    expect(env.bodyText).toBeUndefined();
+    expect(env.contentType).toBe("image/png");
+  });
+
+  it("propagates an upstream 404 as a 404 Response (not an error)", async () => {
+    mockFetch({ json: { status: 404, bodyText: JSON.stringify({ error: "RecordNotFound" }) } });
+    const res = await shim().handle("/xrpc/com.atproto.repo.getRecord?rkey=self", { method: "GET" });
+    expect(res.status).toBe(404);
+    expect(res.ok).toBe(false);
+  });
+
+  it("throws when the internal proxy layer itself fails (dead transport)", async () => {
+    mockFetch({ ok: false, status: 502, json: { error: "SessionRestoreFailed" } });
+    await expect(
+      shim().handle("/xrpc/com.atproto.repo.getRecord?rkey=self", { method: "GET" }),
+    ).rejects.toThrow(/internal 502/);
+  });
+});
+
+describe("appviewSessionInfo", () => {
+  it("reports checked+present and the aud on a 200", async () => {
+    mockFetch({ json: { present: true, aud: "https://pds.example" } });
+    expect(await appviewSessionInfo(DID)).toEqual({
+      checked: true,
+      present: true,
+      aud: "https://pds.example",
+    });
+  });
+
+  it("reports checked but absent when the AppView says present:false", async () => {
+    mockFetch({ json: { present: false, aud: null } });
+    expect(await appviewSessionInfo(DID)).toEqual({ checked: true, present: false, aud: null });
+  });
+
+  it("reports NOT checked on a transport error (never logs the user out on a blip)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("ECONNREFUSED");
+      }),
+    );
+    expect(await appviewSessionInfo(DID)).toEqual({ checked: false, present: false, aud: null });
+  });
+
+  it("is a no-op (unchecked) when forwarding is not configured", async () => {
+    delete process.env["COCORE_APPVIEW_INTERNAL_URL"];
+    const f = vi.fn();
+    vi.stubGlobal("fetch", f);
+    expect(await appviewSessionInfo(DID)).toEqual({ checked: false, present: false, aud: null });
+    expect(f).not.toHaveBeenCalled();
+  });
+});

--- a/packages/console/src/lib/appview-backed-session.test.ts
+++ b/packages/console/src/lib/appview-backed-session.test.ts
@@ -15,7 +15,10 @@ const SECRET = "shh";
 
 type ShimLike = {
   did: string;
-  handle: (path: string, init?: { method?: string; headers?: HeadersInit; body?: BodyInit }) => Promise<Response>;
+  handle: (
+    path: string,
+    init?: { method?: string; headers?: HeadersInit; body?: BodyInit },
+  ) => Promise<Response>;
   getTokenInfo: () => Promise<{ aud: string }>;
 };
 
@@ -64,7 +67,9 @@ describe("AppviewBackedSession.handle", () => {
     // One proxy call, secret + did + verbatim body in the envelope.
     expect(calls).toHaveLength(1);
     expect(calls[0]!.url).toBe(`${BASE}/internal/pds/proxy`);
-    expect((calls[0]!.init!.headers as Record<string, string>)["x-cocore-internal-secret"]).toBe(SECRET);
+    expect((calls[0]!.init!.headers as Record<string, string>)["x-cocore-internal-secret"]).toBe(
+      SECRET,
+    );
     const env = JSON.parse(calls[0]!.init!.body as string);
     expect(env).toMatchObject({
       did: DID,
@@ -98,7 +103,9 @@ describe("AppviewBackedSession.handle", () => {
 
   it("propagates an upstream 404 as a 404 Response (not an error)", async () => {
     mockFetch({ json: { status: 404, bodyText: JSON.stringify({ error: "RecordNotFound" }) } });
-    const res = await shim().handle("/xrpc/com.atproto.repo.getRecord?rkey=self", { method: "GET" });
+    const res = await shim().handle("/xrpc/com.atproto.repo.getRecord?rkey=self", {
+      method: "GET",
+    });
     expect(res.status).toBe(404);
     expect(res.ok).toBe(false);
   });

--- a/packages/console/src/lib/community-tools/catalog.ts
+++ b/packages/console/src/lib/community-tools/catalog.ts
@@ -17,7 +17,7 @@ export const COMMUNITY_TOOLS_CATALOG: Array<CommunityTool> = [
     repoUrl: "https://github.com/willnewby/pi-cocore",
     install: "pi install git:github.com/willnewby/pi-cocore",
     setup: [
-      "Get your API key from console.cocore.dev.",
+      "Get your API key from cocore.dev.",
       "Start pi — on first run you'll be prompted for the key.",
       "Or run /cocore-setup at any time to configure or change your key.",
     ],

--- a/packages/console/src/lib/inference-docs/base-url.ts
+++ b/packages/console/src/lib/inference-docs/base-url.ts
@@ -1,4 +1,4 @@
-export const INFERENCE_DOCS_DEFAULT_BASE_URL = "https://console.cocore.dev/api/v1";
+export const INFERENCE_DOCS_DEFAULT_BASE_URL = "https://cocore.dev/api/v1";
 
 export function inferenceBaseUrl(origin?: string): string {
   if (origin != null && origin.length > 0) return `${origin}/api/v1`;

--- a/packages/console/src/lib/openai-routes.server.ts
+++ b/packages/console/src/lib/openai-routes.server.ts
@@ -7,7 +7,7 @@
 //                    older openapi versions; still honored).
 //   * `/v1/*`      — the canonical OpenAI layout. Point any OpenAI
 //                    SDK / LiteLLM / etc. at
-//                    `base_url="https://console.cocore.dev/v1"` and
+//                    `base_url="https://cocore.dev/v1"` and
 //                    it appends `/chat/completions`, `/models`, … the
 //                    way it appends them to `https://api.openai.com/v1`.
 //
@@ -22,6 +22,11 @@ import type { OAuthSession } from "@atcute/oauth-node-client";
 import { runTraced } from "@/lib/o11y.server.ts";
 
 import { restoreAtprotoSessionEffect } from "@/integrations/auth/atproto.server.ts";
+import {
+  appviewBackedSession,
+  appviewSessionInfo,
+} from "@/lib/appview-backed-session.server.ts";
+import { isAppviewForwardConfigured } from "@/lib/appview-pds-forward.server.ts";
 import { type DispatchInputs, runDispatch } from "@/lib/inference-dispatch.server.ts";
 import { listMyFriendDids } from "@/lib/friends.server.ts";
 import {
@@ -66,6 +71,24 @@ async function authenticate(
   }
   if (!isDid(resolved.did)) {
     return jsonError(500, "Stored DID is malformed", "server_error");
+  }
+
+  // Single-owner cutover: when forwarding is configured the AppView owns and
+  // solely refreshes this DID's session. Restoring locally here would
+  // refresh in parallel and cannibalize the single-use refresh token, so
+  // hand back an AppView-backed session (every PDS call + service-auth mint
+  // is replayed by the AppView). Only a DEFINITIVE "session absent" 401s;
+  // a transient AppView blip doesn't (the session likely still exists).
+  if (isAppviewForwardConfigured()) {
+    const info = await appviewSessionInfo(resolved.did);
+    if (info.checked && !info.present) {
+      return jsonError(
+        401,
+        "API key's underlying ATProto session is no longer valid; mint a new key after re-authenticating",
+        "authentication_error",
+      );
+    }
+    return { did: resolved.did, oauthSession: appviewBackedSession(resolved.did as Did) };
   }
 
   // Restore the OAuth session for this DID. The session store is

--- a/packages/console/src/lib/openai-routes.server.ts
+++ b/packages/console/src/lib/openai-routes.server.ts
@@ -22,10 +22,7 @@ import type { OAuthSession } from "@atcute/oauth-node-client";
 import { runTraced } from "@/lib/o11y.server.ts";
 
 import { restoreAtprotoSessionEffect } from "@/integrations/auth/atproto.server.ts";
-import {
-  appviewBackedSession,
-  appviewSessionInfo,
-} from "@/lib/appview-backed-session.server.ts";
+import { appviewBackedSession, appviewSessionInfo } from "@/lib/appview-backed-session.server.ts";
 import { isAppviewForwardConfigured } from "@/lib/appview-pds-forward.server.ts";
 import { type DispatchInputs, runDispatch } from "@/lib/inference-dispatch.server.ts";
 import { listMyFriendDids } from "@/lib/friends.server.ts";

--- a/packages/console/src/lib/pair-store.ts
+++ b/packages/console/src/lib/pair-store.ts
@@ -32,7 +32,7 @@ export interface ProviderSession {
   /** `cocore-...` API key minted on pair-approve, scoped to `did`. */
   apiKey: string;
   /** Console base URL the agent should POST records to. e.g.
-   *  `https://console.cocore.dev`. The agent appends
+   *  `https://cocore.dev`. The agent appends
    *  `/api/pds/createRecord`. */
   apiBase: string;
 }

--- a/packages/console/src/lib/wipe-my-data.server.ts
+++ b/packages/console/src/lib/wipe-my-data.server.ts
@@ -15,7 +15,7 @@
 //
 // What this does NOT do:
 //   * Touch the user's OAuth session (so they stay signed in to
-//     console.cocore.dev).
+//     cocore.dev).
 //   * Touch any provider's (other-DID) PDS records — only the user's
 //     own.
 //   * Talk to advisor — provider records on advisor are live wire

--- a/packages/console/src/middleware/auth.server.ts
+++ b/packages/console/src/middleware/auth.server.ts
@@ -7,6 +7,11 @@ import {
   resolveAppSessionToken,
   revokeAppSession,
 } from "@/integrations/auth/app-session-store.server.ts";
+import {
+  appviewBackedSession,
+  appviewSessionInfo,
+} from "@/lib/appview-backed-session.server.ts";
+import { isAppviewForwardConfigured } from "@/lib/appview-pds-forward.server.ts";
 import { runTraced } from "@/lib/o11y.server.ts";
 import { readAllAuthSessionTokens } from "@/integrations/auth/cookie-parse.ts";
 
@@ -33,6 +38,22 @@ export function atprotoSessionForRequestEffect(
 
       const { did } = app;
       if (!isDid(did)) continue;
+
+      // Single-owner cutover: when forwarding is configured the AppView owns
+      // (and solely refreshes) this DID's session. Restoring locally here
+      // would refresh in parallel and cannibalize the single-use refresh
+      // token, so instead hand back an AppView-backed session and ask the
+      // AppView — the owner — whether a live session exists. Only a
+      // DEFINITIVE "absent" (not a transient AppView blip) drops the app
+      // session for re-auth.
+      if (isAppviewForwardConfigured()) {
+        const info = yield* Effect.promise(() => appviewSessionInfo(did));
+        if (info.checked && !info.present) {
+          revokeAppSession(sessionToken);
+          continue;
+        }
+        return { did, oauthSession: appviewBackedSession(did) };
+      }
 
       const oauthSession = yield* restoreAtprotoSessionEffect(did);
       if (!oauthSession) {

--- a/packages/console/src/middleware/auth.server.ts
+++ b/packages/console/src/middleware/auth.server.ts
@@ -7,10 +7,7 @@ import {
   resolveAppSessionToken,
   revokeAppSession,
 } from "@/integrations/auth/app-session-store.server.ts";
-import {
-  appviewBackedSession,
-  appviewSessionInfo,
-} from "@/lib/appview-backed-session.server.ts";
+import { appviewBackedSession, appviewSessionInfo } from "@/lib/appview-backed-session.server.ts";
 import { isAppviewForwardConfigured } from "@/lib/appview-pds-forward.server.ts";
 import { runTraced } from "@/lib/o11y.server.ts";
 import { readAllAuthSessionTokens } from "@/integrations/auth/cookie-parse.ts";

--- a/packages/console/src/routes/_header-layout.index.tsx
+++ b/packages/console/src/routes/_header-layout.index.tsx
@@ -1648,10 +1648,10 @@ function MarketingPage() {
             <Heading2 style={styles.sectionH2}>Just change three lines.</Heading2>
             <Body style={[styles.sectionSub, styles.dropInSub]}>
               co/core speaks the same API language as everybody else. Point your existing SDK at{" "}
-              <InlineCode>cocore.dev/v1</InlineCode>, drop in a{" "}
-              <InlineCode>cocore-…</InlineCode> key, and keep going — streaming, tool calls, and the
-              usual <InlineCode>chat/completions</InlineCode> shape all work, no code changes. Host
-              from our presets or any{" "}
+              <InlineCode>cocore.dev/v1</InlineCode>, drop in a <InlineCode>cocore-…</InlineCode>{" "}
+              key, and keep going — streaming, tool calls, and the usual{" "}
+              <InlineCode>chat/completions</InlineCode> shape all work, no code changes. Host from
+              our presets or any{" "}
               <a
                 href="https://huggingface.co/models?library=mlx"
                 target="_blank"
@@ -1740,8 +1740,7 @@ function MarketingPage() {
               <span {...stylex.props(styles.swapKw)}>import</span> OpenAI{"\n\n"}
               client = OpenAI({"\n"}
               {"    "}base_url=
-              <span {...stylex.props(styles.swapHighlight)}>"https://cocore.dev/v1"</span>,
-              {"\n"}
+              <span {...stylex.props(styles.swapHighlight)}>"https://cocore.dev/v1"</span>,{"\n"}
               {"    "}api_key=
               <span {...stylex.props(styles.swapHighlight)}>"cocore-7f3a2c…"</span>,{"\n"}){"\n\n"}
               resp = client.chat.completions.<span {...stylex.props(styles.swapFn)}>create</span>(

--- a/packages/console/src/routes/_header-layout.index.tsx
+++ b/packages/console/src/routes/_header-layout.index.tsx
@@ -1648,7 +1648,7 @@ function MarketingPage() {
             <Heading2 style={styles.sectionH2}>Just change three lines.</Heading2>
             <Body style={[styles.sectionSub, styles.dropInSub]}>
               co/core speaks the same API language as everybody else. Point your existing SDK at{" "}
-              <InlineCode>console.cocore.dev/v1</InlineCode>, drop in a{" "}
+              <InlineCode>cocore.dev/v1</InlineCode>, drop in a{" "}
               <InlineCode>cocore-…</InlineCode> key, and keep going — streaming, tool calls, and the
               usual <InlineCode>chat/completions</InlineCode> shape all work, no code changes. Host
               from our presets or any{" "}
@@ -1740,7 +1740,7 @@ function MarketingPage() {
               <span {...stylex.props(styles.swapKw)}>import</span> OpenAI{"\n\n"}
               client = OpenAI({"\n"}
               {"    "}base_url=
-              <span {...stylex.props(styles.swapHighlight)}>"https://console.cocore.dev/v1"</span>,
+              <span {...stylex.props(styles.swapHighlight)}>"https://cocore.dev/v1"</span>,
               {"\n"}
               {"    "}api_key=
               <span {...stylex.props(styles.swapHighlight)}>"cocore-7f3a2c…"</span>,{"\n"}){"\n\n"}

--- a/packages/console/src/routes/_header-layout.models.tsx
+++ b/packages/console/src/routes/_header-layout.models.tsx
@@ -44,7 +44,7 @@ import type { ModelDirectoryEntry } from "@/lib/model-directory.server.ts";
 
 const ButtonLink = createLink(Button);
 
-const DEFAULT_API_V1_BASE = "https://console.cocore.dev/v1";
+const DEFAULT_API_V1_BASE = "https://cocore.dev/v1";
 
 const KIND_TABS = ["all", "text", "image", "audio", "video", "test", "other"] as const;
 type ModelKind = (typeof KIND_TABS)[number];

--- a/packages/console/src/routes/agent.inference.ts
+++ b/packages/console/src/routes/agent.inference.ts
@@ -1,6 +1,6 @@
 // Backward-compat alias for the old curl-pipe-sh URL:
 //
-//   curl -fsSL https://console.cocore.dev/agent/inference | sh
+//   curl -fsSL https://cocore.dev/agent/inference | sh
 //
 // v0.6.0 collapsed stub vs. inference into a single install path
 // (see the doc-comment at the top of `agent-install.sh` for the

--- a/packages/console/src/routes/agent.ts
+++ b/packages/console/src/routes/agent.ts
@@ -1,6 +1,6 @@
 // Serves the cocore agent installer at `/agent` so users can run:
 //
-//   curl -fsSL https://console.cocore.dev/agent | sh
+//   curl -fsSL https://cocore.dev/agent | sh
 //
 // The script (sibling file `agent-install.sh`) downloads the latest
 // macOS arm64 release from https://github.com/graze-social/cocore/releases,

--- a/packages/console/src/routes/agent.uninstall.ts
+++ b/packages/console/src/routes/agent.uninstall.ts
@@ -1,6 +1,6 @@
 // Serves the cocore agent uninstaller at `/agent/uninstall`. Use:
 //
-//   curl -fsSL https://console.cocore.dev/agent/uninstall | sh
+//   curl -fsSL https://cocore.dev/agent/uninstall | sh
 //
 // Removes the LaunchAgent, the binary, the ~/.cocore state dir
 // (including the Python venv), and any mlx-community model caches

--- a/packages/console/src/routes/api/agent.health.ts
+++ b/packages/console/src/routes/api/agent.health.ts
@@ -120,7 +120,7 @@ function diagnose(input: {
   if (!input.advisorOnline && !input.pdsHasProvider) {
     return {
       diagnosis: "never-paired",
-      hint: "No agent has run under this DID. Install with `curl -fsSL console.cocore.dev/agent | sh`, then `cocore agent pair`.",
+      hint: "No agent has run under this DID. Install with `curl -fsSL cocore.dev/agent | sh`, then `cocore agent pair`.",
     };
   }
   if (advisorFresh && input.pdsHasProvider) {

--- a/packages/console/src/routes/api/agent.status.ts
+++ b/packages/console/src/routes/api/agent.status.ts
@@ -15,7 +15,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { runTraced } from "@/lib/o11y.server.ts";
 
 import { appviewListProvidersEffect } from "@/integrations/appview/appview.server.ts";
-import { restoreAtprotoSessionEffect } from "@/integrations/auth/atproto.server.ts";
+import { sessionNeedsReauth } from "@/integrations/auth/atproto.server.ts";
 import { resolveBearerKey } from "@/lib/api-keys.server.ts";
 import { cocoreConfig } from "@/lib/cocore-config.ts";
 import { sumReceiptInSince } from "@/lib/earnings.ts";
@@ -55,8 +55,17 @@ async function fetchConfidentialEligible(did: string): Promise<boolean> {
       confidentialEligible?: boolean;
       trustTier?: string;
     }>;
-    const mineRow = list.find((p) => p.did === did);
-    return mineRow?.confidentialEligible === true || mineRow?.trustTier === "attested-confidential";
+    // A DID can hold MULTIPLE advisor rows: one per connected machine, plus
+    // stale ghost registrations that haven't aged out yet. The old `.find`
+    // returned the FIRST matching row, which was frequently the stale
+    // best-effort ghost — so the menu showed "not confidential" even though
+    // the live worker was attested. Treat the DID as confidential-eligible
+    // when ANY of its rows is: the live attested row wins over a stale ghost.
+    return list.some(
+      (p) =>
+        p.did === did &&
+        (p.confidentialEligible === true || p.trustTier === "attested-confidential"),
+    );
   } catch {
     return false;
   }
@@ -73,25 +82,25 @@ export const Route = createFileRoute("/api/agent/status")({
 
         const did = resolved.did;
         const since = Date.now() - 24 * 60 * 60 * 1000;
+
+        // "Does the agent need a fresh sign-in?" — a NON-refreshing read of
+        // the stored OAuth session (see sessionNeedsReauth). The old probe
+        // called restore(), which refreshes/rotates the single-use refresh
+        // token on every status poll; because the AppView is the designated
+        // refresher, that parallel rotation was cannibalizing the session it
+        // was meant to monitor and causing the recurring write 401s. This
+        // read only reports re-auth when the session is genuinely gone.
+        const needsReauth = sessionNeedsReauth(did as Did);
+
         // All three degrade gracefully so a single backend hiccup yields
         // partial data the menu can still render, not a 500.
-        const [balance, events, providers, confidential, session] = await Promise.all([
+        const [balance, events, providers, confidential] = await Promise.all([
           getBalance(did).catch(() => null),
           listEvents(did, EVENT_LIMIT).catch(() => ({ events: [] })),
           runTraced("appview.listProviders", appviewListProvidersEffect).catch(() => ({
             providers: [],
           })),
           fetchConfidentialEligible(did),
-          // The authoritative "can this agent publish right now?" probe: the
-          // same DPoP session restore every putRecord depends on. A null means
-          // the OAuth session is dead (refresh token expired/revoked) and the
-          // agent is silently failing all publishes — so the menu can prompt a
-          // re-sign-in instead of leaving a stale record on screen. We do NOT
-          // surface a transient probe error as needsReauth (don't nag): only a
-          // definitive null counts.
-          runTraced("auth.sessionProbe", restoreAtprotoSessionEffect(did as Did))
-            .then((s) => s === null)
-            .catch(() => false),
         ]);
 
         const earned24h = sumReceiptInSince(events.events, since);
@@ -108,7 +117,7 @@ export const Route = createFileRoute("/api/agent/status")({
             trustLevel: body.trustLevel ?? null,
             confidential,
             agentVersion: body.binaryVersion ?? null,
-            needsReauth: session,
+            needsReauth,
           }),
           { status: 200, headers: { "content-type": "application/json" } },
         );

--- a/packages/console/src/routes/v1.chat.completions.ts
+++ b/packages/console/src/routes/v1.chat.completions.ts
@@ -2,7 +2,7 @@
 //
 // The canonical OpenAI-compatible chat-completions endpoint. Point any
 // OpenAI SDK / LiteLLM / etc. at
-// `base_url="https://console.cocore.dev/v1"` and it appends
+// `base_url="https://cocore.dev/v1"` and it appends
 // `/chat/completions` exactly as it would for `https://api.openai.com/v1`.
 //
 // Authed by an API key (`Authorization: Bearer cocore-…`). The key

--- a/packages/console/src/routes/v1.private.chat.completions.ts
+++ b/packages/console/src/routes/v1.private.chat.completions.ts
@@ -2,7 +2,7 @@
 //
 // Friends-only sibling of `/v1/chat/completions`. Same OpenAI wire
 // format — point a client at
-// `base_url="https://console.cocore.dev/v1/private"` and it Just Works
+// `base_url="https://cocore.dev/v1/private"` and it Just Works
 // — but the request is constrained to providers the authenticated DID
 // has explicitly friended (dev.cocore.account.friend records on the
 // DID's PDS). Crypto is identical end-to-end; the difference is which

--- a/provider-shell/Sources/CoCoreShell/Brand.swift
+++ b/provider-shell/Sources/CoCoreShell/Brand.swift
@@ -1,5 +1,5 @@
 // Brand: the cocore visual identity, shared by every window the tray
-// opens so the app matches the console (console.cocore.dev) instead of
+// opens so the app matches the console (cocore.dev) instead of
 // defaulting to system blue.
 //
 // Colors are transcribed from the console design system — a Radix

--- a/provider-shell/Sources/CoCoreShell/Endpoints.swift
+++ b/provider-shell/Sources/CoCoreShell/Endpoints.swift
@@ -18,7 +18,7 @@
 import Foundation
 
 enum Endpoints {
-    static let prodConsole = "https://console.cocore.dev"
+    static let prodConsole = "https://cocore.dev"
     static let prodAdvisor = "wss://advisor.cocore.dev/v1/agent"
 
     /// Build-time default written into Info.plist, else prod. This is the

--- a/provider-shell/Sources/CoCoreShell/ModelsView.swift
+++ b/provider-shell/Sources/CoCoreShell/ModelsView.swift
@@ -84,10 +84,10 @@ final class ModelManager: ObservableObject {
             case .failed(let m):
                 return "✗ \(m) failed to load. co/core runs MLX-format models only "
                     + "(mlx-community/… or another repo with MLX 4-bit weights); a stock "
-                    + "PyTorch repo won't load. See this machine on console.cocore.dev for details."
+                    + "PyTorch repo won't load. See this machine on cocore.dev for details."
             case .pending(let m):
                 return "Added \(m). First-time downloads can take a minute — watch this "
-                    + "machine on console.cocore.dev to confirm it starts serving."
+                    + "machine on cocore.dev to confirm it starts serving."
             }
         }
 

--- a/provider/src/doctor.rs
+++ b/provider/src/doctor.rs
@@ -421,7 +421,7 @@ fn launchagent_status() -> Check {
             name: "LaunchAgent",
             ok: false,
             note: format!(
-                "{target} not loaded. The installer didn't run, or the LaunchAgent was unloaded. Re-run the installer with `curl -fsSL console.cocore.dev/agent | sh`."
+                "{target} not loaded. The installer didn't run, or the LaunchAgent was unloaded. Re-run the installer with `curl -fsSL cocore.dev/agent | sh`."
             ),
         };
     }
@@ -468,7 +468,7 @@ fn apply_fixes() {
         .map(|o| o.status.success())
         .unwrap_or(false);
     if !installed {
-        println!("  - LaunchAgent not installed; skipping kickstart. Re-run `curl -fsSL console.cocore.dev/agent | sh` if you want it installed.");
+        println!("  - LaunchAgent not installed; skipping kickstart. Re-run `curl -fsSL cocore.dev/agent | sh` if you want it installed.");
         return;
     }
     let bounced = Command::new("launchctl")

--- a/provider/src/engines/subprocess.rs
+++ b/provider/src/engines/subprocess.rs
@@ -398,7 +398,7 @@ impl SubprocessEngine {
 
         if !self.venv_python.exists() {
             bail!(
-                "venv python missing at {}. Run `curl … console.cocore.dev/agent | sh` to (re)provision the venv.",
+                "venv python missing at {}. Run `curl … cocore.dev/agent | sh` to (re)provision the venv.",
                 self.venv_python.display()
             );
         }

--- a/provider/src/models_cli.rs
+++ b/provider/src/models_cli.rs
@@ -398,7 +398,7 @@ fn check_model_addable(model: &str, venv_present: bool) -> Result<()> {
          can't load `{model}` and will publish supportedModels=[\"stub\"].\n\
          \n\
          Provision the venv with:\n  \
-         curl -fsSL console.cocore.dev/agent | sh\n\
+         curl -fsSL cocore.dev/agent | sh\n\
          \n\
          (Re-running the installer is idempotent — it won't redo work\n\
          that's already done.)"
@@ -676,7 +676,7 @@ fn report_outcomes(outcomes: &[(String, LoadOutcome)], log_path: &Path) {
              \x20     Check {} for the python traceback.\n\n\
              \x20     Common causes:\n\
              \x20       * Python venv at ~/.cocore/python is broken — reinstall via\n\
-             \x20         `curl -fsSL console.cocore.dev/agent/inference | sh`\n\
+             \x20         `curl -fsSL cocore.dev/agent/inference | sh`\n\
              \x20       * Model id is wrong or not on HuggingFace\n\
              \x20       * Out-of-memory during load (check Activity Monitor)\n\n\
              \x20     The plist was still updated; if you fix the underlying issue,\n\
@@ -909,7 +909,7 @@ mod tests {
             "error must point at the missing venv path: {msg}"
         );
         assert!(
-            msg.contains("console.cocore.dev/agent"),
+            msg.contains("cocore.dev/agent"),
             "error must give the recovery one-liner: {msg}"
         );
     }

--- a/provider/src/oauth.rs
+++ b/provider/src/oauth.rs
@@ -40,7 +40,7 @@ pub struct PairStartResponse {
 ///   console proxy. Bound to `did` server-side.
 /// - `api_base` — console URL the agent appends
 ///   `/api/pds/createRecord` to. e.g.,
-///   `https://console.cocore.dev`.
+///   `https://cocore.dev`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Session {


### PR DESCRIPTION
## Summary

Closes out the Secure Mode OAuth-session failure mode end to end, plus a
domain cleanup. Three commits:

1. **`fix`: stop the session cannibalization + stale confidential read** (the
   original two surgical fixes).
2. **`feat`: finish the single-owner cutover** — the durable fix: the console
   never refreshes the OAuth token anymore.
3. **`chore`: point hardcoded `console.cocore.dev` defaults at `cocore.dev`.**

### 1. Stop the OAuth-session cannibalization (the recurring 401s)

`GET /api/agent/status` recomputed `needsReauth` by calling `restore()` on
every poll, which refreshes + rotates the **single-use** DPoP refresh token.
The AppView is the designated refresher, so the console rotating in parallel
on every poll cannibalized one shared token → `invalid_grant` → dead session →
every forwarded write 401s. Replaced with a **non-refreshing** `sessionNeedsReauth()`.

### 2. Stale confidential-eligibility read

`fetchConfidentialEligible` returned the **first** advisor row for a DID
(often a stale best-effort ghost). Now eligible when **any** row is.

### 3. Finish the single-owner cutover (the durable fix)

The codebase already decided the AppView is the **sole owner/refresher** of
each user's session (login handoff + write forwarding existed). The cutover
was unfinished: the console still `restore()`d — and thus refreshed — for the
**web UI** and **inference** paths, so it kept racing the AppView on the
single-use refresh token. This finishes it:

- **AppView** — two internal endpoints that operate the owned session:
  - `POST /internal/pds/proxy`: replays a single **allowlisted** XRPC call
    (`com.atproto.repo.*` + `com.atproto.server.getServiceAuth`) and returns
    the upstream status + body verbatim. Binary `uploadBlob` bodies ride as
    base64; the internal secret + path allowlist are the trust boundary.
  - `GET /internal/pds/session-info`: a **non-refreshing** `{present, aud}`
    read of the stored session.
- **Console** — `AppviewBackedSession` implements the `OAuthSession` subset the
  PDS helpers actually use (`.did` / `.handle` / `.getTokenInfo().aud`) by
  routing every call through the proxy. `middleware/auth.server.ts` (all web
  UI PDS ops) and `openai-routes.server.ts` (inference) return it **instead of
  `restore()`** when forwarding is configured — so the console refreshes
  **nothing**. The ~10 PDS helper call sites are untouched (they receive a
  structurally-compatible session).

**Gating / safety:** all of (2)'s behavior is behind
`COCORE_APPVIEW_INTERNAL_URL` + `COCORE_INTERNAL_SECRET`. With them unset the
console uses the legacy local session exactly as before — a deploy without the
forward env is a no-op. Liveness only logs a user out on a **definitive**
"session absent", never on a transient AppView blip.

**Still on the legacy local path (intentional):** `disputes-resolve` (uses the
exchange's own single-owner DID, no console/AppView split) and the admin-only
`wipe-everything`. Neither is a continuous refresher.

### 4. Domain: `console.cocore.dev` → `cocore.dev`

The canonical origin moved to the apex. Patched the hardcoded fallbacks/links
that still pointed at the subdomain — the tray app's prod console URL (login +
UI), the services exchange-API/terms defaults, the provider agent's install/
help URLs (+ matching test), and the console's install scripts, OpenAI-compat
base-URL examples, and UI strings.

**Deliberately NOT touched:** `did:web:console.cocore.dev` identifiers (stable
service-auth identity, not navigation), the cookie-domain multi-subdomain
logic + its tests (`console.cocore.dev` still serves as an alias), and the
historical cutover runbooks under `docs/`.

## Test plan

- `tsc --noEmit`: clean for console, appview, and infra/services.
- New `appview-backed-session.test.ts` (8 tests, mocked fetch — no SQLite):
  proxy envelope (JSON `bodyText` vs binary `blobB64`), upstream-status
  passthrough (404 stays 404), internal-failure throws, and the
  `checked/present` liveness semantics. Passes.
- `cookie-domain.test.ts` (the preserved multi-subdomain logic): passes.
- The remaining `vitest` failures are a pre-existing `better-sqlite3` native-
  ABI mismatch (node v26 / MODULE_VERSION 147 can't load the prebuilt binding)
  — unrelated to this change; CI runs them with a working binding.

## ⚠️ Deploy notes (env, not code)

- For (2) to work, the AppView must present the **same OAuth `client_id`** as
  the console that minted the session — i.e. `ATPROTO_BASE_URL` /
  `CONSOLE_PUBLIC_URL` must resolve to the **same origin** on both the console
  and the AppView/services. With the domain now `cocore.dev`, set them
  consistently to `https://cocore.dev` on both services. Sessions minted under
  the old `console.cocore.dev` client_id may need a one-time re-auth.
- Run the existing `migrate-sessions-to-appview` cutover (if not already) so
  back-catalogue sessions live on the AppView before the console stops
  refreshing them.

## Follow-ups (not in this PR)

- Teach the Rust agent's `parse_chain_response` to accept base64 DER (revert
  the console PEM-wrap from #76).
- Evict the stale `a2c714…` advisor registration (ops).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
