### PR TITLE
Redirect legacy console.cocore.dev pages to cocore.dev

### DIFF
--- a/packages/console/src/lib/legacy-host-redirect.test.ts
+++ b/packages/console/src/lib/legacy-host-redirect.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { canonicalConsoleRedirectUrl } from "./legacy-host-redirect.ts";
+
+describe("canonicalConsoleRedirectUrl", () => {
+  it("redirects the legacy console host to the canonical apex, preserving path + query", () => {
+    expect(
+      canonicalConsoleRedirectUrl("https://console.cocore.dev/machines?tab=fleet", null, null),
+    ).toBe("https://cocore.dev/machines?tab=fleet");
+  });
+
+  it("preserves the root path", () => {
+    expect(canonicalConsoleRedirectUrl("https://console.cocore.dev/", null, null)).toBe(
+      "https://cocore.dev/",
+    );
+  });
+
+  it("returns null when already on the canonical apex", () => {
+    expect(canonicalConsoleRedirectUrl("https://cocore.dev/machines", null, null)).toBeNull();
+  });
+
+  it("returns null for localhost dev", () => {
+    expect(canonicalConsoleRedirectUrl("http://localhost:3000/start", null, null)).toBeNull();
+  });
+
+  it("returns null for Railway preview hosts", () => {
+    expect(
+      canonicalConsoleRedirectUrl("https://client-cocore-pr-81.up.railway.app/", null, null),
+    ).toBeNull();
+  });
+
+  it("prefers the Host header over the URL host", () => {
+    // Behind a proxy the URL host can be an internal address; the Host
+    // header carries the real public hostname.
+    expect(
+      canonicalConsoleRedirectUrl("http://10.0.0.5:8080/account", "console.cocore.dev", null),
+    ).toBe("https://cocore.dev/account");
+  });
+
+  it("prefers x-forwarded-host over the Host header", () => {
+    expect(
+      canonicalConsoleRedirectUrl(
+        "http://10.0.0.5:8080/account",
+        "internal.railway",
+        "console.cocore.dev",
+      ),
+    ).toBe("https://cocore.dev/account");
+  });
+
+  it("takes the first value from a comma-separated x-forwarded-host", () => {
+    expect(
+      canonicalConsoleRedirectUrl("http://10.0.0.5/x", null, "console.cocore.dev, proxy.internal"),
+    ).toBe("https://cocore.dev/x");
+  });
+
+  it("is case-insensitive on the hostname", () => {
+    expect(canonicalConsoleRedirectUrl("https://CONSOLE.COCORE.DEV/blog", null, null)).toBe(
+      "https://cocore.dev/blog",
+    );
+  });
+
+  it("ignores a port on the legacy host", () => {
+    expect(canonicalConsoleRedirectUrl("https://console.cocore.dev:443/jobs", null, null)).toBe(
+      "https://cocore.dev/jobs",
+    );
+  });
+
+  it("does not match an unrelated host that merely contains the legacy host", () => {
+    expect(
+      canonicalConsoleRedirectUrl("https://console.cocore.dev.evil.example/x", null, null),
+    ).toBeNull();
+  });
+});

--- a/packages/console/src/lib/legacy-host-redirect.ts
+++ b/packages/console/src/lib/legacy-host-redirect.ts
@@ -52,7 +52,7 @@ export function canonicalConsoleRedirectUrl(
  * route files (the import-protection plugin blocks it), so the page routes
  * call this instead of touching `getRequest` directly.
  */
-export const legacyConsoleHostRedirectFn = createServerFn({ method: "GET" }).handler(async () => {
+const legacyConsoleHostRedirectFn = createServerFn({ method: "GET" }).handler(async () => {
   const { getRequest } = await import("@tanstack/react-start/server");
   const request = getRequest();
   return canonicalConsoleRedirectUrl(

--- a/packages/console/src/lib/legacy-host-redirect.ts
+++ b/packages/console/src/lib/legacy-host-redirect.ts
@@ -1,0 +1,82 @@
+// Redirect the human-facing console pages from the legacy host
+// (console.cocore.dev) to the canonical apex (cocore.dev).
+//
+// CRITICAL SAFETY CONSTRAINT: console.cocore.dev must keep *serving*
+// (never redirect) the paths baked into already-installed agents and the
+// `curl …/agent | sh` installer — `/agent*`, `/api*`, `/v1*`, `/xrpc*`,
+// `/.well-known/*` (plus the DID docs and `/lexicons/*`). Those are all
+// server-handler routes that live OUTSIDE the two page layouts, and only
+// the page routes (`/_header-layout/*`, `/_docs-header-layout/*`, `/login`)
+// call `enforceCanonicalConsoleHost`. So the redirect is safe by
+// construction: this code is never in the agent/API request path, and the
+// failure mode is "a page we forgot doesn't redirect" — never "an agent
+// path got redirected". See the cocore.dev cutover notes / CLAUDE.md.
+
+import { redirect } from "@tanstack/react-router";
+import { createServerFn } from "@tanstack/react-start";
+
+const LEGACY_CONSOLE_HOST = "console.cocore.dev";
+const CANONICAL_CONSOLE_HOST = "cocore.dev";
+
+/**
+ * Pure host-decision core (kept separate from the server fn so it's
+ * unit-testable). Given the request URL and the relevant headers, returns
+ * the absolute https://cocore.dev URL to redirect to — path + query
+ * preserved — when the request arrived on the legacy console host, or
+ * `null` when it didn't (canonical host, localhost, *.up.railway.app
+ * previews, etc.).
+ *
+ * `x-forwarded-host` wins over the `Host` header because Railway's edge
+ * forwards the public hostname there; both fall back to the URL's own host.
+ */
+export function canonicalConsoleRedirectUrl(
+  requestUrl: string,
+  hostHeader: string | null,
+  forwardedHost: string | null,
+): string | null {
+  const url = new URL(requestUrl);
+  const rawHost = (forwardedHost?.split(",")[0] ?? hostHeader ?? url.host).trim();
+  const hostname = rawHost.split(":")[0]?.toLowerCase() ?? "";
+  if (hostname !== LEGACY_CONSOLE_HOST) return null;
+  url.protocol = "https:";
+  url.hostname = CANONICAL_CONSOLE_HOST;
+  // Drop any inbound port so we always land on plain https://cocore.dev
+  // (setting `hostname` alone would leave an existing :port attached).
+  url.port = "";
+  return url.toString();
+}
+
+/**
+ * Server fn: reads the current request and returns the canonical redirect
+ * target (or null). `@tanstack/react-start/server` can't be imported from
+ * route files (the import-protection plugin blocks it), so the page routes
+ * call this instead of touching `getRequest` directly.
+ */
+export const legacyConsoleHostRedirectFn = createServerFn({ method: "GET" }).handler(async () => {
+  const { getRequest } = await import("@tanstack/react-start/server");
+  const request = getRequest();
+  return canonicalConsoleRedirectUrl(
+    request.url,
+    request.headers.get("host"),
+    request.headers.get("x-forwarded-host"),
+  );
+});
+
+/**
+ * Call from a page route's `beforeLoad`. On the server (initial document
+ * render) it 30x's legacy-host requests to the canonical apex; on the
+ * client it's a no-op (the body is dead-code-eliminated from the browser
+ * bundle via `import.meta.env.SSR`, and the user is already on cocore.dev
+ * after the first hop anyway).
+ *
+ * Uses 302 (temporary) for the initial rollout so a mistake isn't
+ * hard-cached by browsers. Once the page/agent split is confirmed in
+ * production, flip to `statusCode: 301`.
+ */
+export async function enforceCanonicalConsoleHost(): Promise<void> {
+  if (!import.meta.env.SSR) return;
+  const target = await legacyConsoleHostRedirectFn();
+  if (target) {
+    throw redirect({ href: target, statusCode: 302 });
+  }
+}

--- a/packages/console/src/routes/_docs-header-layout.tsx
+++ b/packages/console/src/routes/_docs-header-layout.tsx
@@ -3,8 +3,12 @@ import { Outlet, createFileRoute } from "@tanstack/react-router";
 
 import { docsStyles } from "@/components/docs/docs-page.stylex.tsx";
 import { DocsTopbar } from "@/components/docs/docs-topbar.tsx";
+import { enforceCanonicalConsoleHost } from "@/lib/legacy-host-redirect.ts";
 
 export const Route = createFileRoute("/_docs-header-layout")({
+  beforeLoad: async () => {
+    await enforceCanonicalConsoleHost();
+  },
   component: DocsHeaderLayoutRoute,
 });
 

--- a/packages/console/src/routes/_header-layout.tsx
+++ b/packages/console/src/routes/_header-layout.tsx
@@ -9,6 +9,7 @@ import {
   useLocation,
 } from "@tanstack/react-router";
 
+import { enforceCanonicalConsoleHost } from "@/lib/legacy-host-redirect.ts";
 import { listMyMachinesQueryOptions } from "@/components/machines/machines.functions.ts";
 import { NavbarAuth } from "@/components/NavbarAuth.tsx";
 import { NavbarDiscoverMenu } from "@/components/NavbarDiscoverMenu.tsx";
@@ -75,6 +76,7 @@ const FooterRouterLink = createLink(DSLink);
 
 export const Route = createFileRoute("/_header-layout")({
   beforeLoad: async ({ context, location }) => {
+    await enforceCanonicalConsoleHost();
     await context.queryClient.ensureQueryData(getSessionQueryOptions);
     const session = context.queryClient.getQueryData(getSessionQueryOptions.queryKey);
     const skipTermsStateQuery =

--- a/packages/console/src/routes/login.tsx
+++ b/packages/console/src/routes/login.tsx
@@ -31,6 +31,7 @@ import {
   verticalSpace,
 } from "@/design-system/theme/semantic-spacing.stylex";
 import { Body, Heading1, Heading4, InlineCode } from "@/design-system/typography";
+import { enforceCanonicalConsoleHost } from "@/lib/legacy-host-redirect.ts";
 import { unauthMiddleware } from "@/middleware/auth.ts";
 import { Text } from "@/design-system/typography/text";
 import { type SavedHandle, saveHandle } from "@/utils/saved-handles.ts";
@@ -148,6 +149,9 @@ interface SavedHandleEntry extends SavedHandle {
 
 export const Route = createFileRoute("/login")({
   validateSearch: searchSchema,
+  beforeLoad: async () => {
+    await enforceCanonicalConsoleHost();
+  },
   server: {
     middleware: [unauthMiddleware],
   },


### PR DESCRIPTION
## What & why

Human-facing console pages should live on the canonical apex (`cocore.dev`), but `console.cocore.dev` still serves them directly. This adds a **server-side host redirect**: page requests arriving on `console.cocore.dev` get a 30x to `https://cocore.dev<same-path><same-query>`.

## The hard constraint (and how this respects it)

`console.cocore.dev` **must keep serving** — never redirect — the paths baked into already-installed agents and the `curl …/agent | sh` installer: `/agent*`, `/api*`, `/v1*`, `/xrpc*`, `/.well-known/*`, the DID docs, and `/lexicons/*`. Redirecting any of those breaks every deployed agent.

This is **safe by construction**, not by allowlist: only the human **page** routes call the guard —
- `/_header-layout/*` (the 21 app pages)
- `/_docs-header-layout/*` (docs)
- `/login`

Every must-keep-serving path is a **server-handler route that lives outside those layouts**, so the redirect code is never in its request path. The failure mode is "a page we forgot doesn't redirect" (benign) — never "an agent path got redirected."

## How it works

- `lib/legacy-host-redirect.ts`:
  - `canonicalConsoleRedirectUrl(url, hostHeader, forwardedHost)` — pure, unit-tested host-decision core. Prefers `x-forwarded-host` (Railway's edge) → `Host` → URL host; case-insensitive; strips port.
  - `legacyConsoleHostRedirectFn` — `createServerFn` wrapper that reads `getRequest()` (route files can't import `@tanstack/react-start/server` directly — same pattern as `accept-terms`).
  - `enforceCanonicalConsoleHost()` — called from the page routes' `beforeLoad`. Server-only (body is dead-code-eliminated from the browser bundle via `import.meta.env.SSR`); throws the router redirect.
- Wired into the two layout routes + `/login`.

## Rollout note

Uses **302 (temporary)** so a mistake isn't hard-cached by browsers. Flip the `statusCode` to **301** in `enforceCanonicalConsoleHost` once the page/agent split is confirmed in production.

## Tests

`lib/legacy-host-redirect.test.ts` — 11 cases: path+query preserved, canonical/localhost/`*.up.railway.app` pass through, proxy-header precedence, comma-separated forwarded host, port stripping, case-insensitivity, and a lookalike-host (`console.cocore.dev.evil.example`) negative.

## Not in scope

- DNS/edge redirect was considered and ruled out: `console.cocore.dev` is DNS-only through Cloudflare (resolves straight to Railway), so Cloudflare redirect rules can't fire without proxying it in front of Railway's TLS.
- Generated `routeTree.gen.ts` intentionally not committed (no new route files were added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)