### PR TITLE
Add an OpenAI-compatible HTTP engine + make the agent build on Linux

### DIFF
--- a/docs/openai-endpoint.md
+++ b/docs/openai-endpoint.md
@@ -1,0 +1,87 @@
+# Serving via an OpenAI-compatible endpoint (incl. Linux)
+
+cocore's default backend is Apple-MLX (`vllm-mlx`), which only runs on Apple
+Silicon. The **OpenAI-compatible HTTP engine** lets a provider — on Linux or
+anywhere — serve real inference by proxying to any server that speaks the
+OpenAI `/v1/chat/completions` API. cocore is a pure client here: it does **not**
+spawn or supervise the endpoint.
+
+Works with anything OpenAI-compatible: llama.cpp's `llama-server`, Ollama,
+vLLM, LM Studio, OpenRouter, the OpenAI API itself, etc. HTTP and HTTPS are both
+supported (transport is rustls).
+
+## Build (Linux)
+
+The agent builds from source with no system OpenSSL dependency:
+
+```sh
+cd provider
+cargo build --release --locked
+install -m755 target/release/cocore ~/.local/bin/cocore
+```
+
+## Configure
+
+| Env var | Meaning | Default |
+|---|---|---|
+| `COCORE_ENGINE_BACKEND` | set to `openai` to use this engine | (unset → Apple-MLX path) |
+| `COCORE_OPENAI_BASE_URL` | endpoint root, e.g. `http://127.0.0.1:8080` or `https://api.example.com` (a trailing `/v1` is fine) | — (required) |
+| `COCORE_OPENAI_API_KEY` | sent as `Authorization: Bearer …` if set | — (optional) |
+| `COCORE_INFERENCE_MODELS` | comma-separated model ids; each is advertised to cocore **and** sent verbatim as the upstream `model` | — |
+| `COCORE_MACHINE_LABEL` | display name on the console | hostname |
+
+The cocore model id you advertise is sent as the request's `model`, so use the
+name your endpoint expects.
+
+## Examples
+
+**llama.cpp `llama-server`** (started separately, e.g. `llama-server -m model.gguf --host 127.0.0.1 --port 8080`):
+
+```sh
+export COCORE_ENGINE_BACKEND=openai
+export COCORE_OPENAI_BASE_URL=http://127.0.0.1:8080
+export COCORE_INFERENCE_MODELS="my-local-model"   # llama-server ignores the name; advertise what you like
+cocore agent pair      # one-time: bind to your AT Protocol identity
+cocore agent serve
+```
+
+**Ollama** (`ollama serve`, OpenAI-compatible at `/v1`):
+
+```sh
+export COCORE_ENGINE_BACKEND=openai
+export COCORE_OPENAI_BASE_URL=http://127.0.0.1:11434
+export COCORE_INFERENCE_MODELS="llama3.1:8b"
+cocore agent serve
+```
+
+**A hosted OpenAI-compatible API:**
+
+```sh
+export COCORE_ENGINE_BACKEND=openai
+export COCORE_OPENAI_BASE_URL=https://api.example.com
+export COCORE_OPENAI_API_KEY=sk-...
+export COCORE_INFERENCE_MODELS="gpt-4o-mini"
+cocore agent serve
+```
+
+## Behaviour notes
+
+- **Readiness / health.** A model is advertised only if `GET {base}/v1/models`
+  returns 2xx at startup. A dead or misconfigured endpoint surfaces as a
+  content-safe `engineFault` on the provider record (the machine still appears,
+  serving only `stub`) rather than silently dropping jobs. If your endpoint
+  doesn't implement `/v1/models`, this engine won't advertise it.
+- **Timeouts.** The dial is bounded by a connect timeout; a generation by a
+  generous total request timeout (10 min). Long generations beyond that are cut.
+- **No RAM guard.** The catalog RAM-fit checks are skipped — inference runs on
+  the endpoint, not this machine.
+
+## Trust / privacy
+
+The requester's prompt is decrypted by the agent and **forwarded in cleartext
+(over TLS) to your configured endpoint** — so you (and implicitly the
+requester) trust that endpoint with prompt content. For a local endpoint that's
+nothing new; for a third-party one it's a deliberate choice. The model set is
+operator-configured and never requester-controlled, so a remote requester can't
+redirect the agent to a different endpoint or model. Prompt/response content is
+never written to the agent's logs.

--- a/provider/Cargo.lock
+++ b/provider/Cargo.lock
@@ -371,6 +371,7 @@ dependencies = [
  "rand 0.8.6",
  "rcgen",
  "reqwest 0.12.28",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -745,21 +746,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1410,23 +1396,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,47 +1476,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "openssl"
-version = "0.10.79"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.115"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -1700,12 +1632,6 @@ dependencies = [
  "der",
  "spki",
 ]
-
-[[package]]
-name = "pkg-config"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "poly1305"
@@ -2128,6 +2054,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2674,16 +2601,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2701,9 +2618,11 @@ checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
- "native-tls",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tungstenite",
 ]
 
@@ -2919,8 +2838,9 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "native-tls",
  "rand 0.9.4",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
@@ -3006,12 +2926,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/provider/Cargo.lock
+++ b/provider/Cargo.lock
@@ -1919,7 +1919,9 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -17,7 +17,11 @@ path = "src/lib.rs"
 clap = { version = "4", features = ["derive", "env"] }
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"
-tokio-tungstenite = { version = "0.26", features = ["native-tls"] }
+# rustls (not native-tls) so the agent builds on a stock Linux box with NO
+# system OpenSSL dev dependency — matching the `rustls-tls` choice for `reqwest`
+# below and the "stay portable" rationale on `flate2`. `*-native-roots` keeps
+# cert verification anchored in the OS trust store, same as native-tls did.
+tokio-tungstenite = { version = "0.26", features = ["rustls-tls-native-roots"] }
 futures-util = "0.3"
 
 serde = { version = "1", features = ["derive"] }
@@ -49,6 +53,12 @@ opentelemetry-otlp = { version = "0.32", default-features = false, features = [
 tracing-opentelemetry = "0.33"
 
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+
+# rustls is already in the tree (via tokio-tungstenite + reqwest). We depend on
+# it directly only to install a process-default CryptoProvider at startup: with
+# both aws-lc-rs and ring compiled in, rustls 0.23 can't auto-select one and
+# panics at the first TLS handshake. See `install_crypto_provider` in main.rs.
+rustls = "0.23"
 
 # `cocore agent update` extracts the release tarball in-process so we
 # don't need a system tar / curl in the path. flate2's `rust_backend`

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -52,7 +52,12 @@ opentelemetry-otlp = { version = "0.32", default-features = false, features = [
 ] }
 tracing-opentelemetry = "0.33"
 
-reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+# `blocking` powers the OpenAI-compatible HTTP engine (engines/openai.rs): the
+# Engine trait is synchronous (called on a spawn_blocking thread), and the
+# blocking Response implements `Read` for SSE streaming. (The blocking client
+# is already in the tree via opentelemetry-otlp's reqwest-blocking-client; this
+# enables it on our direct dependency so we can use it explicitly.)
+reqwest = { version = "0.12", features = ["json", "rustls-tls", "blocking"], default-features = false }
 
 # rustls is already in the tree (via tokio-tungstenite + reqwest). We depend on
 # it directly only to install a process-default CryptoProvider at startup: with

--- a/provider/src/engines/mod.rs
+++ b/provider/src/engines/mod.rs
@@ -36,6 +36,7 @@ use std::sync::Arc;
 
 #[cfg(feature = "native_mlx")]
 pub mod native_mlx;
+pub mod openai;
 pub mod stub;
 pub mod subprocess;
 

--- a/provider/src/engines/openai.rs
+++ b/provider/src/engines/openai.rs
@@ -1,0 +1,459 @@
+//! OpenAI-compatible HTTP(S) inference engine.
+//!
+//! Proxies inference to any server that speaks the OpenAI
+//! `/v1/chat/completions` API — llama.cpp's `llama-server`, Ollama, vLLM,
+//! LM Studio, OpenAI itself, OpenRouter, … This is how a cocore provider on
+//! Linux (or anywhere) serves real inference without a local model runtime:
+//! point it at an endpoint you run or trust.
+//!
+//! Unlike the macOS vllm-mlx backend, cocore neither spawns nor supervises the
+//! endpoint — it's a pure client. Transport is `reqwest` (rustls), so HTTPS
+//! works out of the box. We use the **blocking** client because the `Engine`
+//! trait is synchronous and the call already runs on a `spawn_blocking` thread
+//! (see `advisor.rs`); a generation bounds itself with a generous total
+//! [`REQUEST_TIMEOUT`] and the dial with [`CONNECT_TIMEOUT`]. `restart()` is the
+//! trait's no-op default: cocore can't restart a process it doesn't own — if
+//! the endpoint goes away, `ready()` reports it and the serve loop's health
+//! watchdog re-registers without the model.
+//!
+//! ## Trust / privacy
+//!
+//! The requester's prompt is decrypted by the agent and **forwarded in
+//! cleartext (over TLS) to the configured endpoint** — so the operator (and
+//! implicitly the requester) trusts that endpoint with prompt content. For a
+//! local endpoint that's nothing new; for a third-party one it's a real choice.
+//! The model id is operator-configured (`COCORE_INFERENCE_MODELS`), never
+//! requester-controlled, so the advisor's `for_model` gate still holds and a
+//! remote requester can't redirect this anywhere. Prompts/responses are never
+//! logged (error paths elide bodies, which can echo the prompt).
+
+// Serve-path module: a panic here can poison shared state or take the agent
+// down. Deny the panic-on-the-happy-path footguns in production builds; the
+// `#[cfg(test)]` module is exempt.
+#![cfg_attr(
+    not(test),
+    deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)
+)]
+
+use anyhow::{bail, Context, Result};
+use std::io::Read;
+use std::time::Duration;
+use zeroize::Zeroizing;
+
+use crate::engines::{Engine, GenerateRequest, GenerateResponse};
+
+/// Connect timeout for the endpoint dial.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+/// Total per-request timeout for a generation: generous so a long completion
+/// isn't cut short, but bounded so a wedged endpoint can't tie up a worker
+/// forever. reqwest's *blocking* client builder exposes no idle/read timeout,
+/// so we bound the whole request instead of per-read idle time.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(600);
+/// Short total timeout for the lightweight `/v1/models` readiness probe.
+const READY_TIMEOUT: Duration = Duration::from_secs(5);
+
+pub struct OpenAiEngine {
+    /// cocore model id; also the `model` we send upstream.
+    model_id: String,
+    /// `{base}/v1/chat/completions`.
+    chat_url: String,
+    /// `{base}/v1/models` — the readiness probe.
+    models_url: String,
+    api_key: Option<String>,
+    client: reqwest::blocking::Client,
+}
+
+impl OpenAiEngine {
+    /// Build an engine for `model_id` against `base_url` (e.g.
+    /// `http://127.0.0.1:8080` or `https://api.example.com`). No network I/O —
+    /// reachability is checked via [`ready`](Engine::ready).
+    pub fn new(
+        model_id: impl Into<String>,
+        base_url: &str,
+        api_key: Option<String>,
+    ) -> Result<Self> {
+        let base = normalize_base(base_url);
+        // connect_timeout bounds the dial; each request sets its own total
+        // timeout (REQUEST_TIMEOUT for generation, READY_TIMEOUT for the probe).
+        let client = reqwest::blocking::Client::builder()
+            .connect_timeout(CONNECT_TIMEOUT)
+            .build()
+            .context("building HTTP client for the OpenAI endpoint")?;
+        Ok(Self {
+            model_id: model_id.into(),
+            chat_url: format!("{base}/v1/chat/completions"),
+            models_url: format!("{base}/v1/models"),
+            api_key,
+            client,
+        })
+    }
+
+    fn with_auth(
+        &self,
+        rb: reqwest::blocking::RequestBuilder,
+    ) -> reqwest::blocking::RequestBuilder {
+        match &self.api_key {
+            Some(k) => rb.bearer_auth(k),
+            None => rb,
+        }
+    }
+
+    /// OpenAI `chat.completions` body. `stream` toggles SSE; when streaming we
+    /// also ask for a terminal `usage` chunk so token counts are exact.
+    fn body(&self, request: &GenerateRequest, stream: bool) -> serde_json::Value {
+        let messages: Vec<serde_json::Value> = request
+            .messages
+            .iter()
+            .map(|m| serde_json::json!({ "role": m.role, "content": m.content }))
+            .collect();
+        let mut b = serde_json::json!({
+            "model": self.model_id,
+            "messages": messages,
+            "max_tokens": request.max_tokens,
+            "stream": stream,
+        });
+        if stream {
+            b["stream_options"] = serde_json::json!({ "include_usage": true });
+        }
+        if let Some(t) = request.temperature {
+            b["temperature"] = serde_json::json!(t);
+        }
+        if let Some(p) = request.top_p {
+            b["top_p"] = serde_json::json!(p);
+        }
+        b
+    }
+}
+
+/// Normalize a base URL: drop a trailing `/` and a trailing `/v1` (so both
+/// `https://h` and `https://h/v1` end up as `https://h`, and we always append
+/// `/v1/chat/completions` ourselves).
+fn normalize_base(base: &str) -> String {
+    let b = base.trim().trim_end_matches('/');
+    b.strip_suffix("/v1").unwrap_or(b).to_string()
+}
+
+/// Drain complete SSE `data:` lines from `buf` starting at `cursor`, forwarding
+/// `choices[0].delta.content` to `on_data` and capturing `usage` token counts.
+/// reqwest hands us the already-decoded (dechunked) body, so this only parses
+/// SSE framing — no HTTP framing. Stops at a partial trailing line so the
+/// caller can read more bytes; compacts the buffer once the cursor is large.
+fn process_sse(
+    buf: &mut Vec<u8>,
+    cursor: &mut usize,
+    on_data: &mut dyn FnMut(&str) -> Result<()>,
+    tokens: &mut (u64, u64),
+) -> Result<()> {
+    while *cursor < buf.len() {
+        let rest = &buf[*cursor..];
+        let Some(nl) = rest.iter().position(|&b| b == b'\n') else {
+            break;
+        };
+        let mut line = &rest[..nl];
+        *cursor += nl + 1;
+        if line.ends_with(b"\r") {
+            line = &line[..line.len() - 1];
+        }
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(s) = std::str::from_utf8(line) else {
+            continue;
+        };
+        let Some(data) = s.strip_prefix("data: ") else {
+            continue;
+        };
+        if data == "[DONE]" {
+            continue;
+        }
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(data) else {
+            continue;
+        };
+        if let Some(content) = v
+            .pointer("/choices/0/delta/content")
+            .and_then(|c| c.as_str())
+        {
+            if !content.is_empty() {
+                on_data(content)?;
+            }
+        }
+        if let Some(u) = v.get("usage") {
+            if let Some(p) = u.get("prompt_tokens").and_then(|v| v.as_u64()) {
+                tokens.0 = p;
+            }
+            if let Some(c) = u.get("completion_tokens").and_then(|v| v.as_u64()) {
+                tokens.1 = c;
+            }
+        }
+    }
+    if *cursor > 8192 {
+        buf.drain(..*cursor);
+        *cursor = 0;
+    }
+    Ok(())
+}
+
+/// Read an SSE stream from `r` (a reqwest blocking `Response`, already
+/// dechunked), forwarding deltas via `on_delta`, returning `(prompt_tokens,
+/// completion_tokens)` from the terminal `usage` (0 if the endpoint omits it —
+/// the caller falls back to an estimate).
+fn read_sse_stream(
+    r: &mut impl Read,
+    on_delta: &mut dyn FnMut(&str) -> Result<()>,
+) -> Result<(u64, u64)> {
+    let mut buf: Vec<u8> = Vec::new();
+    let mut read_buf = [0u8; 4096];
+    let mut cursor = 0usize;
+    let mut tokens = (0u64, 0u64);
+    loop {
+        let n = match r.read(&mut read_buf) {
+            Ok(0) => break,
+            Ok(n) => n,
+            // The request's total timeout (or a transport stall) surfaces here
+            // as TimedOut / WouldBlock depending on platform.
+            Err(e)
+                if e.kind() == std::io::ErrorKind::TimedOut
+                    || e.kind() == std::io::ErrorKind::WouldBlock =>
+            {
+                bail!(
+                    "endpoint stream timed out or stalled (exceeded {}s)",
+                    REQUEST_TIMEOUT.as_secs()
+                );
+            }
+            Err(e) => return Err(e.into()),
+        };
+        buf.extend_from_slice(&read_buf[..n]);
+        process_sse(&mut buf, &mut cursor, on_delta, &mut tokens)?;
+    }
+    Ok(tokens)
+}
+
+impl Engine for OpenAiEngine {
+    fn name(&self) -> &'static str {
+        "openai-http"
+    }
+
+    /// Reachable when `GET /v1/models` returns 2xx. This is the standard
+    /// OpenAI-compatible discovery endpoint (llama-server, vLLM, Ollama, OpenAI
+    /// all serve it). A non-2xx (incl. 401 with the configured key) means the
+    /// endpoint is misconfigured/unreachable, so the model isn't advertised.
+    fn ready(&self) -> bool {
+        match self
+            .with_auth(self.client.get(&self.models_url))
+            .timeout(READY_TIMEOUT)
+            .send()
+        {
+            Ok(resp) => resp.status().is_success(),
+            Err(_) => false,
+        }
+    }
+
+    fn generate_once(&self, request: &GenerateRequest) -> Result<GenerateResponse> {
+        // Serialized body wrapped in Zeroizing so the local copy is wiped on
+        // drop. (The prompt is forwarded to the endpoint by design — see the
+        // module's trust note.)
+        let bytes = Zeroizing::new(serde_json::to_vec(&self.body(request, false))?);
+        let resp = self
+            .with_auth(self.client.post(&self.chat_url))
+            .timeout(REQUEST_TIMEOUT)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(bytes.to_vec())
+            .send()
+            .with_context(|| format!("POST {}", self.chat_url))?;
+        let status = resp.status();
+        if !status.is_success() {
+            // Do NOT log the body: endpoints often echo the request (prompt)
+            // back in error responses.
+            bail!("endpoint returned HTTP {status} (body elided to avoid content logging)");
+        }
+        let v: serde_json::Value = resp.json().context("parsing endpoint JSON response")?;
+        let text = v
+            .pointer("/choices/0/message/content")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let tokens_in = v
+            .pointer("/usage/prompt_tokens")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        let tokens_out = v
+            .pointer("/usage/completion_tokens")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        Ok(GenerateResponse {
+            text,
+            tokens_in,
+            tokens_out,
+        })
+    }
+
+    fn generate_stream(
+        &self,
+        request: &GenerateRequest,
+        on_delta: &mut dyn FnMut(&str) -> Result<()>,
+    ) -> Result<GenerateResponse> {
+        let bytes = Zeroizing::new(serde_json::to_vec(&self.body(request, true))?);
+        let mut resp = self
+            .with_auth(self.client.post(&self.chat_url))
+            .timeout(REQUEST_TIMEOUT)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(bytes.to_vec())
+            .send()
+            .with_context(|| format!("POST {}", self.chat_url))?;
+        let status = resp.status();
+        if !status.is_success() {
+            bail!(
+                "endpoint returned HTTP {status} (streaming body elided to avoid content logging)"
+            );
+        }
+        let (tokens_in, tokens_out) = read_sse_stream(&mut resp, on_delta)?;
+        Ok(GenerateResponse {
+            text: String::new(),
+            tokens_in,
+            tokens_out,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engines::Message;
+    use std::io::Write;
+    use std::net::TcpListener;
+
+    #[test]
+    fn normalize_base_strips_trailing_slash_and_v1() {
+        assert_eq!(normalize_base("http://h:8080"), "http://h:8080");
+        assert_eq!(normalize_base("http://h:8080/"), "http://h:8080");
+        assert_eq!(normalize_base("https://h/v1"), "https://h");
+        assert_eq!(normalize_base("https://h/v1/"), "https://h");
+        assert_eq!(normalize_base("  https://h  "), "https://h");
+    }
+
+    #[test]
+    fn process_sse_forwards_deltas_and_reads_usage() {
+        let mut buf = b"data: {\"choices\":[{\"delta\":{\"content\":\"Hel\"}}]}\n\
+                        data: {\"choices\":[{\"delta\":{\"content\":\"lo\"}}]}\n\
+                        data: {\"usage\":{\"prompt_tokens\":9,\"completion_tokens\":2}}\n\
+                        data: [DONE]\n"
+            .to_vec();
+        let mut cursor = 0usize;
+        let mut tokens = (0u64, 0u64);
+        let mut got = String::new();
+        process_sse(
+            &mut buf,
+            &mut cursor,
+            &mut |d| {
+                got.push_str(d);
+                Ok(())
+            },
+            &mut tokens,
+        )
+        .unwrap();
+        assert_eq!(got, "Hello");
+        assert_eq!(tokens, (9, 2));
+    }
+
+    fn req() -> GenerateRequest {
+        GenerateRequest {
+            model: "test-model".into(),
+            messages: vec![Message {
+                role: "user".into(),
+                content: "hi".into(),
+            }],
+            max_tokens: 16,
+            temperature: None,
+            top_p: None,
+        }
+    }
+
+    /// Minimal fake OpenAI-compatible server: `GET /v1/models` → 200; a
+    /// streaming chat POST → SSE; a non-streaming chat POST → JSON. Drains the
+    /// full request before responding (a half-read TCP socket would RST). Loop
+    /// is bounded so it self-terminates.
+    fn spawn_fake_endpoint() -> (u16, std::thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let handle = std::thread::spawn(move || {
+            for _ in 0..16 {
+                let Ok((mut conn, _)) = listener.accept() else {
+                    return;
+                };
+                let _ = conn.set_read_timeout(Some(Duration::from_millis(200)));
+                let mut raw = Vec::new();
+                let mut tmp = [0u8; 4096];
+                loop {
+                    match conn.read(&mut tmp) {
+                        Ok(0) => break,
+                        Ok(n) => {
+                            raw.extend_from_slice(&tmp[..n]);
+                            // Heuristic: once we've seen the headers and any
+                            // body, a short read-timeout ends the drain.
+                        }
+                        Err(_) => break,
+                    }
+                }
+                let reqs = String::from_utf8_lossy(&raw);
+                let resp = if reqs.starts_with("GET /v1/models") {
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 11\r\nConnection: close\r\n\r\n{\"data\":[]}".to_string()
+                } else if reqs.contains("\"stream\":true") {
+                    let body = "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\n\
+                                data: {\"choices\":[{\"delta\":{\"content\":\" there\"}}]}\n\n\
+                                data: {\"usage\":{\"prompt_tokens\":7,\"completion_tokens\":2}}\n\n\
+                                data: [DONE]\n\n";
+                    format!("HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nConnection: close\r\n\r\n{body}")
+                } else {
+                    let json = "{\"choices\":[{\"message\":{\"content\":\"Hello there\"}}],\"usage\":{\"prompt_tokens\":7,\"completion_tokens\":2}}";
+                    format!("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{json}", json.len())
+                };
+                let _ = conn.write_all(resp.as_bytes());
+            }
+        });
+        (port, handle)
+    }
+
+    #[test]
+    fn ready_true_when_models_endpoint_answers() {
+        let (port, server) = spawn_fake_endpoint();
+        let engine =
+            OpenAiEngine::new("test-model", &format!("http://127.0.0.1:{port}"), None).unwrap();
+        assert!(engine.ready());
+        drop(server);
+    }
+
+    #[test]
+    fn ready_false_when_nothing_listening() {
+        // Port 1 is privileged + unused; connect fails fast.
+        let engine = OpenAiEngine::new("m", "http://127.0.0.1:1", None).unwrap();
+        assert!(!engine.ready());
+    }
+
+    #[test]
+    fn generate_once_parses_json() {
+        let (port, server) = spawn_fake_endpoint();
+        let engine =
+            OpenAiEngine::new("test-model", &format!("http://127.0.0.1:{port}"), None).unwrap();
+        let resp = engine.generate_once(&req()).unwrap();
+        drop(server);
+        assert_eq!(resp.text, "Hello there");
+        assert_eq!((resp.tokens_in, resp.tokens_out), (7, 2));
+    }
+
+    #[test]
+    fn generate_stream_relays_sse_deltas() {
+        let (port, server) = spawn_fake_endpoint();
+        let engine =
+            OpenAiEngine::new("test-model", &format!("http://127.0.0.1:{port}"), None).unwrap();
+        let mut got = String::new();
+        let resp = engine
+            .generate_stream(&req(), &mut |d| {
+                got.push_str(d);
+                Ok(())
+            })
+            .unwrap();
+        drop(server);
+        assert_eq!(got, "Hello there");
+        assert_eq!((resp.tokens_in, resp.tokens_out), (7, 2));
+    }
+}

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -1835,6 +1835,98 @@ fn inference_models_action(confidential: bool, desired: &[String]) -> InferenceM
 /// for `start()` to arbitrate. Set `COCORE_IGNORE_RAM_FLOOR=1` to bypass
 /// the guard (e.g. a machine the operator knows can run a model the
 /// conservative floor rejects).
+/// True when the operator selected the OpenAI-compatible HTTP backend via
+/// `COCORE_ENGINE_BACKEND=openai` (case-insensitive, surrounding whitespace
+/// ignored). Default (unset / anything else) keeps the existing Apple-MLX/vllm
+/// path, so this is purely opt-in and changes nothing for existing installs.
+fn backend_is_openai() -> bool {
+    std::env::var("COCORE_ENGINE_BACKEND")
+        .map(|v| v.trim().eq_ignore_ascii_case("openai"))
+        .unwrap_or(false)
+}
+
+/// Build the engine registry for the OpenAI-compatible HTTP backend: one
+/// `OpenAiEngine` per configured model id, all pointed at
+/// `COCORE_OPENAI_BASE_URL` (Bearer `COCORE_OPENAI_API_KEY` if set). The
+/// cocore model id is sent verbatim as the upstream `model`. We gate
+/// registration on a `/v1/models` reachability probe so a dead/misconfigured
+/// endpoint surfaces as an `engineFault` (and isn't advertised) instead of a
+/// green machine that drops every job. No RAM-floor guard — inference is
+/// remote.
+fn build_openai_engines(
+    mut registry: cocore_provider::engines::EngineRegistry,
+    configured: Vec<String>,
+) -> (
+    cocore_provider::engines::EngineRegistry,
+    Option<EngineFault>,
+) {
+    use cocore_provider::engines::openai::OpenAiEngine;
+    use cocore_provider::engines::Engine; // bring `ready()` into scope
+
+    let base_url = std::env::var("COCORE_OPENAI_BASE_URL")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+    let Some(base_url) = base_url else {
+        tracing::warn!(
+            "COCORE_ENGINE_BACKEND=openai but COCORE_OPENAI_BASE_URL is unset; serving stub only"
+        );
+        let fault = EngineFault {
+            code: "openai-base-url-missing".to_string(),
+            message: "The OpenAI-compatible backend is selected \
+                      (COCORE_ENGINE_BACKEND=openai) but COCORE_OPENAI_BASE_URL is not set, so no \
+                      endpoint could be reached. The machine is online but only serving the no-op \
+                      `stub` engine. Fix: set COCORE_OPENAI_BASE_URL to your endpoint (e.g. \
+                      http://127.0.0.1:8080) and start serving again."
+                .to_string(),
+            models: vec![],
+            at: chrono::Utc::now(),
+        };
+        return (registry, Some(fault));
+    };
+    let api_key = std::env::var("COCORE_OPENAI_API_KEY")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+
+    let mut failed: Vec<String> = vec![];
+    for model in &configured {
+        match OpenAiEngine::new(model.as_str(), &base_url, api_key.clone()) {
+            // Gate on reachability: `ready()` probes `GET /v1/models`.
+            Ok(engine) if engine.ready() => {
+                tracing::info!(model = %model, "openai endpoint engine ready");
+                registry.register(model.clone(), std::sync::Arc::new(engine));
+            }
+            Ok(_) => {
+                tracing::warn!(model = %model, "inference engine load failed");
+                failed.push(model.clone());
+            }
+            Err(e) => {
+                tracing::warn!(model = %model, error = %format!("{e:#}"), "inference engine load failed");
+                failed.push(model.clone());
+            }
+        }
+    }
+
+    if failed.is_empty() {
+        return (registry, None);
+    }
+    let fault = EngineFault {
+        code: "openai-endpoint-unreachable".to_string(),
+        message: format!(
+            "The OpenAI-compatible endpoint at {base_url} did not answer a /v1/models probe for \
+             model(s) [{}], so they were not loaded. The machine is online but only serving the \
+             no-op `stub` engine. Fix: confirm the endpoint is running and reachable, that \
+             COCORE_OPENAI_BASE_URL is correct, and that COCORE_OPENAI_API_KEY (if the endpoint \
+             requires auth) is set, then start serving again.",
+            failed.join(", "),
+        ),
+        models: failed,
+        at: chrono::Utc::now(),
+    };
+    (registry, Some(fault))
+}
+
 fn build_engines(
     ram_gb: u32,
 ) -> (
@@ -1931,6 +2023,21 @@ fn build_engines(
         // (inference runs in-process), so a native failure is the fault to
         // surface here. On best-effort machines `native_fault` is `None`.
         return (registry, native_fault);
+    }
+
+    // Backend selection. The OpenAI-compatible HTTP engine (the Linux
+    // real-inference path) attaches to an external endpoint, so it skips the
+    // venv + RAM-floor machinery the Apple-MLX path below needs — a remote
+    // endpoint's RAM isn't this machine's concern. Opt in with
+    // COCORE_ENGINE_BACKEND=openai; the default keeps the vllm-mlx path below
+    // unchanged.
+    if backend_is_openai() {
+        let configured: Vec<String> = raw
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        return build_openai_engines(registry, configured);
     }
 
     // Resolve the venv interpreter once. The install script writes it

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -190,6 +190,11 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
     init_tracing(&cli.log);
 
+    // Install a process-default rustls CryptoProvider before any TLS handshake
+    // (the advisor WebSocket, the OpenAI engine, PDS/console HTTPS). Required
+    // because this tree compiles in more than one provider (see the fn).
+    install_crypto_provider();
+
     match cli.cmd {
         Cmd::Agent(AgentCmd::Pair { console }) => cmd_pair(&console).await,
         Cmd::Agent(AgentCmd::Serve { advisor }) => cmd_serve_entry(advisor).await,
@@ -431,6 +436,34 @@ fn init_tracing(level: &str) {
     // Stderr (as before) PLUS a rolling, content-safe file log under
     // ~/.cocore/logs so a crash leaves a durable trail.
     cocore_provider::diagnostics::init_logging(level);
+}
+
+/// Install a process-wide default rustls `CryptoProvider`.
+///
+/// rustls 0.23 resolves its crypto backend from a process-level default, and
+/// auto-selects one only when exactly one of the `aws-lc-rs` / `ring` features
+/// is compiled in. This dependency tree pulls in BOTH (reqwest's `rustls-tls`
+/// brings aws-lc-rs; the tokio-tungstenite rustls stack brings ring), so the
+/// auto-select fails and rustls panics at the first TLS handshake — which is
+/// the advisor WebSocket connect in `cmd_serve`. We pick `aws-lc-rs`
+/// explicitly (the rustls 0.23 default, and what reqwest uses) so every TLS
+/// path — the WebSocket, the OpenAI engine, and PDS/console HTTPS — shares one
+/// provider. Idempotent: `install_default` returns `Err` if a default is
+/// already set, which we ignore (first winner stands).
+fn install_crypto_provider() {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+}
+
+#[cfg(test)]
+mod crypto_provider_tests {
+    #[test]
+    fn install_sets_a_process_default() {
+        // After installing, a process-default provider must exist — without it,
+        // the rustls WebSocket connect panics at runtime. Idempotent, so this
+        // is safe regardless of test ordering.
+        super::install_crypto_provider();
+        assert!(rustls::crypto::CryptoProvider::get_default().is_some());
+    }
 }
 
 async fn cmd_pair(console: &str) -> Result<()> {

--- a/provider/src/system_profile.rs
+++ b/provider/src/system_profile.rs
@@ -1,28 +1,22 @@
 //! Real machine telemetry for the `dev.cocore.compute.provider` record.
 //!
-//! Pre-v0.3.1 cmd_serve published hardcoded stubs (`chip = "Apple M-stub"`,
-//! `ramGB = 64`). Matchmakers need real values to route inference work
-//! to capable hardware, so this module collects what we can without
-//! root from a Mac:
+//! Matchmakers route inference work by hardware, so `serve` publishes real
+//! values (chip + RAM are the load-bearing ones). Collection is
+//! platform-specific:
 //!
-//!   * `chip` — from `sysctl machdep.cpu.brand_string`
-//!   * `ramGB` — from `sysctl hw.memsize`
-//!   * `cpuCores` / `pCores` / `eCores` — from `sysctl hw.ncpu` and
-//!     the perf-level splits
-//!   * `gpuCores` — parsed from `system_profiler -json SPDisplaysDataType`
-//!   * `memoryBandwidthGBs` — looked up from a chip-name table
-//!     (Apple doesn't expose this via sysctl)
-//!   * `modelIdentifier` — from `sysctl hw.model`
-//!   * `os` — from `sw_vers -productVersion` (prefixed with `macOS `)
-//!   * `machineLabel` — `COCORE_MACHINE_LABEL` (owner-chosen, set in the
-//!     tray during setup) if present, else `hostname`, with a fallback
+//!   * **macOS / Apple Silicon** — `sysctl`, `system_profiler`, `sw_vers`.
+//!   * **Linux** (the OpenAI-endpoint provider path) — `/proc/meminfo`,
+//!     `/proc/cpuinfo`, `/etc/os-release`, `available_parallelism`.
 //!
-//! Every individual probe is independently fallible. A failure on any
-//! one returns None for that field rather than failing the whole
-//! collect — partial data is better than no data, and the fields
-//! that matter most for matchmaking (chip + ram) are also the most
-//! reliable to read.
+//! Before this module grew a Linux arm, `collect()` was macOS-only: every
+//! probe failed on Linux, so `ram_gb` came back **0** and `chip` "unknown",
+//! mis-advertising a perfectly capable Linux box to the advisor.
+//!
+//! Every individual probe is independently fallible; a failure on any one
+//! leaves that field at its `None` / fallback value rather than failing the
+//! whole collect — partial data beats no data.
 
+#[cfg(any(target_os = "macos", not(target_os = "linux")))]
 use std::process::Command;
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -40,8 +34,23 @@ pub struct SystemProfile {
     pub os: Option<String>,
 }
 
-/// Probe the host for a `SystemProfile`. Best-effort: any individual
-/// probe failure leaves that field at its `None` / fallback value.
+/// Owner-chosen display name (`COCORE_MACHINE_LABEL`, set during setup) wins
+/// over the system hostname, so a provider isn't forced to expose their
+/// `.local` host name. Falls back to the hostname, then a generic label.
+fn machine_label(fallback: &str) -> String {
+    std::env::var("COCORE_MACHINE_LABEL")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .or_else(hostname)
+        .unwrap_or_else(|| fallback.to_string())
+}
+
+// ─────────────────────────── macOS ───────────────────────────
+
+/// Probe the host for a `SystemProfile`. Best-effort: any individual probe
+/// failure leaves that field at its `None` / fallback value.
+#[cfg(target_os = "macos")]
 pub fn collect() -> SystemProfile {
     let chip = sysctl("machdep.cpu.brand_string").unwrap_or_else(|| "unknown".to_string());
     let ram_gb = sysctl("hw.memsize")
@@ -55,18 +64,9 @@ pub fn collect() -> SystemProfile {
     let memory_bandwidth_gbs = bandwidth_for_chip(&chip);
     let model_identifier = sysctl("hw.model");
     let os = sw_vers_product_version().map(|v| format!("macOS {v}"));
-    // Owner-chosen display name (set in the tray during setup) wins over the
-    // system hostname, so a provider isn't forced to expose their `.local`
-    // host name. Falls back to the hostname, then a generic label.
-    let machine_label = std::env::var("COCORE_MACHINE_LABEL")
-        .ok()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .or_else(hostname)
-        .unwrap_or_else(|| "macOS host".to_string());
 
     SystemProfile {
-        machine_label,
+        machine_label: machine_label("macOS host"),
         chip,
         ram_gb,
         cpu_cores,
@@ -79,6 +79,7 @@ pub fn collect() -> SystemProfile {
     }
 }
 
+#[cfg(target_os = "macos")]
 fn sysctl(key: &str) -> Option<String> {
     let out = Command::new("sysctl").arg("-n").arg(key).output().ok()?;
     if !out.status.success() {
@@ -92,14 +93,16 @@ fn sysctl(key: &str) -> Option<String> {
     }
 }
 
+#[cfg(target_os = "macos")]
 fn sysctl_u32(key: &str) -> Option<u32> {
     sysctl(key).and_then(|s| s.parse::<u32>().ok())
 }
 
+#[cfg(target_os = "macos")]
 fn parse_gpu_cores() -> Option<u32> {
-    // `system_profiler -json SPDisplaysDataType` returns an array of
-    // GPU entries. Apple Silicon integrated GPUs carry an
-    // `sppci_cores` field; we take the first one we find.
+    // `system_profiler -json SPDisplaysDataType` returns an array of GPU
+    // entries. Apple Silicon integrated GPUs carry an `sppci_cores` field; we
+    // take the first one we find.
     let out = Command::new("system_profiler")
         .arg("-json")
         .arg("SPDisplaysDataType")
@@ -120,6 +123,7 @@ fn parse_gpu_cores() -> Option<u32> {
     None
 }
 
+#[cfg(target_os = "macos")]
 fn sw_vers_product_version() -> Option<String> {
     let out = Command::new("sw_vers")
         .arg("-productVersion")
@@ -131,18 +135,10 @@ fn sw_vers_product_version() -> Option<String> {
     Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
 }
 
-fn hostname() -> Option<String> {
-    let out = Command::new("hostname").output().ok()?;
-    if !out.status.success() {
-        return None;
-    }
-    Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
-}
-
-/// Memory-bandwidth lookup keyed by chip-family substring. Apple
-/// publishes these specs but doesn't expose them via sysctl.
-/// Conservative values from public spec sheets — order matters
-/// (Pro/Max/Ultra checked before bare M\d).
+/// Memory-bandwidth lookup keyed by chip-family substring. Apple publishes
+/// these specs but doesn't expose them via sysctl. Conservative values from
+/// public spec sheets — order matters (Pro/Max/Ultra checked before bare M\d).
+#[cfg(target_os = "macos")]
 fn bandwidth_for_chip(chip: &str) -> Option<u32> {
     let lower = chip.to_lowercase();
     // M4 family
@@ -197,44 +193,212 @@ fn bandwidth_for_chip(chip: &str) -> Option<u32> {
     None
 }
 
+// ─────────────────────────── Linux ───────────────────────────
+
+/// Probe a Linux host (the OpenAI-endpoint provider path). Apple-only fields
+/// (`gpu_cores`, `p_cores`, `e_cores`, `model_identifier`) stay `None` — the
+/// provider lexicon treats them as optional, and honest absence beats
+/// fabricating Apple-shaped numbers.
+#[cfg(target_os = "linux")]
+pub fn collect() -> SystemProfile {
+    let chip = read_to_string("/proc/cpuinfo")
+        .and_then(|c| parse_cpuinfo_model(&c))
+        .unwrap_or_else(|| "unknown".to_string());
+    let ram_gb = read_to_string("/proc/meminfo")
+        .and_then(|c| parse_meminfo_total_kb(&c))
+        .map(|kb| (kb / (1024 * 1024)) as u32)
+        .unwrap_or(0);
+    let cpu_cores = std::thread::available_parallelism()
+        .ok()
+        .map(|n| n.get() as u32);
+    let os = read_to_string("/etc/os-release").and_then(|c| parse_os_release_pretty(&c));
+
+    SystemProfile {
+        machine_label: machine_label("linux host"),
+        chip,
+        ram_gb,
+        cpu_cores,
+        p_cores: None,
+        e_cores: None,
+        gpu_cores: None,
+        memory_bandwidth_gbs: None,
+        model_identifier: None,
+        os,
+    }
+}
+
+/// `std::fs::read_to_string` that swallows errors into `None`, so a missing
+/// or unreadable `/proc` entry leaves its field at the fallback rather than
+/// failing the whole collect.
+#[cfg(target_os = "linux")]
+fn read_to_string(path: &str) -> Option<String> {
+    std::fs::read_to_string(path).ok()
+}
+
+/// Total RAM in kB from `/proc/meminfo`'s `MemTotal:` line.
+#[cfg(target_os = "linux")]
+fn parse_meminfo_total_kb(contents: &str) -> Option<u64> {
+    for line in contents.lines() {
+        if let Some(rest) = line.strip_prefix("MemTotal:") {
+            // Format: `MemTotal:       131981312 kB`
+            return rest.split_whitespace().next()?.parse::<u64>().ok();
+        }
+    }
+    None
+}
+
+/// CPU brand string from `/proc/cpuinfo`. x86 reports it as `model name`;
+/// some ARM kernels use `Model` / `Hardware` instead, so we fall back through
+/// those. Returns the first non-empty match.
+#[cfg(target_os = "linux")]
+fn parse_cpuinfo_model(contents: &str) -> Option<String> {
+    for key in ["model name", "Model", "Hardware"] {
+        for line in contents.lines() {
+            if let Some((k, v)) = line.split_once(':') {
+                if k.trim() == key {
+                    let v = v.trim();
+                    if !v.is_empty() {
+                        return Some(v.to_string());
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+/// `PRETTY_NAME` from `/etc/os-release` (e.g. `Ubuntu 24.04.1 LTS`), with the
+/// surrounding quotes stripped.
+#[cfg(target_os = "linux")]
+fn parse_os_release_pretty(contents: &str) -> Option<String> {
+    for line in contents.lines() {
+        if let Some(rest) = line.strip_prefix("PRETTY_NAME=") {
+            return Some(rest.trim().trim_matches('"').to_string());
+        }
+    }
+    None
+}
+
+// ─────────────────────── other platforms ───────────────────────
+
+/// Fallback for platforms that are neither macOS nor Linux. The agent only
+/// ships on those two, but keeping `collect()` defined everywhere lets the
+/// crate build (and unit-test the pure parsers) on any dev host.
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+pub fn collect() -> SystemProfile {
+    SystemProfile {
+        machine_label: machine_label("host"),
+        chip: "unknown".to_string(),
+        ram_gb: 0,
+        cpu_cores: std::thread::available_parallelism()
+            .ok()
+            .map(|n| n.get() as u32),
+        p_cores: None,
+        e_cores: None,
+        gpu_cores: None,
+        memory_bandwidth_gbs: None,
+        model_identifier: None,
+        os: None,
+    }
+}
+
+// ─────────────────────────── shared ───────────────────────────
+
+#[cfg(any(target_os = "macos", not(target_os = "linux")))]
+fn hostname() -> Option<String> {
+    let out = Command::new("hostname").output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+/// Linux reads the hostname from the kernel rather than shelling out — no
+/// dependency on a `hostname` binary being installed.
+#[cfg(target_os = "linux")]
+fn hostname() -> Option<String> {
+    std::fs::read_to_string("/proc/sys/kernel/hostname")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn bandwidth_table_picks_specific_before_base() {
-        // Pro/Max/Ultra need to be checked before bare M\d to avoid
-        // misclassifying e.g. "Apple M3 Pro" as "M3 base".
-        assert_eq!(bandwidth_for_chip("Apple M3 Max"), Some(400));
-        assert_eq!(bandwidth_for_chip("Apple M3 Pro"), Some(150));
-        assert_eq!(bandwidth_for_chip("Apple M3"), Some(100));
-        assert_eq!(bandwidth_for_chip("Apple M1 Max"), Some(400));
-        assert_eq!(bandwidth_for_chip("Apple M1 Pro"), Some(200));
-        assert_eq!(bandwidth_for_chip("Apple M1"), Some(68));
-        assert_eq!(bandwidth_for_chip("Apple M4 Pro"), Some(273));
-        assert_eq!(bandwidth_for_chip("Apple M2 Ultra"), Some(800));
+    #[cfg(target_os = "macos")]
+    mod macos {
+        use super::*;
+
+        #[test]
+        fn bandwidth_table_picks_specific_before_base() {
+            assert_eq!(bandwidth_for_chip("Apple M3 Max"), Some(400));
+            assert_eq!(bandwidth_for_chip("Apple M3 Pro"), Some(150));
+            assert_eq!(bandwidth_for_chip("Apple M3"), Some(100));
+            assert_eq!(bandwidth_for_chip("Apple M1"), Some(68));
+            assert_eq!(bandwidth_for_chip("Apple M4 Pro"), Some(273));
+            assert_eq!(bandwidth_for_chip("Apple M2 Ultra"), Some(800));
+        }
+
+        #[test]
+        fn bandwidth_returns_none_for_unknown_chip() {
+            assert_eq!(bandwidth_for_chip("Intel Core i9"), None);
+            assert_eq!(bandwidth_for_chip(""), None);
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    mod linux {
+        use super::*;
+
+        #[test]
+        fn parses_memtotal_to_kb() {
+            let meminfo = "MemTotal:       131981312 kB\nMemFree:        1000 kB\n";
+            assert_eq!(parse_meminfo_total_kb(meminfo), Some(131_981_312));
+            assert_eq!((131_981_312u64 / (1024 * 1024)) as u32, 125);
+        }
+
+        #[test]
+        fn memtotal_absent_is_none() {
+            assert_eq!(parse_meminfo_total_kb("MemFree: 1000 kB\n"), None);
+        }
+
+        #[test]
+        fn parses_cpuinfo_model_name() {
+            let cpuinfo = "processor\t: 0\nvendor_id\t: AuthenticAMD\n\
+                           model name\t: AMD Ryzen AI Max+ 395 w/ Radeon 8060S\n";
+            assert_eq!(
+                parse_cpuinfo_model(cpuinfo).as_deref(),
+                Some("AMD Ryzen AI Max+ 395 w/ Radeon 8060S")
+            );
+        }
+
+        #[test]
+        fn cpuinfo_falls_back_to_arm_fields() {
+            let cpuinfo = "processor\t: 0\nBogoMIPS\t: 108.00\nModel\t: Raspberry Pi 5\n";
+            assert_eq!(
+                parse_cpuinfo_model(cpuinfo).as_deref(),
+                Some("Raspberry Pi 5")
+            );
+        }
+
+        #[test]
+        fn parses_pretty_name_unquoted() {
+            let osr = "NAME=\"Ubuntu\"\nPRETTY_NAME=\"Ubuntu 24.04.1 LTS\"\nID=ubuntu\n";
+            assert_eq!(
+                parse_os_release_pretty(osr).as_deref(),
+                Some("Ubuntu 24.04.1 LTS")
+            );
+        }
     }
 
     #[test]
-    fn bandwidth_returns_none_for_unknown_chip() {
-        assert_eq!(bandwidth_for_chip("Intel Core i9"), None);
-        assert_eq!(bandwidth_for_chip(""), None);
-        assert_eq!(bandwidth_for_chip("unknown"), None);
-    }
-
-    #[test]
-    fn collect_returns_plausible_data_on_macos() {
-        // This test runs against the actual host — we don't assert
-        // specific values, only that the probe doesn't panic and the
-        // most-critical fields (chip + ram) are populated when
-        // running on a real Mac. CI runs on Linux where most of
-        // these probes return None / fallback strings, so we only
-        // assert the struct shape there.
+    fn collect_returns_plausible_data() {
+        // Platform-agnostic: the probe must not panic, the chip is always at
+        // least "unknown" (non-empty), and RAM is a sane magnitude.
         let p = collect();
-        // chip is always at least "unknown" on non-mac CI runners
         assert!(!p.chip.is_empty());
-        // ram_gb is 0 on Linux runners (no `hw.memsize` sysctl key);
-        // bound the assertion accordingly.
         assert!(p.ram_gb < 4096); // sanity: nobody has >4 TB
     }
 }


### PR DESCRIPTION
Today the only backend that does real inference is Apple-MLX, so a provider has to be a Mac. This PR adds an engine that just talks to any OpenAI-compatible endpoint over HTTP/HTTPS (such ash llama.cpp's llama-server, Ollama, vLLM, a hosted API, etc) plus the couple of fixes needed to build and run the agent cleanly on Linux. So you can run a provider on a Linux box and point it at your own inference server, which is what I'm doing right now. You can see the AMD Ryzen AI MAX+ 395 machine running on my profile here: https://cocore.dev/u/bgrift.dev

It's opt-in and doesn't touch the existing Mac path:

```
COCORE_ENGINE_BACKEND=openai
COCORE_OPENAI_BASE_URL=http://127.0.0.1:8080    # your endpoint
COCORE_OPENAI_API_KEY=...                       # optional, if it needs auth
COCORE_INFERENCE_MODELS=your-model              # sent as the upstream model name
```

What's in here:
- **`OpenAiEngine`** (`engines/openai.rs`): streams completions back via SSE (with a non-streaming fallback), and gates on a `/v1/models` health check so a dead/misconfigured endpoint shows up as an `engineFault` instead of a green machine that silently drops jobs. Doesn't log prompts/responses.
- **Backend selection** in `build_engines` — `COCORE_ENGINE_BACKEND=openai` routes to it; default behavior is unchanged.
- **Linux `system_profile`** — it was macOS-only, so on Linux it reported `ram=0` / chip `"unknown"`. Now it reads `/proc`.
- **rustls for the advisor WebSocket** (was native-tls) so the agent builds on a stock Linux box without `libssl-dev`. reqwest already uses rustls and cert verification still goes through the OS trust store, so this also changes the Mac build's WS TLS backend. I don't expect this to cause any issues, but I wanted to flag it just in case.

A couple other notes:
- It uses the **blocking** reqwest client because the `Engine` trait is sync and runs on a `spawn_blocking` thread; going async would mean a `block_on` dance or making the whole trait async (bigger change that'd touch the Mac engine).
- When the endpoint isn't on the same machine as the agent, the provider record's hardware specs + attestation describe the *agent* host, not wherever inference actually runs. That's fine for a local/self-hosted server, but might be worth thinking about more if someone points it at a third-party API. Happy to add a non-localhost warning if you want one.

Builds on Linux now (no OpenSSL), tests + clippy + fmt all green.