### PR TITLE
fix(provider): update apns call site for write_provision_status arity

### DIFF
--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -825,6 +825,10 @@ async fn prepare_native_confidential_model() {
         "provisioning",
         std::slice::from_ref(&model),
         model_download_bytes(std::slice::from_ref(&model)),
+        // We're entering the download phase, so show a download bar, not the
+        // "loading into memory…" state (loading=false). The serve loop's own
+        // monitor recomputes this from `.incomplete` probes once engines build.
+        false,
         None,
     );
 


### PR DESCRIPTION
## Why

Cutting 0.9.30 (the first confidential-by-default fleet build, PR #91) failed the confidential worker build:

```
error[E0061]: this function takes 5 arguments but 4 arguments were supplied
   --> src/main.rs:824:5   write_provision_status(...)  // argument #4 `loading: bool` is missing
```

`write_provision_status` gained a `loading: bool` parameter, but the **`apns`-gated** confidential-model download path was never updated. The non-apns build and CI never compile that path, so the breakage stayed latent until `COCORE_BUILD_APNS=1` became the default prod build.

## Fix

Pass `loading=false` at the download-entry call site (we're about to download weights → show a download bar, not the "loading into memory…" state). Matches the other `"provisioning"` call sites. Verified with `cargo check --features apns` (clean).

## Follow-up (not in this PR)
CI builds the headless tarball without `--features apns`, so nothing guards the confidential worker from compiling. A cheap `cargo check --features apns` job would catch this class of latent breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)