### PR TITLE
Add search to the chat model selector

### DIFF
--- a/packages/console/src/components/chat/ChatPage.tsx
+++ b/packages/console/src/components/chat/ChatPage.tsx
@@ -837,7 +837,16 @@ function ModelPicker({
   onMaxTokens: (n: number) => void;
 }): ReactElement {
   const [open, setOpen] = useState(false);
+  const [modelQuery, setModelQuery] = useState("");
   const selected = models.find((m) => m.modelId === modelId) ?? null;
+  const filteredModels = useMemo(() => {
+    const q = modelQuery.trim().toLowerCase();
+    if (!q) return models;
+    return models.filter((m) => {
+      if (m.modelId.toLowerCase().includes(q)) return true;
+      return m.machines.some((mac) => machineLabel(mac).toLowerCase().includes(q));
+    });
+  }, [models, modelQuery]);
   const machines: MachineOption[] = (selected?.machines ?? []).map((m) => ({
     did: m.did,
     label: machineLabel(m),
@@ -865,7 +874,10 @@ function ModelPicker({
     <div {...stylex.props(styles.modelPickerRoot)}>
       <Popover
         isOpen={open}
-        onOpenChange={setOpen}
+        onOpenChange={(next) => {
+          setOpen(next);
+          if (!next) setModelQuery("");
+        }}
         placement="top start"
         trigger={
           <AriaButton {...stylex.props(styles.chipBtn)}>
@@ -886,13 +898,27 @@ function ModelPicker({
           <span>model</span>
           <span {...stylex.props(styles.popSectHint)}>models live on the network</span>
         </div>
+        {models.length > 4 ? (
+          <SearchField
+            size="sm"
+            placeholder="search models"
+            value={modelQuery}
+            onChange={setModelQuery}
+            aria-label="search models"
+          />
+        ) : null}
         <Flex direction="column" gap="xs">
           {models.length === 0 ? (
             <Text variant="secondary" size="sm">
               no models online right now
             </Text>
           ) : null}
-          {models.map((m) => (
+          {models.length > 0 && filteredModels.length === 0 ? (
+            <Text variant="secondary" size="sm">
+              no models match “{modelQuery.trim()}”
+            </Text>
+          ) : null}
+          {filteredModels.map((m) => (
             <button
               key={m.modelId}
               type="button"


### PR DESCRIPTION
## What

Adds a search field to the model picker popover in the chat UI.

The picker can list many models once a fleet is online, making it tedious to scroll. This adds a `SearchField` at the top of the **model** section that filters the list as you type.

## Details

- Search matches on **model id** and on the **handle/label of any machine** serving a model, so you can find a model by provider too.
- The field only appears when there are more than 4 models, keeping the popover clean for small lists.
- The query **resets when the popover closes**.
- An empty-result hint (`no models match "…"`) is shown when nothing matches.

Reuses the existing `@/design-system/search-field` component already used for the sessions filter — no new dependencies.

## Verification

- `pnpm typecheck` ✅
- `oxlint` / `oxfmt --check` on the changed file ✅
- `vitest run src/components/chat` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)