### PR TITLE
fix(provider): stop leaking inference engine subprocesses (#95)

### DIFF
--- a/packages/console/agent-uninstall.sh
+++ b/packages/console/agent-uninstall.sh
@@ -178,6 +178,53 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
   fi
 fi
 
+# --- running processes -------------------------------------------------
+#
+# Reap anything still running BEFORE we delete the binary, venv, and
+# state dir out from under it. Two kinds of process:
+#
+#   1. The agent itself (`cocore agent serve` / the confidential
+#      `cocore-provider agent serve`). The LaunchAgent bootout above
+#      handles the launchd-supervised case, but an app-supervised or
+#      manually-started agent isn't covered by that.
+#   2. The Python inference engines (`cocore_inference_server.py`, one
+#      per served model). These are spawned by the agent and, if the
+#      agent is gone, have reparented to launchd (PID 1). Nothing else
+#      signals them, so without this they survive the uninstall holding
+#      hundreds of MB of RAM (the bug this phase fixes). Newer agents
+#      ship a parent-death watchdog that self-reaps these, but we still
+#      sweep here so an uninstall of an older agent — or one killed
+#      mid-startup before its watchdog armed — leaves nothing behind.
+
+phase "running processes"
+reap_pattern() {
+  # SIGTERM matching PIDs, wait briefly, then SIGKILL survivors. Uses
+  # pgrep/kill (not pkill) so dry-run can just report. `|| true` keeps
+  # set -e happy when nothing matches.
+  local label="$1" pattern="$2" pids
+  pids="$(pgrep -f "$pattern" 2>/dev/null || true)"
+  if [[ -z "$pids" ]]; then
+    note "no $label running"
+    return 0
+  fi
+  # shellcheck disable=SC2086
+  if [[ "$COCORE_DRY_RUN" == "1" ]]; then
+    note "  [dry-run] kill $label: $(echo $pids | tr '\n' ' ')"
+    return 0
+  fi
+  note "stopping $label ($(echo $pids | tr '\n' ' '))"
+  echo "$pids" | while read -r pid; do [[ -n "$pid" ]] && kill "$pid" 2>/dev/null || true; done
+  sleep 1
+  echo "$pids" | while read -r pid; do
+    [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null && kill -9 "$pid" 2>/dev/null || true
+  done
+}
+# Engines first — once the agent is gone there's no one to respawn them,
+# and reaping them before the agent avoids the agent's health watchdog
+# trying to restart a child mid-uninstall.
+reap_pattern "inference engine(s)" "cocore_inference_server.py"
+reap_pattern "agent process(es)" "cocore(-provider)? agent serve"
+
 # --- binary ------------------------------------------------------------
 
 phase "binary"

--- a/provider/python/cocore_inference_server.py
+++ b/provider/python/cocore_inference_server.py
@@ -5,7 +5,18 @@ cocore inference subprocess wrapper.
 The Rust agent (`cocore agent serve`) spawns one instance of this
 script per model it wants to serve. The script loads vllm-mlx, binds
 its FastAPI app to a Unix domain socket, and serves until the parent
-sends SIGTERM.
+sends SIGTERM *or* the parent goes away.
+
+The second condition is a hard failsafe. An explicit SIGTERM is the
+clean teardown path, but it is not the only one the parent can take:
+the agent can be SIGKILLed, crash, get `launchctl kickstart -k`'d, or
+exit non-gracefully on a trust-tier / model switch (`std::process::exit`
+skips Rust destructors), and an uninstall removes the app without
+signalling its children at all. In every one of those cases this child
+would otherwise reparent to launchd (PPID 1) and run forever, holding
+hundreds of MB of RAM on a socket nobody can reach. So a daemon thread
+watches the parent PID and exits this process the moment the parent is
+gone — see `_start_parent_death_watch`. The agent cannot leak us.
 
 Why a subprocess and not in-process PyO3:
   * The Rust binary stays free of libpython linkage — `otool -L
@@ -116,6 +127,49 @@ def _unlink_if_owned(socket_path: Path, owned_ino: "int | None") -> None:
         pass
 
 
+# How often the parent-death watchdog checks whether the agent is still
+# our parent. 2s is a negligible cost (one getppid() syscall) and bounds
+# how long an orphan can linger after the parent dies — far below the
+# minutes-long TCP timeout that left engines running in the field.
+_PARENT_WATCH_INTERVAL_S = 2.0
+
+
+def _start_parent_death_watch(
+    parent_pid: int, socket_path: Path, bound_ino: "list[int | None]"
+) -> None:
+    """Exit this process if the parent agent ever goes away.
+
+    The only *clean* teardown is an explicit SIGTERM from the parent, but
+    that path is not guaranteed: the agent can be SIGKILLed, crash, be
+    ``launchctl kickstart -k``'d, exit via ``std::process::exit`` on a
+    tier/model switch (which skips its Rust ``Drop`` that would SIGTERM
+    us), or be removed wholesale by an uninstall. In all of those the
+    kernel reparents us to launchd (PID 1) and our ``getppid()`` stops
+    equalling ``parent_pid``. A daemon thread polls for exactly that and,
+    when it sees it, unlinks our own socket and hard-exits — so an engine
+    can never outlive the agent that spawned it.
+
+    ``parent_pid`` is the agent's PID, passed explicitly via ``--parent-pid``
+    (PID reuse can't cause a false negative: an orphan's parent is launchd,
+    never the recycled agent PID). We compare against it rather than just
+    checking ``getppid() == 1`` so the watch also fires under a process
+    reaper / subreaper that adopts orphans at a PID other than 1.
+    """
+
+    def _watch() -> None:
+        while True:
+            time.sleep(_PARENT_WATCH_INTERVAL_S)
+            if os.getppid() != parent_pid:
+                # Parent is gone. Drop our socket so we don't leave a dead
+                # file behind, then hard-exit: uvicorn owns the main thread
+                # and won't honour sys.exit() from here, so os._exit is the
+                # only reliable way out of a foreign event loop.
+                _unlink_if_owned(socket_path, bound_ino[0])
+                os._exit(0)
+
+    threading.Thread(target=_watch, name="parent-death-watch", daemon=True).start()
+
+
 def main() -> None:
     ap = argparse.ArgumentParser(description="cocore inference subprocess wrapper")
     ap.add_argument(
@@ -127,6 +181,17 @@ def main() -> None:
         "--uds",
         required=True,
         help="Unix domain socket path to bind",
+    )
+    ap.add_argument(
+        "--parent-pid",
+        type=int,
+        default=None,
+        help=(
+            "PID of the spawning agent. When set, a watchdog thread exits "
+            "this process if the parent goes away (reparent off this PID), so "
+            "the engine can't outlive the agent. Defaults to the actual parent "
+            "PID at startup for older agents that don't pass it."
+        ),
     )
     args = ap.parse_args()
 
@@ -168,6 +233,18 @@ def main() -> None:
     threading.Thread(
         target=_record_bound_socket, name="socket-ino-recorder", daemon=True
     ).start()
+
+    # Parent-death failsafe: exit if the agent ever goes away, however it
+    # goes (SIGKILL, crash, kickstart -k, std::process::exit on a tier/model
+    # switch, uninstall). Capture the parent PID now — explicit from the
+    # agent when given, else our actual parent at startup for older agents.
+    # Started before the slow model load so an agent that dies *during* load
+    # still reaps us. Shares bound_ino so it unlinks only our own socket.
+    _start_parent_death_watch(
+        args.parent_pid if args.parent_pid is not None else os.getppid(),
+        socket_path,
+        bound_ino,
+    )
 
     # Load the model into vllm-mlx's module-level global. The
     # FastAPI routes inside vllm_mlx.server pick it up via

--- a/provider/src/advisor.rs
+++ b/provider/src/advisor.rs
@@ -318,6 +318,10 @@ impl AdvisorClient {
                                 from = ?active_at_start, to = ?active_now,
                                 "a model's schedule window changed the active set; restarting to reload engines"
                             );
+                            // process::exit runs no destructors, so reap the
+                            // engine subprocesses here — otherwise their Drop
+                            // never fires and the Python children orphan.
+                            ctx.engines.terminate_all();
                             std::process::exit(3);
                         }
                     }
@@ -348,6 +352,11 @@ impl AdvisorClient {
                             from = ?desired_tier_at_start, to = ?desired_tier,
                             "owner changed this machine's trust tier from the console; restarting to re-select the worker"
                         );
+                        // Reap engine subprocesses before the destructor-
+                        // skipping exit — confidential serves in-process, so
+                        // a leaked best-effort child would linger with no
+                        // owner. (See terminate_all.)
+                        ctx.engines.terminate_all();
                         std::process::exit(3);
                     }
                     if models_changed(&desired, desired_at_start) {
@@ -360,6 +369,10 @@ impl AdvisorClient {
                             from = ?desired_at_start, to = ?desired,
                             "owner changed this machine's models from the console; restarting to reload engines"
                         );
+                        // Reap engine subprocesses before the destructor-
+                        // skipping exit so the old model's child doesn't
+                        // orphan while the fresh serve loads the new set.
+                        ctx.engines.terminate_all();
                         std::process::exit(3);
                     }
                 }
@@ -397,7 +410,11 @@ impl AdvisorClient {
                         // Exit non-zero so launchd KeepAlive (SuccessfulExit
                         // =false) / the app supervisor respawn us. A distinct
                         // code from the model-change reload (exit 3) keeps the
-                        // two causes apart in logs.
+                        // two causes apart in logs. Reap first: the engines
+                        // that AREN'T dead would otherwise orphan past this
+                        // destructor-skipping exit (terminate is a no-op on
+                        // the already-dead ones).
+                        ctx.engines.terminate_all();
                         std::process::exit(7);
                     }
                 }
@@ -436,6 +453,9 @@ impl AdvisorClient {
                             models = ?dead,
                             "self-right could not restart engine(s); restarting agent to re-register without them"
                         );
+                        // Reap surviving engines before the destructor-
+                        // skipping exit (no-op on the dead ones).
+                        ctx.engines.terminate_all();
                         std::process::exit(7);
                     }
                     tracing::info!("self-right succeeded; cleared bad-standing");

--- a/provider/src/engines/mod.rs
+++ b/provider/src/engines/mod.rs
@@ -123,6 +123,18 @@ impl EngineRegistry {
             .map(|(k, v)| (k.clone(), Arc::clone(v)))
             .collect()
     }
+
+    /// Reap every engine's external process, synchronously. Call this
+    /// immediately before any `std::process::exit` on the serve path
+    /// (trust-tier / model switch) — `std::process::exit` runs no
+    /// destructors, so without this the engines' `Drop` never fires and
+    /// their Python children orphan to launchd until their own watchdog
+    /// notices. Idempotent and safe after a partial reap.
+    pub fn terminate_all(&self) {
+        for engine in self.by_model.values() {
+            engine.terminate();
+        }
+    }
 }
 
 impl Default for EngineRegistry {
@@ -434,6 +446,19 @@ pub trait Engine: Send + Sync {
     fn restart(&self) -> Result<()> {
         Ok(())
     }
+
+    /// Reap any external process this engine owns, synchronously, before
+    /// the agent exits. The default is a no-op — correct for engines with
+    /// no subprocess (the stub). The subprocess engine SIGTERMs (then
+    /// SIGKILLs) its Python child and unlinks its socket.
+    ///
+    /// `Drop` already does this on the normal unwind path, but the serve
+    /// loop also exits via `std::process::exit` on a trust-tier or model
+    /// switch (the supervisor must re-select the worker shape), and
+    /// `std::process::exit` runs no destructors. Calling `terminate()`
+    /// explicitly at those sites reaps the children promptly instead of
+    /// leaning on the child-side parent-death watchdog's poll latency.
+    fn terminate(&self) {}
 
     /// Synchronous, non-streaming generate. Collects a streaming
     /// response when the engine only implements token deltas.

--- a/provider/src/engines/subprocess.rs
+++ b/provider/src/engines/subprocess.rs
@@ -418,6 +418,17 @@ impl SubprocessEngine {
             .arg(&self.model_id)
             .arg("--uds")
             .arg(&self.socket_path)
+            // Parent-death failsafe: tell the child our PID so its
+            // watchdog thread can self-exit if we ever go away without a
+            // clean SIGTERM (SIGKILL, crash, `kickstart -k`, the
+            // `std::process::exit` we take on a tier/model switch — which
+            // skips the Drop below — or an uninstall that just removes the
+            // app). Without this the child reparents to launchd and runs
+            // forever on a socket nobody can reach. The explicit Drop
+            // teardown is still the fast path; this only backstops the
+            // exits that never reach Drop.
+            .arg("--parent-pid")
+            .arg(std::process::id().to_string())
             // Capture stdout + stderr into a bounded ring buffer
             // (see ENGINE_RING_BUFFER_CAP). We deliberately do NOT
             // pipe child output into tracing: vllm-mlx logs prompt
@@ -427,8 +438,11 @@ impl SubprocessEngine {
             // startup-failure bail paths below.
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
-            // Don't inherit a controlling tty; we want this child to
-            // be reparentable by launchd if the agent itself dies.
+            // Don't inherit a controlling tty. If the agent dies the
+            // child does reparent to launchd, but it no longer *survives*
+            // there: the `--parent-pid` watchdog above notices the agent
+            // is gone and exits the child. Reparenting is just the kernel
+            // mechanic; the failsafe is what bounds its lifetime.
             .stdin(Stdio::null());
 
         let mut child = cmd.spawn().with_context(|| {
@@ -867,26 +881,30 @@ impl SubprocessEngine {
     }
 }
 
-impl Drop for SubprocessEngine {
-    fn drop(&mut self) {
-        // NEVER `.unwrap()` a lock inside a Drop. If the mutex is
-        // poisoned (some thread panicked while holding it), `unwrap()`
-        // panics — and a panic inside a destructor that runs *during
-        // an unwind* is "panic while panicking", which Rust turns into
-        // an immediate `abort()` (SIGABRT) via `panic_in_cleanup`.
-        // That abort (a) kills the whole agent and (b) skips the
-        // SIGTERM below, orphaning the Python inference child. Recover
-        // the guard from the poison instead: the `Option<Child>` it
-        // protects is still valid data, and we WANT to run the kill
-        // path regardless of whether some other thread panicked.
+impl SubprocessEngine {
+    /// Reap the child (if running) and unlink its socket. SIGTERM first —
+    /// the Python wrapper has a SIGTERM handler that unlinks the socket
+    /// cleanly — then escalate to SIGKILL after 5s if it hasn't exited.
+    ///
+    /// Shared by `Drop` and [`Engine::terminate`] so both the unwind path
+    /// and the explicit pre-`std::process::exit` reap behave identically.
+    /// Takes the child out under the lock so a second call is a no-op.
+    /// Poison-tolerant on the lock (see the Drop note below) and safe to
+    /// call from any thread.
+    fn terminate_child(&self) {
+        // NEVER `.unwrap()` a lock here. When this runs from Drop during an
+        // unwind, an `unwrap()` on a poisoned mutex would panic, and a panic
+        // while panicking is `panic_in_cleanup` → an immediate `abort()`
+        // (SIGABRT) that (a) kills the whole agent and (b) skips the SIGTERM
+        // below, orphaning the Python inference child. Recover the guard from
+        // the poison instead: the `Option<Child>` it protects is still valid
+        // data, and we WANT to run the kill path regardless of whether some
+        // other thread panicked.
         let mut guard = self
             .child
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         if let Some(mut child) = guard.take() {
-            // SIGTERM first — the Python wrapper has a SIGTERM handler
-            // that unlinks the socket cleanly. Wait up to 5s, then
-            // escalate to SIGKILL.
             tracing::info!(model = %self.model_id, "terminating inference subprocess");
             #[cfg(unix)]
             unsafe {
@@ -911,6 +929,12 @@ impl Drop for SubprocessEngine {
     }
 }
 
+impl Drop for SubprocessEngine {
+    fn drop(&mut self) {
+        self.terminate_child();
+    }
+}
+
 impl Engine for SubprocessEngine {
     fn name(&self) -> &'static str {
         "subprocess-vllm-mlx"
@@ -918,6 +942,10 @@ impl Engine for SubprocessEngine {
 
     fn ready(&self) -> bool {
         self.is_alive()
+    }
+
+    fn terminate(&self) {
+        self.terminate_child();
     }
 
     /// Reap the dead child (if any) and respawn it on the same

--- a/scripts/uninstall-mac-provider.sh
+++ b/scripts/uninstall-mac-provider.sh
@@ -62,6 +62,34 @@ else
   note "$MENUBAR_PLIST not found"
 fi
 
+# Reap anything still running before we delete its files. `bootout`
+# above covers the launchd-supervised agent, but not an app-supervised
+# or manually-started one — and never the Python inference engines it
+# spawns (`cocore_inference_server.py`, one per served model). Those
+# reparent to launchd when the agent goes and, unsignalled, survive the
+# uninstall holding hundreds of MB of RAM. Newer agents self-reap via a
+# parent-death watchdog; this sweep covers older ones and mid-startup
+# kills. Engines first (no agent left to respawn them), then the agent.
+bold "==> stop running processes"
+reap_pattern() {
+  local label="$1" pattern="$2" pids
+  pids="$(pgrep -f "$pattern" 2>/dev/null || true)"
+  if [[ -z "$pids" ]]; then
+    note "no $label running"
+    return 0
+  fi
+  note "stopping $label"
+  # shellcheck disable=SC2086
+  echo $pids | tr ' ' '\n' | while read -r pid; do [[ -n "$pid" ]] && kill "$pid" 2>/dev/null || true; done
+  sleep 1
+  # shellcheck disable=SC2086
+  echo $pids | tr ' ' '\n' | while read -r pid; do
+    [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null && kill -9 "$pid" 2>/dev/null || true
+  done
+}
+reap_pattern "inference engine(s)" "cocore_inference_server.py"
+reap_pattern "agent process(es)" "cocore(-provider)? agent serve"
+
 bold "==> remove installed binary"
 if [[ -f "$INSTALL_BIN" ]]; then
   rm -f "$INSTALL_BIN"


### PR DESCRIPTION
Fixes #95.

## Root cause

The best-effort MLX inference engines (`cocore_inference_server.py`, one per served model) were reaped only by an explicit parent `SIGTERM`. Any parent exit that skipped that path left the child reparented to launchd (PID 1) running forever, holding hundreds of MB of RAM on a socket nobody could reach. Confirmed in code across all three reported triggers:

- **Tier/model switch** → `std::process::exit(3)` in `advisor.rs`, which runs **no Rust destructors**, so `Drop for SubprocessEngine` never fired (issue case 3).
- **App restart** → `killStrayAgents()` SIGKILLs orphaned agents after 0.5s, and a previously-orphaned agent's children are already PPID-1 orphans that nothing reaps (case 2).
- **Uninstall** → `agent-uninstall.sh` wipes `~/.cocore` but never signalled the children (case 1).

## The fix (three layers)

1. **Child-side parent-death watchdog (keystone).** The wrapper now takes `--parent-pid` and runs a daemon thread that exits the process the moment its parent goes away (reparent off that PID). This bounds an engine's lifetime to its agent's *regardless of how the agent dies* — SIGKILL, crash, `kickstart -k`, `process::exit`, or uninstall — covering every trigger in the report. ~2s poll, one `getppid()` syscall.

2. **Prompt Rust-side reaping.** Refactored the `Drop` teardown into a shared `terminate_child`, exposed via a new `Engine::terminate` + `EngineRegistry::terminate_all`, and called it before every `std::process::exit` on the serve loop (tier/model switch, dead-engine restart) so children die immediately instead of waiting on the watchdog's poll latency.

3. **Uninstall hook.** Both `agent-uninstall.sh` (the hosted + in-app path) and `uninstall-mac-provider.sh` now SIGTERM→SIGKILL any lingering `cocore_inference_server.py` and `cocore agent serve` before wiping the binary, venv, and state dir — so an uninstall of an *older* agent (no watchdog) still leaves nothing behind.

## Verification

- **Watchdog:** stays quiet while the parent lives (no false positive), self-reaps within the poll interval after a real parent is SIGKILLed, and unlinks **only** its own inode-owned socket (ownership guard respected in both directions).
- **Reap hook:** `reap_pattern` kills a matching process; both shell scripts pass `bash -n`.
- 126 provider unit tests pass; `cargo clippy --lib` clean (the engine module is `deny(unwrap/expect/panic)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)