### PR TITLE
ci: type-check the apns confidential-worker build on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,3 +161,30 @@ jobs:
           name: ci-log-${{ github.run_id }}-${{ github.run_attempt }}
           path: /tmp/ci.log
           if-no-files-found: ignore
+
+  # The confidential worker is built `cargo build --features apns`, and the
+  # apns module is additionally cfg(target_os = "macos"). The clippy step above
+  # runs --all-features but on ubuntu, where that macOS-gated code compiles to
+  # nothing — so apns-only code (e.g. a call site that misses a new fn arg) can
+  # rot unnoticed until someone cuts a confidential release. This caught exactly
+  # that (PR #93: write_provision_status arity). A macOS type-check closes it.
+  #
+  # COCORE_SKIP_NATIVE_BUILD=1 skips the Swift/Metal MLX engine build in build.rs
+  # (`apns` implies `native_mlx`): `cargo check` never links, so the type-check
+  # stays complete without the slow, network-heavy mlx-swift compile.
+  apns-build-check:
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: provider
+
+      - name: cargo check --features apns (macOS-gated confidential worker code)
+        env:
+          COCORE_SKIP_NATIVE_BUILD: "1"
+        run: cargo check --locked --features apns --manifest-path provider/Cargo.toml

--- a/provider/build.rs
+++ b/provider/build.rs
@@ -24,8 +24,23 @@ fn main() {
     // engine). The Rust agent links one libCoCoreMLX.dylib (which statically
     // contains MLX + the Swift code); enforced library validation + a pinned
     // dylib/metallib hash keep the owner from swapping it.
+    println!("cargo:rerun-if-env-changed=COCORE_SKIP_NATIVE_BUILD");
     if std::env::var("CARGO_FEATURE_NATIVE_MLX").is_ok() && cfg!(target_os = "macos") {
-        build_and_link_mlx_engine();
+        // COCORE_SKIP_NATIVE_BUILD lets CI TYPE-CHECK the native/apns Rust paths
+        // (`cargo check --features apns`) without the Swift/Metal engine build —
+        // a fast guard so the macOS-only, apns-gated code can't rot unnoticed
+        // between confidential releases (see PR #93). `cargo check` never links,
+        // so skipping the dylib build + link directives leaves the type-check
+        // complete. NEVER set this for a real `cargo build` — the result won't
+        // link against libCoCoreMLX.
+        if std::env::var("COCORE_SKIP_NATIVE_BUILD").is_ok() {
+            println!(
+                "cargo:warning=COCORE_SKIP_NATIVE_BUILD set: skipping MLX engine build \
+                 (type-check only; the resulting artifact will NOT link)"
+            );
+        } else {
+            build_and_link_mlx_engine();
+        }
     }
 
     let sha = std::env::var("COCORE_GIT_SHA").ok().or_else(|| {


### PR DESCRIPTION
## Why

The confidential worker is built `cargo build --features apns`, and the `apns` module is additionally `cfg(target_os = "macos")`. CI's existing `cargo clippy --all-features` runs on **ubuntu**, where that macOS-gated code compiles to nothing — so `apns`-only breakage stays latent until someone cuts a confidential release.

That's exactly what happened cutting 0.9.30: a `write_provision_status` call site missed a new `loading: bool` argument (fixed in #93) and broke `make mac-release` *mid-release*. Nothing in CI would have caught it.

## What changed

- **New macOS job `apns-build-check`** runs `cargo check --locked --features apns --manifest-path provider/Cargo.toml`.
- **`build.rs` escape hatch `COCORE_SKIP_NATIVE_BUILD=1`**: because `apns` implies `native_mlx`, `build.rs` would otherwise run the slow, network-heavy Swift/Metal MLX engine build. `cargo check` never links, so skipping the dylib build leaves the type-check complete. The flag is CI-only and emits a loud `cargo:warning`; never set it for a real `cargo build`.

## Verification (local)
- `COCORE_SKIP_NATIVE_BUILD=1 cargo check --features apns` → passes, with the skip warning (no Swift build invoked).
- Negative test: reintroducing the missing arg → `error[E0061]: this function takes 5 arguments but 4 arguments were supplied`. The guard catches the exact class of bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)