### PR TITLE
Proof-backed verified completions path + trust-tier badges

### DIFF
--- a/packages/console/src/components/start/StartGuide.tsx
+++ b/packages/console/src/components/start/StartGuide.tsx
@@ -24,14 +24,12 @@ import { Flex } from "@/design-system/flex";
 import { Page } from "@/design-system/page/index.tsx";
 import { SegmentedControl, SegmentedControlItem } from "@/design-system/segmented-control";
 import { Select, SelectItem } from "@/design-system/select";
-import { successColor, uiColor } from "@/design-system/theme/color.stylex";
-import { radius } from "@/design-system/theme/radius.stylex";
+import { uiColor } from "@/design-system/theme/color.stylex";
 import { horizontalSpace, verticalSpace } from "@/design-system/theme/semantic-spacing.stylex";
 import {
   fontFamily,
   fontSize,
   fontWeight,
-  lineHeight,
 } from "@/design-system/theme/typography.stylex";
 import { Body, Heading1, InlineCode } from "@/design-system/typography";
 
@@ -74,30 +72,6 @@ const styles = stylex.create({
     fontSize: fontSize.xs,
     color: uiColor.text1,
     fontWeight: fontWeight.normal,
-  },
-  cliBox: {
-    backgroundColor: uiColor.component1,
-    borderRadius: radius.md,
-    color: uiColor.text2,
-    fontSize: fontSize.xs,
-    lineHeight: lineHeight.base,
-    marginBottom: verticalSpace["xl"],
-    marginTop: verticalSpace["xl"],
-    paddingBottom: verticalSpace["3xl"],
-    paddingLeft: horizontalSpace["2xl"],
-    paddingRight: horizontalSpace["2xl"],
-    paddingTop: verticalSpace["3xl"],
-    position: "relative",
-  },
-  cliCopy: {
-    position: "absolute",
-    right: horizontalSpace.sm,
-    top: verticalSpace.sm,
-  },
-  cliPrompt: {
-    color: successColor.solid1,
-    marginRight: horizontalSpace.md,
-    userSelect: "none",
   },
   usage: {
     fontFamily: fontFamily.mono,
@@ -260,21 +234,6 @@ export function StartGuide() {
                   memory — it installs the <InlineCode>vllm-mlx</InlineCode> runtime for you — and
                   starting to serve.
                 </Body>
-
-                <Body style={styles.subtleNote}>
-                  Running headless or a fleet of Macs with no GUI? The terminal installer still
-                  works (the app is the recommended path for everyone else):
-                </Body>
-                <div {...stylex.props(styles.cliBox)}>
-                  <CopyToClipboardButton
-                    text="curl -fsSL console.cocore.dev/agent | sh"
-                    style={styles.cliCopy}
-                  />
-                  <div>
-                    <span {...stylex.props(styles.cliPrompt)}>$</span>curl -fsSL
-                    console.cocore.dev/agent | sh
-                  </div>
-                </div>
 
                 <Flex direction="row" gap="md" style={styles.bodySpaced} wrap>
                   <ButtonLink to="/machines" variant="secondary" size="sm">

--- a/packages/console/src/components/start/StartGuide.tsx
+++ b/packages/console/src/components/start/StartGuide.tsx
@@ -25,12 +25,8 @@ import { Page } from "@/design-system/page/index.tsx";
 import { SegmentedControl, SegmentedControlItem } from "@/design-system/segmented-control";
 import { Select, SelectItem } from "@/design-system/select";
 import { uiColor } from "@/design-system/theme/color.stylex";
-import { horizontalSpace, verticalSpace } from "@/design-system/theme/semantic-spacing.stylex";
-import {
-  fontFamily,
-  fontSize,
-  fontWeight,
-} from "@/design-system/theme/typography.stylex";
+import { verticalSpace } from "@/design-system/theme/semantic-spacing.stylex";
+import { fontFamily, fontSize, fontWeight } from "@/design-system/theme/typography.stylex";
 import { Body, Heading1, InlineCode } from "@/design-system/typography";
 
 const REQUESTER_SNIPPET_LANG: SnippetLang = "typescript";


### PR DESCRIPTION
## What & why

Adds a proof-backed **verified completions** inference path and surfaces the resulting trust signal in the console, plus a small start-guide cleanup.

### `feat(inference): proof-backed verified completions path (/v1/verified)`
- New `/v1/verified/chat/completions` (and `/api/v1/verified/...`) routes that run inference through a path which returns a verifiable proof of standing alongside the completion.
- `lib/verified-standing.server.ts` (+ tests) computes/validates the standing; `lib/openai-routes.server.ts` wires the verified variant into the OpenAI-compatible surface.
- SDK: `p256.ts` / `verify-provider.ts` tweaks supporting verification; `openapi.yaml` and inference-docs catalog document the new endpoint.

### `feat(console): proof-backed trust-tier badges on the directory + fleet`
- `TrustTierBadge.tsx` renders a provider's trust tier; wired into the models directory (`_header-layout.models.tsx`, `model-directory.server.ts`) and the machines dashboard (`machines.server.ts` + tests, `machines-data.ts`).

### `feat(console): drop terminal-installer copy from start guide`
- Removes the headless/fleet `curl … | sh` fallback copy and its CLI box from the "Run a machine" start card (app download is the path we want to surface). Dead `cliBox`/`cliCopy`/`cliPrompt` styles and orphaned imports removed too. The real install endpoints (`cli-snippets`, `/agent` routes) are untouched — those must keep serving on `console.cocore.dev` for already-installed agents.

## Reviewer notes
- Honors the core invariant that receipts/proofs are self-verifying — the verified path returns a proof the SDK can validate offline; it does not introduce a privileged coordinator.
- Generated `routeTree.gen.ts` was intentionally **not** committed (generated code per CLAUDE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)