### PR TITLE
chore(release): bump version to 0.9.28

### DIFF
--- a/provider-shell/Sources/CoCoreShell/Resources/Info.plist
+++ b/provider-shell/Sources/CoCoreShell/Resources/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleName</key>
 	<string>co/core</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.27</string>
+	<string>0.9.28</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -22,7 +22,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>927</string>
+	<string>928</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/provider/Cargo.lock
+++ b/provider/Cargo.lock
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "cocore-provider"
-version = "0.9.27"
+version = "0.9.28"
 dependencies = [
  "anyhow",
  "asn1-rs",

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cocore-provider"
-version = "0.9.27"
+version = "0.9.28"
 edition = "2021"
 description = "co/core provider agent: runs hardened compute and publishes signed receipts to AT Protocol."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Cuts the **0.9.28** macOS app release shipping the thinking/reasoning-clause work merged in PR #58 ("thinking") + follow-ups: provider engine reasoning streaming, tray `ModelsView` changes, and the console chat-thinking UI.

Bumps all three version sites:
- `provider/Cargo.toml`
- `provider/Cargo.lock` (`cocore-provider`)
- `provider-shell/.../Info.plist` (Short `0.9.28` / Bundle `928`)

Tag `v0.9.28` already pushed; the notarized `cocore.app.zip` + `SHA256SUMS` are uploaded to the GitHub release alongside the CI tarball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)