### PR TITLE
fix(shell): address #100 review — non-blocking worker reap + clear bounce cooldown on user intent

### DIFF
--- a/provider-shell/Sources/CoCoreShell/AgentSupervisor.swift
+++ b/provider-shell/Sources/CoCoreShell/AgentSupervisor.swift
@@ -110,8 +110,9 @@ final class AgentSupervisor {
         // THIS shell that `process` no longer points at; left alive it keeps a
         // resident MLX engine and a second advisor registration. That's the
         // "paused but still burning CPU" report (#90): pause stopped the
-        // tracked worker, the leaked sibling kept running. Kill them all.
-        Self.reapWorkers()
+        // tracked worker, the leaked sibling kept running. Kill them all —
+        // via the async reaper so Pause never freezes the main actor.
+        await Self.reapWorkersAsync()
     }
 
     /// Synchronous teardown for `applicationWillTerminate`. The async
@@ -396,9 +397,14 @@ final class AgentSupervisor {
     /// while ALSO catching the same-shell leaks that were #90's root cause
     /// (duplicate confidential workers → mismatched encryption keys → endless
     /// `aead::Error` + bounce churn). `pgrep -P <ppid> -f <pat>` is AND
-    /// semantics on macOS. Best-effort and synchronous (it runs before a spawn
-    /// and on stop, where a ~half-second wait is acceptable).
-    private static func reapWorkers() {
+    /// semantics on macOS. Best-effort.
+    ///
+    /// Two flavours share `strayWorkerPids()`: the blocking `reapWorkers()` for
+    /// the pre-spawn + app-termination paths (a ~½s wait is fine there), and
+    /// the `await`-based `reapWorkersAsync()` for the `@MainActor async stop()`
+    /// path — Pause/Quit must NOT freeze the UI for the grace window, which is
+    /// precisely the leaked-worker case this hardens (caught in review of #100).
+    private static func strayWorkerPids() -> [Int32] {
         let mine = ProcessInfo.processInfo.processIdentifier
         var pids = Set<Int32>()
         for parent in ["1", String(mine)] {
@@ -421,14 +427,33 @@ final class AgentSupervisor {
             }
         }
         pids.remove(mine)
+        return Array(pids)
+    }
+
+    /// SIGTERM, then (after a grace window) SIGKILL any survivor. The grace lets
+    /// each worker's Drop SIGTERM its Python child + flip its provider record to
+    /// serving=false, so we don't race a half-dead registration.
+    private static func reapWorkers() {
+        let pids = strayWorkerPids()
         guard !pids.isEmpty else { return }
         NSLog("cocore: reaping %d stray agent worker(s): %@",
               pids.count, pids.map(String.init).joined(separator: ","))
         for pid in pids { kill(pid, SIGTERM) }
-        // Give them a moment to unwind (their Drop SIGTERMs the Python child +
-        // flips the provider record to serving=false) so we don't race a
-        // half-dead registration.
         Thread.sleep(forTimeInterval: 0.5)
+        for pid in pids where kill(pid, 0) == 0 { kill(pid, SIGKILL) }
+    }
+
+    /// Non-blocking twin of `reapWorkers()` for the MainActor-async `stop()`
+    /// path: yields the grace window with `Task.sleep` instead of
+    /// `Thread.sleep`, so a Pause/Quit with a leaked worker present doesn't
+    /// block the main actor for ~500 ms.
+    private static func reapWorkersAsync() async {
+        let pids = strayWorkerPids()
+        guard !pids.isEmpty else { return }
+        NSLog("cocore: reaping %d stray agent worker(s): %@",
+              pids.count, pids.map(String.init).joined(separator: ","))
+        for pid in pids { kill(pid, SIGTERM) }
+        try? await Task.sleep(nanoseconds: 500_000_000)
         for pid in pids where kill(pid, 0) == 0 { kill(pid, SIGKILL) }
     }
 

--- a/provider-shell/Sources/CoCoreShell/MenuBarController.swift
+++ b/provider-shell/Sources/CoCoreShell/MenuBarController.swift
@@ -520,9 +520,14 @@ final class MenuBarController {
             UserDefaults.standard.set(on, forKey: "cachedConfidentialDesired")
             if !on { state.confidentialBlockedReason = nil }
             // Fresh intent → allow exactly one auto-bounce again if it gets
-            // stuck, and start the grace clock from this apply-bounce.
+            // stuck, and start the grace clock from this apply-bounce. Clear
+            // the auto-bounce cooldown too: an explicit user enable is intent,
+            // and must not be silently blocked by a floor left over from an
+            // earlier stuck window (else a re-enable within 30m sits in
+            // "Applying…" with no auto-recovery until the cooldown lapses).
             didAutoBounceConfidential = false
             lastConfidentialActionAt = on ? Date() : nil
+            lastAutoBounceAt = nil
             // Bounce so the fresh serve reads the new desiredTier and the
             // supervisor selects the right worker (same as Restart serving).
             await supervisor.stop()
@@ -563,6 +568,7 @@ final class MenuBarController {
             NSLog("cocore: user retried confidential — bouncing agent to re-verify")
             didAutoBounceConfidential = false
             lastConfidentialActionAt = Date()
+            lastAutoBounceAt = nil  // explicit Retry overrides the auto-bounce cooldown
             await supervisor.stop()
             await supervisor.start()
             refreshServing()


### PR DESCRIPTION
Follow-up to #100 (already merged) — addresses both P2 findings from the Greptile review of that PR. Related: #90.

### 1. `Thread.sleep` blocked the main actor on Pause/Quit
`reapWorkers()` was synchronous and ran `Thread.sleep(0.5)` (the SIGTERM→SIGKILL grace window). `#100` started calling it from `stop()`, which is `@MainActor async` — so a Pause or Quit *with a leaked worker present* (precisely the case `#100` hardens) froze the UI for ~500 ms.

Fix: factor pid collection into `strayWorkerPids()`, keep a blocking `reapWorkers()` for the pre-spawn and app-termination paths (blocking is fine there), and add an `await`-based **`reapWorkersAsync()`** that yields the grace window via `Task.sleep`. `stop()` now uses the async variant. `stopSynchronously()` (app terminating) and `spawnChild()` (pre-spawn, only-on-leak — pre-existing behaviour) keep the blocking version.

### 2. Auto-bounce cooldown wasn't cleared on explicit user intent
`#100` added a 30-min `autoBounceCooldown` floor between *reconciler* auto-bounces. But `setConfidential(on:)` and `retryConfidential()` reset the one-shot latch + grace clock without clearing `lastAutoBounceAt`. So a user who disabled/re-enabled confidential (or hit Retry) within 30 min had the reconciler's auto-recovery silently suppressed — the machine could sit in "Applying…" with no bounce until the cooldown lapsed.

Fix: both explicit-user paths now reset `lastAutoBounceAt = nil`. Explicit intent overrides the anti-churn floor; the floor still applies to the *automatic* reconciler path it was built for.

Compile-checked (`swift build`). No behaviour change to the singleton/reaper logic validated in #100 — these are the two edges the review flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)