### PR TITLE
chore(release): bump version to 0.9.30

### DIFF
--- a/provider-shell/Sources/CoCoreShell/Resources/Info.plist
+++ b/provider-shell/Sources/CoCoreShell/Resources/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleName</key>
 	<string>co/core</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.29</string>
+	<string>0.9.30</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -22,7 +22,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>929</string>
+	<string>930</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/provider/Cargo.lock
+++ b/provider/Cargo.lock
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "cocore-provider"
-version = "0.9.29"
+version = "0.9.30"
 dependencies = [
  "anyhow",
  "asn1-rs",

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cocore-provider"
-version = "0.9.29"
+version = "0.9.30"
 edition = "2021"
 description = "co/core provider agent: runs hardened compute and publishes signed receipts to AT Protocol."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Cuts **0.9.30** — the first fleet release whose `cocore.app` contains the nested `CoCoreProvider.app` **confidential worker** (PR #91 made `COCORE_BUILD_APNS=1` the prod-release default). Machines that opted into `attested-confidential` (`desiredTier`) can finally attest instead of silently falling back to the default binary.

Also carries the security-posture lifecycle work from #88 (durable desired-states, idempotent Secure Mode wizard, Off/Applying…/Active surfacing).

Bumps all three version sites:
- `provider/Cargo.toml`
- `provider/Cargo.lock` (`cocore-provider`)
- `provider-shell/.../Info.plist` (Short `0.9.30` / Bundle `930`)

After merge: tag `v0.9.30` → CI tarball; locally `make mac-release` (now confidential by default) → `scripts/.publish-0.9.30.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)