### PR TITLE
Prioritise self's machines, when providing a requested model

### DIFF
--- a/packages/appview/src/inference/dispatch.ts
+++ b/packages/appview/src/inference/dispatch.ts
@@ -27,6 +27,7 @@
 
 import type { RecordTransport } from "@cocore/sdk/publish";
 import { submitJob } from "@cocore/sdk/publish";
+import { ownMachineCandidates } from "@cocore/sdk/provider-selection";
 import { FetchHttpClient, HttpClient, HttpClientRequest } from "@effect/platform";
 import { makeRuntime } from "@cocore/o11y";
 import { Effect } from "effect";
@@ -264,6 +265,7 @@ async function fetchProviders(advisorUrl: string): Promise<AdvisorProviderRow[]>
 async function pickProvider(
   advisorUrl: string,
   model: string,
+  requesterDid: string,
   targetDid: string | undefined,
   options: PickProviderOptions,
   /** Providers already tried this dispatch (a prior attempt's `/jobs`
@@ -283,6 +285,9 @@ async function pickProvider(
     if (!targetPasses) throw new ProviderPayoutsNotEligibleError(targetDid);
     return hit;
   }
+
+  const own = ownMachineCandidates(attested, requesterDid, model, excludeDids ?? new Set());
+  if (own.length > 0) return own[0]!;
 
   const pool =
     excludeDids && excludeDids.size > 0
@@ -438,6 +443,7 @@ export async function* runDispatch(
       candidate = await pickProvider(
         deps.advisorUrl,
         input.model,
+        input.did,
         input.targetProviderDid,
         { payoutsEligibleDids: null, selfLoopExempt: null },
         excludeDids,
@@ -490,6 +496,8 @@ export async function* runDispatch(
         ciphertext: [...candidateCiphertext],
         sessionId,
         targetProviderDid: candidate.did,
+        // Pin the exact machine we sealed the prompt to, the only one that can unseal.
+        ...(candidate.machineId ? { targetMachineId: candidate.machineId } : {}),
       }),
     });
 

--- a/packages/console/src/lib/inference-dispatch.server.ts
+++ b/packages/console/src/lib/inference-dispatch.server.ts
@@ -20,6 +20,7 @@
 
 import type { OAuthSession } from "@atcute/oauth-node-client";
 import { submitJob } from "@cocore/sdk/publish";
+import { ownMachineCandidates } from "@cocore/sdk/provider-selection";
 import { Effect } from "effect";
 import nacl from "tweetnacl";
 
@@ -314,6 +315,7 @@ export class ProviderPayoutsNotEligibleError extends Error {
 async function pickProvider(
   advisorUrl: string,
   model: string,
+  requesterDid: string,
   targetDid: string | undefined,
   options: PickProviderOptions,
   allowedDids: Set<string> | undefined,
@@ -340,6 +342,9 @@ async function pickProvider(
     if (!targetPasses) throw new ProviderPayoutsNotEligibleError(targetDid);
     return hit;
   }
+
+  const own = ownMachineCandidates(attested, requesterDid, model, excludeDids ?? new Set());
+  if (own.length > 0) return own[0]!;
 
   // Drop providers a prior attempt already tried-and-failed so failover
   // doesn't keep re-picking the same flapped machine. The error counts
@@ -566,6 +571,7 @@ export async function* runDispatch(input: DispatchInputs): AsyncGenerator<Dispat
       candidate = await pickProvider(
         config.advisorUrl,
         input.model,
+        input.did,
         input.targetProviderDid,
         { payoutsEligibleDids: null, selfLoopExempt: null },
         input.targetProviderDid ? undefined : input.allowedProviderDids,
@@ -622,6 +628,8 @@ export async function* runDispatch(input: DispatchInputs): AsyncGenerator<Dispat
         ciphertext: [...candidateCiphertext],
         sessionId,
         targetProviderDid: candidate.did,
+        // Pin the exact machine we sealed the prompt to, the only one that can unseal.
+        ...(candidate.machineId ? { targetMachineId: candidate.machineId } : {}),
       }),
     });
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -15,6 +15,7 @@
     "./verify-provider": "./src/verify-provider.ts",
     "./oauth-scope": "./src/oauth-scope.ts",
     "./p256": "./src/p256.ts",
+    "./provider-selection": "./src/provider-selection.ts",
     "./publish": "./src/publish.ts",
     "./resolve": "./src/resolve.ts",
     "./types": "./src/types.ts",

--- a/packages/sdk/src/provider-selection.test.ts
+++ b/packages/sdk/src/provider-selection.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { ownMachineCandidates } from "./provider-selection.ts";
+
+describe("ownMachineCandidates", () => {
+  const ME = "did:plc:alice";
+  const mineOld = { did: ME, supportedModels: ["m"], lastSeen: "2026-01-01T00:00:00Z" };
+  const mineFresh = { did: ME, supportedModels: ["m"], lastSeen: "2026-01-02T00:00:00Z" };
+  const mineOtherModel = { did: ME, supportedModels: ["other"], lastSeen: "2026-01-03T00:00:00Z" };
+  const foreign = { did: "did:plc:bob", supportedModels: ["m"], lastSeen: "2026-01-09T00:00:00Z" };
+
+  it("returns only the requester's own machines serving the model, freshest first", () => {
+    expect(ownMachineCandidates([mineOld, foreign, mineFresh], ME, "m", new Set())).toEqual([
+      mineFresh,
+      mineOld,
+    ]);
+  });
+
+  it("is empty when the requester owns no machine serving this model", () => {
+    expect(ownMachineCandidates([foreign], ME, "m", new Set())).toEqual([]);
+    // Owns a machine, but it serves a different model.
+    expect(ownMachineCandidates([mineOtherModel], ME, "m", new Set())).toEqual([]);
+  });
+
+  it("treats a machine advertising no models as serving everything", () => {
+    const wildcard = { did: ME, supportedModels: [], lastSeen: "2026-01-05T00:00:00Z" };
+    expect(ownMachineCandidates([wildcard], ME, "m", new Set())).toEqual([wildcard]);
+  });
+
+  it("excludes own DIDs already burned by a prior failover attempt", () => {
+    expect(ownMachineCandidates([mineFresh, foreign], ME, "m", new Set([ME]))).toEqual([]);
+  });
+});

--- a/packages/sdk/src/provider-selection.ts
+++ b/packages/sdk/src/provider-selection.ts
@@ -1,0 +1,17 @@
+// Pure provider-selection helper shared by the console and AppView dispatch
+// cores.
+
+/** The requester's own machines that serve `model` and haven't been burned by a
+ *  prior failover attempt, freshest-heartbeat first. */
+export function ownMachineCandidates<
+  T extends { did: string; supportedModels: string[]; lastSeen: string },
+>(attested: T[], requesterDid: string, model: string, excludeDids: Set<string>): T[] {
+  return attested
+    .filter(
+      (c) =>
+        c.did === requesterDid &&
+        !excludeDids.has(c.did) &&
+        (c.supportedModels.length === 0 || c.supportedModels.includes(model)),
+    )
+    .sort((a, b) => Date.parse(b.lastSeen) - Date.parse(a.lastSeen));
+}


### PR DESCRIPTION
This little change makes the router prefer the requester's machine(s) when they're providing the model they want (with the side effect that the fee is waived).

I'm not sure if this is what you had in mind @DGaffney, but I figured I'd give it a crack!

There would have been some pure-function duplication between `dispatch.ts` and `inference-dispatch.ts`, so I broke that out — but it may not be how you want to proceed. I'm not precious about what's here at all; please use/amend/ignore as is useful 😊 

Resolves #59 