### PR TITLE
feat(mdm): publicly-trusted front door for step-ca (ca.cocore.dev)

### DIFF
--- a/infra/mdm/gateway/Caddyfile
+++ b/infra/mdm/gateway/Caddyfile
@@ -1,0 +1,41 @@
+# co/core MDM CA gateway — a publicly-trusted front door for step-ca.
+#
+# WHY THIS EXISTS: macOS will not install an MDM/ACME enrollment profile
+# whose CA endpoint serves a self-signed cert (an unsupervised Mac can't be
+# made to trust a private root without a manual per-device dance). step-ca
+# only speaks its OWN self-signed HTTPS, and Railway's HTTP edge can't talk
+# to an HTTPS upstream — which is why step-ca was stuck behind a raw TCP
+# proxy (reseau.proxy.rlwy.net) with an untrusted cert, and why enrollment
+# failed with "install the Trust Profile."
+#
+# This Caddy service bridges that gap: Railway terminates a PUBLICLY-TRUSTED
+# cert for the custom domain (ca.cocore.dev) and forwards plain HTTP here;
+# we re-originate TLS to step-ca's self-signed HTTPS upstream. skip-verify
+# is correct here — it's our own CA, reached over Railway's network, and the
+# trust the Mac cares about is the public edge cert, not this internal hop.
+#
+# step-ca generates its ACME directory URLs from the inbound Host header, so
+# preserving Host keeps the directory self-consistent with the public domain.
+{
+	admin off
+	# Railway terminates public TLS at its edge; Caddy serves plain HTTP on
+	# $PORT. No on-box certs to manage.
+	auto_https off
+}
+
+:{$PORT:8080} {
+	reverse_proxy https://{$STEPCA_UPSTREAM:reseau.proxy.rlwy.net:43462} {
+		transport http {
+			# step-ca presents its own self-signed cert; the public trust
+			# lives at the Railway edge, so verifying this hop adds nothing.
+			tls_insecure_skip_verify
+		}
+		# Preserve the public host so step-ca emits ca.cocore.dev ACME URLs.
+		header_up Host {host}
+	}
+
+	log {
+		output stdout
+		format console
+	}
+}

--- a/infra/mdm/gateway/Dockerfile
+++ b/infra/mdm/gateway/Dockerfile
@@ -1,0 +1,5 @@
+# Publicly-trusted front door for step-ca (ACME + SCEP). See Caddyfile.
+FROM caddy:2.8-alpine
+COPY Caddyfile /etc/caddy/Caddyfile
+# The base image's CMD already runs:
+#   caddy run --config /etc/caddy/Caddyfile --adapter caddyfile


### PR DESCRIPTION
## Summary

Adds the **publicly-trusted front door for step-ca** that fixes Secure Mode
(Apple MDA) enrollment, and captures it in version control (it's currently
deployed as the Railway service `cocore-mdm-gateway` but was not yet in the repo).

### Why

macOS refuses to install an MDM/ACME enrollment profile whose CA endpoint serves
a **self-signed** cert — an unsupervised Mac can't be made to trust a private root
without a manual per-device dance. step-ca only speaks its own self-signed HTTPS,
and Railway's HTTP edge can't reach an HTTPS upstream, so step-ca was stuck behind
a raw TCP proxy (`reseau.proxy.rlwy.net`) with an untrusted cert. Result: the
wizard failed with *"Profile installation failed … install the Trust Profile"* and
a downstream **502** (the device never enrolled, so the attestation push had no
target).

### What

A tiny Caddy reverse-proxy:
- Railway terminates a **publicly-trusted (Let's Encrypt)** cert for `ca.cocore.dev`
  and forwards plain HTTP to Caddy.
- Caddy re-originates TLS to step-ca's self-signed HTTPS upstream
  (`tls_insecure_skip_verify` — the trust the Mac needs lives at the public edge,
  not this internal hop).
- The inbound `Host` is preserved so step-ca emits `ca.cocore.dev` in its ACME
  directory URLs.

### Deploy state (already live)

- Service `cocore-mdm-gateway` deployed; `ca.cocore.dev` CNAME'd to it with a
  Let's Encrypt cert issued. ACME directory + SCEP `GetCACaps` both return 200 over
  the trusted cert.
- Console env repointed: `COCORE_MDM_ACME_URL` / `COCORE_MDM_SCEP_URL` now use
  `https://ca.cocore.dev/...`.

### Notes

- `STEPCA_UPSTREAM` is overridable (defaults to the existing TCP proxy); can be
  switched to step-ca's private-network address later to drop the external hop.
- Does not touch step-ca itself — purely additive, so it can't disturb the
  working CA state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
