### PR TITLE
chore(release): bump version to 0.9.29

### DIFF
--- a/provider-shell/Sources/CoCoreShell/Resources/Info.plist
+++ b/provider-shell/Sources/CoCoreShell/Resources/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleName</key>
 	<string>co/core</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.28</string>
+	<string>0.9.29</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -22,7 +22,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>928</string>
+	<string>929</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/provider/Cargo.lock
+++ b/provider/Cargo.lock
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "cocore-provider"
-version = "0.9.28"
+version = "0.9.29"
 dependencies = [
  "anyhow",
  "asn1-rs",

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cocore-provider"
-version = "0.9.28"
+version = "0.9.29"
 edition = "2021"
 description = "co/core provider agent: runs hardened compute and publishes signed receipts to AT Protocol."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Cuts the **0.9.29** macOS app release shipping the security-posture lifecycle work merged in #88:

- Durable desired-states for **Secure Mode** & **Confidential** (re-enable across restarts).
- Idempotent Secure Mode wizard — an already-enrolled Mac re-attests instead of re-adding a pending enrollment.
- **Off / Applying… (reason) / Active** status surfacing + reconcilers (one bounded auto-bounce + a *Retry now* button), so confidential no longer needs blind toggle/restart.

Bumps all three version sites:
- `provider/Cargo.toml`
- `provider/Cargo.lock` (`cocore-provider`)
- `provider-shell/.../Info.plist` (Short `0.9.29` / Bundle `929`)

After merge: tag `v0.9.29` → CI builds `cocore-mac-arm64.tar.gz`; locally `make mac-release` (notarize) → `scripts/.publish-0.9.29.sh` uploads the notarized `cocore.app.zip` + `SHA256SUMS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)