### PR TITLE
feat: verified machines — proof-backed /v1/verified path + trust badges

### DIFF
--- a/packages/console/public/openapi.yaml
+++ b/packages/console/public/openapi.yaml
@@ -122,6 +122,63 @@ paths:
             application/json:
               schema: { $ref: "#/components/schemas/ErrorEnvelope" }
 
+  /v1/verified/chat/completions:
+    post:
+      tags: [Inference]
+      operationId: createVerifiedChatCompletion
+      summary: Create a chat completion (verified-tier routing)
+      description: >
+        Identical to `/v1/chat/completions`, but routing is constrained to
+        providers whose attestation is CRYPTOGRAPHICALLY VERIFIED to meet a
+        trust floor — recomputed from the provider's signed, Apple-rooted
+        attestation, never its self-asserted `trustLevel`. Set the optional
+        `min_trust` body field to `hardware-attested` (default — any verified
+        machine) or `confidential` (strict `attested-confidential`: known-good
+        measured build + hardened posture + live code-attestation). Fails closed
+        with `no_verified_providers` (503) when none meet the floor for the
+        model. Also available at the legacy path
+        `/api/v1/verified/chat/completions`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: "#/components/schemas/ChatCompletionRequest"
+                - type: object
+                  properties:
+                    min_trust:
+                      type: string
+                      enum: [hardware-attested, confidential]
+                      description: >
+                        Minimum verified trust tier to route to. Defaults to
+                        `hardware-attested`.
+      responses:
+        "200":
+          description: "A completion (or an SSE stream when `stream: true`)."
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ChatCompletion" }
+            text/event-stream:
+              schema: { type: string }
+        "400":
+          description: Unrecognized `min_trust` value (`invalid_min_trust`).
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorEnvelope" }
+        "401":
+          description: Missing or invalid API key.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorEnvelope" }
+        "503":
+          description: No verified provider meets the tier for the model (`no_verified_providers`).
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorEnvelope" }
+
   /v1/models:
     get:
       tags: [Directory]

--- a/packages/console/src/components/TrustTierBadge.tsx
+++ b/packages/console/src/components/TrustTierBadge.tsx
@@ -1,0 +1,35 @@
+// A trust-tier badge driven by a machine's VERIFIED tier — the tier
+// recomputed from its actual signed attestation, never the self-asserted
+// `trustLevel` (see lib/verified-standing.server.ts). Shared by the public
+// model directory and the owner's fleet dashboard so both read identically.
+//
+// best-effort renders nothing: the point is to make VERIFIED machines stand
+// out, not to label the unverified majority.
+
+import { Badge } from "@/design-system/badge";
+
+export type TrustTier = "best-effort" | "hardware-attested" | "attested-confidential";
+
+const CONFIDENTIAL_TITLE =
+  "Confidential tier — verified from this machine's signed, Apple-rooted attestation: genuine hardware bound to its signing key, a known-good measured build, hardened posture, and live code-attestation. Your prompt is sealed so the operator can't read it.";
+
+const HARDWARE_TITLE =
+  "Hardware-attested — verified from this machine's signed, Apple-rooted attestation chain, bound to its signing key. Proven genuine Apple hardware (not a self-asserted claim).";
+
+export function TrustTierBadge({ tier }: { tier: TrustTier }): React.ReactNode {
+  if (tier === "attested-confidential") {
+    return (
+      <Badge size="sm" variant="success" title={CONFIDENTIAL_TITLE}>
+        🔒 Confidential
+      </Badge>
+    );
+  }
+  if (tier === "hardware-attested") {
+    return (
+      <Badge size="sm" variant="primary" title={HARDWARE_TITLE}>
+        🛡️ Hardware-attested
+      </Badge>
+    );
+  }
+  return null;
+}

--- a/packages/console/src/components/machines/MachinesDashboard.tsx
+++ b/packages/console/src/components/machines/MachinesDashboard.tsx
@@ -17,6 +17,7 @@ import {
   CardTitle,
 } from "@/design-system/card";
 import { CopyToClipboardButton } from "@/design-system/copy-to-clipboard-button";
+import { TrustTierBadge } from "@/components/TrustTierBadge.tsx";
 import {
   Dialog,
   DialogBody,
@@ -2141,6 +2142,7 @@ export function MachinesDashboard() {
                                 <Text size="xs" style={ui.textDim}>
                                   {m.id}
                                 </Text>
+                                {m.verifiedTier ? <TrustTierBadge tier={m.verifiedTier} /> : null}
                               </Flex>
                             </TableCell>
                           );

--- a/packages/console/src/components/machines/machines-data.ts
+++ b/packages/console/src/components/machines/machines-data.ts
@@ -1,3 +1,5 @@
+import type { VerifiedTier } from "@/lib/verified-standing.server.ts";
+
 export type MachineState = "running" | "idle" | "paused" | "offline" | "provisioning";
 
 export interface Machine {
@@ -38,6 +40,10 @@ export interface Machine {
    *  to the provider record's `desiredTier`). The agent reconciles toward it;
    *  the achieved {@link tier} only rises once earned. Absent = not opted in. */
   desiredTier?: string;
+  /** Tier recomputed from the machine's ACTUAL signed attestation (proof-
+   *  backed; see verified-standing.server.ts), overlaid from live advisor
+   *  standing. Drives the fleet trust badge. Absent until standing is known. */
+  verifiedTier?: VerifiedTier;
   /** The advisor's VERIFIED confidential standing — the machine passed every
    *  earned leg (known-good cdHash + challenge-verified SIP + code-identity).
    *  This is the honest "operator cannot read your prompt" signal, stricter

--- a/packages/console/src/components/machines/machines.server.test.ts
+++ b/packages/console/src/components/machines/machines.server.test.ts
@@ -373,9 +373,22 @@ test("applyAdvisorStanding flags an unhealthy machine and marks standing known",
     byMachineId: new Map([
       [
         "rkey-laptop",
-        { unhealthy: true, unhealthyReason: "preflight-no-response", silentFailure: false },
+        {
+          unhealthy: true,
+          unhealthyReason: "preflight-no-response",
+          silentFailure: false,
+          verifiedTier: "best-effort" as const,
+        },
       ],
-      ["rkey-desktop", { unhealthy: false, unhealthyReason: null, silentFailure: false }],
+      [
+        "rkey-desktop",
+        {
+          unhealthy: false,
+          unhealthyReason: null,
+          silentFailure: false,
+          verifiedTier: "hardware-attested" as const,
+        },
+      ],
     ]),
   };
   const [laptop, desktop] = applyAdvisorStanding(machines, standing);
@@ -385,6 +398,8 @@ test("applyAdvisorStanding flags an unhealthy machine and marks standing known",
   assert.equal(laptop!.advisorConnected, true);
   assert.equal(desktop!.unhealthy, false);
   assert.equal(desktop!.advisorConnected, true);
+  assert.equal(laptop!.verifiedTier, "best-effort");
+  assert.equal(desktop!.verifiedTier, "hardware-attested");
 });
 
 test("applyAdvisorStanding marks a machine absent from the advisor list as not connected", () => {

--- a/packages/console/src/components/machines/machines.server.ts
+++ b/packages/console/src/components/machines/machines.server.ts
@@ -1,5 +1,6 @@
 import type { AppviewIndexedRecord } from "@/integrations/appview/appview.server.ts";
 import { cocoreConfig } from "@/lib/cocore-config.ts";
+import { verifiedTierFor, type VerifiedTier } from "@/lib/verified-standing.server.ts";
 
 import type { Machine, MachineState } from "./machines-data.ts";
 
@@ -467,6 +468,9 @@ interface AdvisorStanding {
   unhealthy: boolean;
   unhealthyReason: string | null;
   silentFailure: boolean;
+  /** Tier recomputed from the machine's actual signed attestation (proof-
+   *  backed; see verified-standing.server.ts), not its self-asserted value. */
+  verifiedTier: VerifiedTier;
 }
 
 export interface AdvisorStandingResult {
@@ -485,6 +489,9 @@ interface AdvisorProviderRow {
   unhealthy?: unknown;
   unhealthyReason?: unknown;
   silentFailure?: unknown;
+  attestationUri?: unknown;
+  confidentialEligible?: unknown;
+  codeAttested?: unknown;
 }
 
 /** Read live machine standing from the advisor's `/providers` and key it by
@@ -504,15 +511,27 @@ export async function fetchAdvisorStanding(did: string): Promise<AdvisorStanding
     if (!resp.ok) return { byMachineId, reachable: false };
     const rows = (await resp.json()) as AdvisorProviderRow[];
     if (!Array.isArray(rows)) return { byMachineId, reachable: false };
-    for (const r of rows) {
-      if (r.did !== did) continue;
-      if (typeof r.machineId !== "string" || r.machineId.length === 0) continue;
-      byMachineId.set(r.machineId, {
-        unhealthy: r.unhealthy === true,
-        unhealthyReason: typeof r.unhealthyReason === "string" ? r.unhealthyReason : null,
-        silentFailure: r.silentFailure === true,
-      });
-    }
+    const mine = rows.filter(
+      (r) => r.did === did && typeof r.machineId === "string" && r.machineId.length > 0,
+    );
+    // Recompute each machine's tier from its actual signed attestation
+    // (proof-backed, cached by attestation CID), in parallel with the rest.
+    await Promise.all(
+      mine.map(async (r) => {
+        const verifiedTier = await verifiedTierFor({
+          did,
+          attestationUri: typeof r.attestationUri === "string" ? r.attestationUri : null,
+          confidentialEligible: r.confidentialEligible === true,
+          codeAttested: r.codeAttested === true,
+        });
+        byMachineId.set(r.machineId as string, {
+          unhealthy: r.unhealthy === true,
+          unhealthyReason: typeof r.unhealthyReason === "string" ? r.unhealthyReason : null,
+          silentFailure: r.silentFailure === true,
+          verifiedTier,
+        });
+      }),
+    );
     return { byMachineId, reachable: true };
   } catch {
     return { byMachineId, reachable: false };
@@ -540,6 +559,7 @@ export function applyAdvisorStanding(
       unhealthy: s?.unhealthy ?? false,
       unhealthyReason: s?.unhealthyReason ?? undefined,
       silentFailure: s?.silentFailure ?? false,
+      verifiedTier: s?.verifiedTier ?? "best-effort",
     };
   });
 }

--- a/packages/console/src/lib/inference-docs/catalog.ts
+++ b/packages/console/src/lib/inference-docs/catalog.ts
@@ -109,6 +109,39 @@ export const INFERENCE_API_CATALOG: Array<InferenceApiCatalogEntry> = [
     ],
     example: { body: CHAT_BODY, canRun: false },
   },
+  {
+    id: "inference-api-verified-chat-completions",
+    navLabel: "verified/chat/completions",
+    method: "POST",
+    path: "/verified/chat/completions",
+    description:
+      'Same request shape as chat/completions, but routing is limited to providers whose attestation is cryptographically verified (recomputed from the signed Apple-rooted attestation, not the self-asserted label). Set min_trust to "hardware-attested" (default) or "confidential" to pick the floor. Fails closed with no_verified_providers when none qualify.',
+    auth: "required",
+    params: [
+      { name: "model", type: "string", required: true },
+      { name: "messages", type: "array", required: true },
+      { name: "min_trust", type: "string" },
+      { name: "stream", type: "boolean" },
+      { name: "max_tokens", type: "integer" },
+    ],
+    controls: [
+      { kind: "text", param: "model", label: "model", placeholder: "stub" },
+      {
+        kind: "text",
+        param: "message",
+        label: "user message",
+        placeholder: "Hello",
+      },
+      {
+        kind: "text",
+        param: "min_trust",
+        label: "min_trust",
+        placeholder: "hardware-attested",
+      },
+      { kind: "text", param: "max_tokens", label: "max_tokens", placeholder: "256" },
+    ],
+    example: { body: CHAT_BODY, canRun: false },
+  },
 ];
 
 export const INFERENCE_API_ERROR_SECTIONS = [

--- a/packages/console/src/lib/model-directory.server.ts
+++ b/packages/console/src/lib/model-directory.server.ts
@@ -33,6 +33,7 @@ import {
 } from "@/integrations/appview/appview.server.ts";
 import { cocoreConfig } from "@/lib/cocore-config.ts";
 import { RECOMMENDED_MODEL_IDS } from "@/lib/recommended-models.ts";
+import { verifiedTierFor, type VerifiedTier } from "@/lib/verified-standing.server.ts";
 
 interface PriceEntry {
   modelId?: string;
@@ -71,11 +72,14 @@ interface ModelMachine {
   ramGB: number | null;
   attestationPubKey: string | null;
   lastSeen: string | null;
-  /** True when the advisor currently routes this machine as
-   *  `attested-confidential` (hardware-attested + known-good build +
-   *  challenge-verified posture). Drives the "Confidential" badge.
-   *  Recomputed by the advisor; never the machine's self-asserted value. */
+  /** True when the machine's VERIFIED tier is `attested-confidential`.
+   *  Kept for back-compat; prefer `verifiedTier`. */
   confidential: boolean;
+  /** The machine's tier recomputed from its actual signed attestation —
+   *  `attested-confidential`, `hardware-attested`, or `best-effort`. Never the
+   *  self-asserted `trustLevel`; proof-backed (see verified-standing.server.ts).
+   *  Drives the directory trust badges. */
+  verifiedTier: VerifiedTier;
   /** Host profile chip (display name + handle + avatar). null when
    *  the DID has no `dev.cocore.account.profile` record yet — the UI
    *  falls back to a shortened DID in that case. */
@@ -268,6 +272,10 @@ interface AdvisorProviderRow {
    *  cdHash is known-good AND its challenge-verified posture holds. */
   trustTier?: string;
   confidentialEligible?: boolean;
+  /** Strong-ref to the machine's attestation record — verified offline to
+   *  prove the hardware-attested tier (see verified-standing.server.ts). */
+  attestationUri?: string | null;
+  codeAttested?: boolean;
 }
 
 /** DIDs the advisor currently considers routable — attested and not
@@ -277,7 +285,9 @@ interface AdvisorProviderRow {
  *  as offline rather than showing stale PDS records. */
 interface AdvisorOnline {
   lastSeen: string;
-  confidential: boolean;
+  /** The machine's tier recomputed from its ACTUAL signed attestation (the
+   *  SDK verifier), not the self-asserted label. Drives the directory badges. */
+  verifiedTier: VerifiedTier;
 }
 
 async function fetchAdvisorOnlineDids(): Promise<Map<string, AdvisorOnline> | null> {
@@ -286,16 +296,23 @@ async function fetchAdvisorOnlineDids(): Promise<Map<string, AdvisorOnline> | nu
     const r = await fetch(`${base}/providers`);
     if (!r.ok) return null;
     const list = (await r.json()) as AdvisorProviderRow[];
-    const online = new Map<string, AdvisorOnline>();
-    for (const p of list) {
-      if (!p.attestedAt) continue;
-      if (p.active === false) continue;
-      online.set(p.did, {
-        lastSeen: p.lastSeen ?? p.attestedAt,
-        confidential: p.confidentialEligible === true || p.trustTier === "attested-confidential",
-      });
-    }
-    return online;
+    const rows = list.filter((p) => p.attestedAt && p.active !== false);
+    // Recompute each machine's tier from its attestation — proof-backed, never
+    // the self-asserted trustLevel. The offline crypto is cached by attestation
+    // CID, so a warm directory is cheap; a machine whose attestation can't be
+    // fetched/verified degrades to best-effort rather than failing the page.
+    const entries = await Promise.all(
+      rows.map(async (p): Promise<[string, AdvisorOnline]> => {
+        const verifiedTier = await verifiedTierFor({
+          did: p.did,
+          attestationUri: p.attestationUri ?? null,
+          confidentialEligible: p.confidentialEligible,
+          codeAttested: p.codeAttested,
+        });
+        return [p.did, { lastSeen: p.lastSeen ?? p.attestedAt!, verifiedTier }];
+      }),
+    );
+    return new Map(entries);
   } catch (reason) {
     console.warn("[model-directory] Advisor /providers failed:", reason);
     return null;
@@ -416,7 +433,8 @@ export async function buildModelDirectory(): Promise<ModelDirectoryResponse> {
           ramGB: safeNumber(body.ramGB),
           attestationPubKey,
           lastSeen: seen,
-          confidential: onlineInfo?.confidential ?? false,
+          confidential: (onlineInfo?.verifiedTier ?? "best-effort") === "attested-confidential",
+          verifiedTier: onlineInfo?.verifiedTier ?? "best-effort",
           host: hostFor(did),
           activity: activityFor(activity, modelId, did),
         });

--- a/packages/console/src/lib/openai-routes.server.ts
+++ b/packages/console/src/lib/openai-routes.server.ts
@@ -35,6 +35,11 @@ import {
 } from "@/lib/openai-chat-completions.server.ts";
 import { resolveBearerKey } from "@/lib/api-keys.server.ts";
 import { buildModelDirectory } from "@/lib/model-directory.server.ts";
+import {
+  parseTrustFloor,
+  resolveVerifiedProviderDids,
+  type TrustFloor,
+} from "@/lib/verified-standing.server.ts";
 
 // priceCeiling shape (currency + amount) flows into BOTH the job
 // record and the paymentAuthorization record. The exchange's
@@ -160,6 +165,83 @@ export async function handlePrivateChatCompletions(request: Request): Promise<Re
     // friends-only mode. The set may be empty (user has no friends);
     // pickProvider surfaces NoFriendsAvailableError and the buffered/
     // streaming responders map that to a 503 (no_friends_available).
+    allowedProviderDids,
+  };
+
+  if (parsed.stream) {
+    return streamingResponse(id, parsed.model, runDispatch(inputs));
+  }
+  return await bufferedResponse(id, parsed.model, runDispatch(inputs));
+}
+
+/** POST /v1/verified/chat/completions — route ONLY to providers whose
+ *  attestation is cryptographically verified to meet a trust floor. Identical
+ *  wire format to `/v1/chat/completions` plus an optional `min_trust` body
+ *  field: `"hardware-attested"` (default — accept any verified machine) or
+ *  `"confidential"` (strict `attested-confidential`). Fails CLOSED with a 503
+ *  when no verified provider serves the model, so a privacy/integrity request
+ *  never silently downgrades. The allow-set is proof-backed (see
+ *  verified-standing.server.ts): a self-asserted `trustLevel` can't get a
+ *  provider routed here — only a verified Apple-rooted attestation can. */
+export async function handleVerifiedChatCompletions(request: Request): Promise<Response> {
+  const auth = await authenticate(request);
+  if (auth instanceof Response) return auth;
+
+  let raw: OpenAiChatRequest & { min_trust?: unknown };
+  try {
+    raw = (await request.json()) as typeof raw;
+  } catch {
+    return jsonError(400, "Body must be JSON");
+  }
+  const parsed = parseRequest(raw);
+  if (typeof parsed === "string") return jsonError(400, parsed);
+
+  // Floor defaults to hardware-attested ("any verified machine"). An explicit
+  // unrecognized value is a 400, never a silent downgrade.
+  let floor: TrustFloor = "hardware-attested";
+  if (raw.min_trust !== undefined) {
+    const f = parseTrustFloor(raw.min_trust);
+    if (!f) {
+      return jsonError(
+        400,
+        'min_trust must be "hardware-attested" or "confidential"',
+        "invalid_request_error",
+        "invalid_min_trust",
+      );
+    }
+    floor = f;
+  }
+
+  let allowedProviderDids: Set<string>;
+  try {
+    allowedProviderDids = await resolveVerifiedProviderDids(floor, parsed.model);
+  } catch (e) {
+    return jsonError(
+      502,
+      `failed to resolve verified providers: ${(e as Error).message}`,
+      "server_error",
+      "verified_lookup_failed",
+    );
+  }
+  if (allowedProviderDids.size === 0) {
+    return jsonError(
+      503,
+      `no provider is currently verified at the '${floor}' tier for model ${parsed.model}`,
+      "service_unavailable_error",
+      "no_verified_providers",
+    );
+  }
+
+  const id = `chatcmpl-${crypto.randomUUID().replace(/-/g, "")}`;
+  const inputs: DispatchInputs = {
+    did: auth.did,
+    oauthSession: auth.oauthSession,
+    model: parsed.model,
+    prompt: flattenMessages(parsed.messages),
+    maxTokensOut: parsed.maxTokens,
+    priceCeiling: DEFAULT_PRICE_CEILING,
+    // Same mechanism as the friends path, but the set is the proof-backed
+    // verified-provider list rather than the caller's friends.
     allowedProviderDids,
   };
 

--- a/packages/console/src/lib/verified-standing.server.ts
+++ b/packages/console/src/lib/verified-standing.server.ts
@@ -1,0 +1,187 @@
+// Proof-backed trust-tier resolution for providers.
+//
+// A provider record's `trustLevel` and a machine's claimed tier are
+// SELF-ASSERTED — anyone can write them to their own PDS. This module
+// recomputes the tier from the ACTUAL attestation, so a badge or a routing
+// decision can never be faked by editing a record:
+//
+//   * hardware-attested — proven OFFLINE: the SDK verifier checks the
+//     provider's signed attestation carries an Apple-rooted MDA chain that
+//     verifies AND binds to the signing key (leaf-key or freshness-code).
+//     No known-good set or coordinator needed — pure Apple-CA crypto.
+//   * attested-confidential — the above PLUS the advisor's MEASURED standing
+//     (`confidentialEligible`: a known-good cdHash + the un-forgeable,
+//     AMFI-gated APNs code-attestation). The code-attestation is the one leg
+//     an operator can't forge; it's advisor-asserted by design (the
+//     documented coordinator-trust carve-out — see sdk/verify-provider.ts).
+//
+// The offline crypto (Apple cert-chain verification) is cached by attestation
+// CID: a machine's attestation only changes when it re-attests (~daily), so
+// the hot path is a cache hit. The LIVE confidential bit (which can flip with
+// code-attestation) is layered on per-call, never cached.
+
+import { verifyProviderForSeal } from "@cocore/sdk/verify-provider";
+import type { AttestationRecord } from "@cocore/sdk/types";
+
+import { cocoreConfig } from "@/lib/cocore-config.ts";
+
+export type VerifiedTier = "best-effort" | "hardware-attested" | "attested-confidential";
+
+/** The floor a requester can demand. `hardware-attested` accepts EITHER
+ *  verified tier (confidential is strictly stronger); `attested-confidential`
+ *  is strict. */
+export type TrustFloor = "hardware-attested" | "attested-confidential";
+
+export function meetsFloor(tier: VerifiedTier, floor: TrustFloor): boolean {
+  if (floor === "attested-confidential") return tier === "attested-confidential";
+  return tier === "hardware-attested" || tier === "attested-confidential";
+}
+
+/** Map a requester-facing param value to a TrustFloor, or null if invalid.
+ *  Accepts `hardware-attested` and `confidential`/`attested-confidential`. */
+export function parseTrustFloor(v: unknown): TrustFloor | null {
+  if (typeof v !== "string") return null;
+  const s = v.trim().toLowerCase();
+  if (s === "hardware-attested" || s === "hardware") return "hardware-attested";
+  if (s === "confidential" || s === "attested-confidential") return "attested-confidential";
+  return null;
+}
+
+interface AdvisorRow {
+  did: string;
+  machineId?: string;
+  supportedModels?: string[];
+  attestationUri?: string | null;
+  attestedAt?: string | null;
+  confidentialEligible?: boolean;
+  codeAttested?: boolean;
+}
+
+// Codes the SDK verifier emits when the OFFLINE hardware-attestation proof
+// fails (self-signature, the Apple MDA chain, or its binding to the signing
+// key). If NONE are present, genuine-Apple-hardware-bound-to-the-signing-key
+// holds — i.e. at least hardware-attested.
+const HARDWARE_BLOCKER_CODES = new Set([
+  "attestation-signature-invalid",
+  "mda-invalid",
+  "mda-unbound",
+  "mda-no-binding-material",
+  "no-hardware-attestation",
+]);
+
+// offline proof (hardware-attested?) keyed by attestation CID — immutable.
+const offlineTierCache = new Map<string, "hardware-attested" | "best-effort">();
+
+function advisorBase(): string {
+  return cocoreConfig().advisorUrl.replace(/\/$/, "");
+}
+
+/** Resolve a DID's PDS host (public, unauthenticated). */
+async function resolvePds(did: string): Promise<string | null> {
+  try {
+    const r = await fetch(
+      `https://slingshot.microcosm.blue/xrpc/com.bad-example.identity.resolveMiniDoc?identifier=${encodeURIComponent(did)}`,
+      { headers: { Accept: "application/json" } },
+    );
+    if (!r.ok) return null;
+    const mini = (await r.json()) as { pds?: string };
+    return typeof mini.pds === "string" ? mini.pds.replace(/\/$/, "") : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Public getRecord of the provider's attestation. */
+async function fetchAttestation(
+  did: string,
+  attestationUri: string,
+): Promise<{ record: AttestationRecord; cid: string } | null> {
+  const m = /^at:\/\/[^/]+\/([^/]+)\/([^/]+)$/.exec(attestationUri);
+  if (!m) return null;
+  const collection = m[1]!;
+  const rkey = m[2]!;
+  const pds = await resolvePds(did);
+  if (!pds) return null;
+  try {
+    const r = await fetch(
+      `${pds}/xrpc/com.atproto.repo.getRecord?repo=${encodeURIComponent(did)}` +
+        `&collection=${encodeURIComponent(collection)}&rkey=${encodeURIComponent(rkey)}`,
+      { headers: { Accept: "application/json" } },
+    );
+    if (!r.ok) return null;
+    const body = (await r.json()) as { value?: unknown; cid?: unknown };
+    if (!body.value || typeof body.cid !== "string") return null;
+    return { record: body.value as AttestationRecord, cid: body.cid };
+  } catch {
+    return null;
+  }
+}
+
+/** The offline half: does the signed attestation prove genuine Apple hardware
+ *  bound to the signing key? Cached per attestation CID. */
+async function offlineHardwareTier(
+  did: string,
+  attestationUri: string,
+): Promise<"hardware-attested" | "best-effort"> {
+  const fetched = await fetchAttestation(did, attestationUri);
+  if (!fetched) return "best-effort";
+  const cached = offlineTierCache.get(fetched.cid);
+  if (cached) return cached;
+
+  const record = fetched.record;
+  const mdaChain = (record as { mdaCertChain?: string[] }).mdaCertChain;
+  let hardwareOk = false;
+  try {
+    // requireConfidential:false → compute the tier without hard-failing; we
+    // only read the findings to see if the hardware-attestation gates passed.
+    const result = await verifyProviderForSeal(record, mdaChain, { requireConfidential: false });
+    hardwareOk = !result.findings.some((f) => HARDWARE_BLOCKER_CODES.has(f.code));
+  } catch {
+    hardwareOk = false;
+  }
+  const tier = hardwareOk ? "hardware-attested" : "best-effort";
+  offlineTierCache.set(fetched.cid, tier);
+  return tier;
+}
+
+/** Recompute a machine's tier from its actual attestation (offline proof) +
+ *  the advisor's live measured confidential standing. Never trusts the
+ *  self-asserted trustLevel. */
+export async function verifiedTierFor(row: AdvisorRow): Promise<VerifiedTier> {
+  if (!row.attestationUri) return "best-effort";
+  const offline = await offlineHardwareTier(row.did, row.attestationUri);
+  if (offline === "best-effort") return "best-effort";
+  // Genuine Apple hardware bound to the key. Confidential additionally needs
+  // the advisor's measured + code-attested standing (the un-forgeable leg).
+  return row.confidentialEligible === true ? "attested-confidential" : "hardware-attested";
+}
+
+/** Set of provider DIDs whose VERIFIED tier meets `floor` (optionally for a
+ *  given model). This is the proof-backed allow-set the verified completions
+ *  path routes against — built the same way the friends path builds its set,
+ *  but from cryptographic verification instead of friend records. */
+export async function resolveVerifiedProviderDids(
+  floor: TrustFloor,
+  model?: string,
+): Promise<Set<string>> {
+  const r = await fetch(`${advisorBase()}/providers`, { headers: { Accept: "application/json" } });
+  if (!r.ok) throw new Error(`advisor /providers ${r.status}`);
+  const rows = (await r.json()) as AdvisorRow[];
+  const online = rows.filter((p) => p.attestedAt);
+  const dids = new Set<string>();
+  await Promise.all(
+    online.map(async (row) => {
+      if (
+        model &&
+        row.supportedModels &&
+        row.supportedModels.length > 0 &&
+        !row.supportedModels.includes(model)
+      ) {
+        return;
+      }
+      const tier = await verifiedTierFor(row);
+      if (meetsFloor(tier, floor)) dids.add(row.did);
+    }),
+  );
+  return dids;
+}

--- a/packages/console/src/lib/verified-standing.test.ts
+++ b/packages/console/src/lib/verified-standing.test.ts
@@ -1,0 +1,39 @@
+// Pure tests for the trust-floor logic that gates the verified path. The
+// network/crypto half (fetch attestation + run the SDK verifier) is exercised
+// by the SDK's own verifier tests; here we pin the floor semantics: a
+// hardware-attested floor accepts EITHER verified tier, confidential is strict.
+
+import { describe, expect, it } from "vitest";
+
+import { meetsFloor, parseTrustFloor } from "./verified-standing.server.ts";
+
+describe("parseTrustFloor", () => {
+  it("maps the accepted aliases", () => {
+    expect(parseTrustFloor("hardware-attested")).toBe("hardware-attested");
+    expect(parseTrustFloor("hardware")).toBe("hardware-attested");
+    expect(parseTrustFloor("confidential")).toBe("attested-confidential");
+    expect(parseTrustFloor("attested-confidential")).toBe("attested-confidential");
+    expect(parseTrustFloor(" Confidential ")).toBe("attested-confidential");
+  });
+
+  it("rejects unknown / non-string values (caller 400s instead of downgrading)", () => {
+    expect(parseTrustFloor("best-effort")).toBeNull();
+    expect(parseTrustFloor("")).toBeNull();
+    expect(parseTrustFloor(undefined)).toBeNull();
+    expect(parseTrustFloor(42)).toBeNull();
+  });
+});
+
+describe("meetsFloor", () => {
+  it("hardware-attested floor accepts either verified tier, not best-effort", () => {
+    expect(meetsFloor("hardware-attested", "hardware-attested")).toBe(true);
+    expect(meetsFloor("attested-confidential", "hardware-attested")).toBe(true);
+    expect(meetsFloor("best-effort", "hardware-attested")).toBe(false);
+  });
+
+  it("confidential floor is strict — only attested-confidential passes", () => {
+    expect(meetsFloor("attested-confidential", "attested-confidential")).toBe(true);
+    expect(meetsFloor("hardware-attested", "attested-confidential")).toBe(false);
+    expect(meetsFloor("best-effort", "attested-confidential")).toBe(false);
+  });
+});

--- a/packages/console/src/routes/_header-layout.models.tsx
+++ b/packages/console/src/routes/_header-layout.models.tsx
@@ -19,7 +19,7 @@ import {
 } from "@/components/api-docs/snippets.ts";
 import { modelDirectoryRouteQueryOptions } from "@/components/models/models.functions.ts";
 import { OperatorChip } from "@/components/profile/OperatorChip.tsx";
-import { Badge } from "@/design-system/badge";
+import { TrustTierBadge } from "@/components/TrustTierBadge.tsx";
 import { Button } from "@/design-system/button";
 import { CopyToClipboardButton } from "@/design-system/copy-to-clipboard-button";
 import { Flex } from "@/design-system/flex";
@@ -1095,15 +1095,7 @@ function ModelsPage() {
                               {mach.chip ? ` · ${mach.chip}` : ""}
                               {mach.ramGB != null ? `, ${mach.ramGB} GB` : ""}
                             </SmallBody>
-                            {mach.confidential ? (
-                              <Badge
-                                size="sm"
-                                variant="success"
-                                title="Hardware-attested confidential tier — the advisor verified this machine's signed posture against a known-good build. Your prompt is sealed so the operator can't read it."
-                              >
-                                🔒 Confidential
-                              </Badge>
-                            ) : null}
+                            <TrustTierBadge tier={mach.verifiedTier} />
                           </td>
                           <td {...stylex.props(styles.td, isLast && styles.tdLastRow)}>
                             <OperatorChip

--- a/packages/console/src/routes/api.v1.verified.chat.completions.ts
+++ b/packages/console/src/routes/api.v1.verified.chat.completions.ts
@@ -1,0 +1,20 @@
+// POST /api/v1/verified/chat/completions
+//
+// Verified-only sibling of `/api/v1/chat/completions`: same OpenAI wire
+// format, but routing is constrained to providers whose attestation is
+// cryptographically verified to meet a trust floor (min_trust body field:
+// "hardware-attested" default, or "confidential"). See the canonical
+// `/v1/verified/chat/completions` mount for the full contract; both routes
+// call the same handler in `@/lib/openai-routes.server.ts`.
+
+import { createFileRoute } from "@tanstack/react-router";
+
+import { handleVerifiedChatCompletions } from "@/lib/openai-routes.server.ts";
+
+export const Route = createFileRoute("/api/v1/verified/chat/completions")({
+  server: {
+    handlers: {
+      POST: ({ request }) => handleVerifiedChatCompletions(request),
+    },
+  },
+});

--- a/packages/console/src/routes/v1.verified.chat.completions.ts
+++ b/packages/console/src/routes/v1.verified.chat.completions.ts
@@ -1,0 +1,30 @@
+// POST /v1/verified/chat/completions
+//
+// Verified-only sibling of `/v1/chat/completions`. Same OpenAI wire format —
+// point a client at `base_url="https://cocore.dev/v1/verified"` and it Just
+// Works — but routing is constrained to providers whose attestation is
+// CRYPTOGRAPHICALLY VERIFIED to meet a trust floor, recomputed from the actual
+// Apple-rooted attestation rather than the provider's self-asserted label.
+//
+// Optional body field:
+//   * min_trust: "hardware-attested" (default — any verified machine)
+//                "confidential"      (strict attested-confidential tier)
+//
+// Errors specific to this endpoint:
+//   * 503 (no_verified_providers) — none meet the floor for the model
+//   * 400 (invalid_min_trust)     — unrecognized min_trust value
+//
+// The handler is shared with the legacy `/api/v1/verified/chat/completions`
+// mount. See verified-standing.server.ts for the proof-backed allow-set.
+
+import { createFileRoute } from "@tanstack/react-router";
+
+import { handleVerifiedChatCompletions } from "@/lib/openai-routes.server.ts";
+
+export const Route = createFileRoute("/v1/verified/chat/completions")({
+  server: {
+    handlers: {
+      POST: ({ request }) => handleVerifiedChatCompletions(request),
+    },
+  },
+});

--- a/packages/sdk/src/p256.ts
+++ b/packages/sdk/src/p256.ts
@@ -41,12 +41,20 @@ export async function verifyP256(
   const sigRaw = derToRawSignature(sigDer);
   const cryptoKey = await crypto.subtle.importKey(
     "raw",
-    prefixUncompressed(pubRaw),
+    // Copy into a plain ArrayBuffer-backed view: TS 5.7+ types the generic
+    // `Uint8Array<ArrayBufferLike>` as not assignable to WebCrypto's
+    // `BufferSource` (which wants `ArrayBuffer`). Runtime-equivalent.
+    new Uint8Array(prefixUncompressed(pubRaw)),
     { name: "ECDSA", namedCurve: "P-256" },
     false,
     ["verify"],
   );
-  return crypto.subtle.verify({ name: "ECDSA", hash: "SHA-256" }, cryptoKey, sigRaw, message);
+  return crypto.subtle.verify(
+    { name: "ECDSA", hash: "SHA-256" },
+    cryptoKey,
+    new Uint8Array(sigRaw),
+    new Uint8Array(message),
+  );
 }
 
 /** Verify a receipt body's `enclaveSignature` against an attestation's

--- a/packages/sdk/src/verify-provider.ts
+++ b/packages/sdk/src/verify-provider.ts
@@ -483,7 +483,7 @@ export async function freshnessBindsKey(
     return false;
   }
   if (pub.length === 0) return false;
-  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", pub));
+  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", new Uint8Array(pub)));
   return constantTimeEqual(digest, normalizeFreshness(freshnessCode));
 }
 


### PR DESCRIPTION
## Summary

The full "verified machines" feature: a **proof-backed verified completions path** plus **proof-backed trust badges** across the UI. Both read from one primitive that recomputes a machine's tier from its *actual signed attestation* — never the self-asserted `trustLevel` a provider writes to its own PDS, so editing a record can't fake a tier (the exact concern raised).

### The proof primitive — `verified-standing.server.ts`
- **hardware-attested** — proven **offline**: the SDK fail-closed verifier checks the attestation's Apple-rooted MDA chain verifies *and* binds to the signing key. No coordinator/known-good set needed.
- **attested-confidential** — the above **plus** the advisor's *measured* standing (`confidentialEligible`: known-good cdHash + the un-forgeable APNs code-attestation).
- Offline crypto cached by attestation CID (re-verify only when a machine re-attests).

### The path — `/v1/verified/chat/completions` (+ `/api/v1` alias)
- OpenAI wire shape + optional `min_trust` floor: `hardware-attested` (default — any verified) or `confidential` (strict). Confidential is strictly stronger, so the floor covers "each or either."
- Reuses the friends `allowedProviderDids` mechanism with the proof-backed set. **Fails closed** (`503 no_verified_providers`), never a silent downgrade; `400 invalid_min_trust` on a bad value.

### The badges — `TrustTierBadge` (shared)
- 🔒 Confidential / 🛡️ Hardware-attested; best-effort renders nothing so verified machines stand out. Hover explains the proof.
- **Public model directory**: per-machine row reads `verifiedTier` (the loader runs the verifier per online machine, cached).
- **Owner fleet dashboard**: advisor standing carries `verifiedTier`; the fleet table shows the badge.

### Docs
- `openapi.yaml` + inference-docs catalog: the new `/v1/verified/chat/completions` path + `min_trust`.

### SDK type fix
Importing the verifier surfaced a TS 5.7 `Uint8Array`/`BufferSource` false-positive; fixed by copying the small crypto inputs into ArrayBuffer-backed views (runtime-equivalent). **101 SDK tests pass.**

## Test plan
- `tsc --noEmit`: clean (console + sdk).
- New `verified-standing.test.ts` (floor semantics) + updated fleet-standing test (tier overlay): pass.
- SDK suite 101 pass; touched console tests pass.
- Pre-existing `better-sqlite3` native-ABI failures are unrelated.

## Note
Badge/route verification fetches each machine's attestation and runs Apple-CA crypto; it's cached by attestation CID so warm loads are cheap, but a cold public-directory load does N fetch+verify. A background refresh is an easy future optimization if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
