### PR TITLE
Add pro bono path for chat completions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,11 @@ A `dev.cocore.compute.receipt` record commits to, at minimum:
 - `sig` — provider signature (already implicit at the repo layer; this field
   is for any _additional_ enclave-bound signature the provider wants to
   publish alongside the repo signature)
+- `proBono` — optional bool, present (`true`) only when the provider served
+  the job pro bono under its `provider.proBono` election: free, unmetered, no
+  exchange cut. A pro bono receipt MUST carry `price.amount: 0` and
+  `tokens: { in: 0, out: 0 }`, and the exchange settles it with all-zero
+  amounts. Absent/false is a normal metered, billable receipt.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ The mechanics are deliberately few:
 - **A monthly patronage rebate** — most of the treasury flows back to active
   members in proportion to how much they participated. This is the old
   Rochdale co-op dividend (think REI's annual rebate), translated to compute.
+- **A pro bono carve-out** — a provider can hold a machine out for free,
+  unmetered work, either for *anyone* or for an explicit list of direct
+  relationships. A pro bono job counts no tokens and the treasury takes no
+  cut: the receipt records `proBono: true` with a zero price and zero token
+  counts, so a balance-less requester can still be served unlimited. It's
+  purely additive — a requester the policy doesn't cover is still served as a
+  normal paid job, so opting in never costs the machine paid work.
 
 Every parameter lives on a public `dev.cocore.compute.exchangePolicy`
 record, so you — or a competing exchange — can replicate the math without

--- a/infra/services/src/receipt-pipeline.test.ts
+++ b/infra/services/src/receipt-pipeline.test.ts
@@ -263,6 +263,36 @@ describe("ReceiptPipeline", () => {
     expect(recent[0]?.settlementUri).toMatch(/^at:\/\/exchange\/settlement\//);
   });
 
+  it("settles a pro-bono receipt without moving any tokens (no cut, unmetered)", async () => {
+    // A pro-bono receipt is free + unmetered: price.amount is 0 and the
+    // tokens are zero. The exchange settles it (audit trail), but the
+    // pipeline's token-movement guard (amount > 0) means the ledger never
+    // debits the requester or credits the provider — the carve-out for
+    // explicitly unlimited usage.
+    const jobUri = "at://did:plc:requester/dev.cocore.compute.job/probono";
+    const attUri = "at://did:plc:provider/dev.cocore.compute.attestation/att-probono";
+    const { exchange, ledgerApplied } = setup({
+      exchangeResolved: new Set([jobUri, attUri]),
+    });
+
+    const receipt = makeReceipt({
+      rkey: "pb1",
+      providerDid: "did:plc:provider",
+      requesterDid: "did:plc:requester",
+      jobUri,
+      attestationUri: attUri,
+      tokens: { in: 0, out: 0 },
+      price: { amount: 0, currency: "CC" },
+    });
+    store.upsert(receipt);
+    await firehose.dispatch(receipt);
+
+    // Settled (the settlement record is the audit trail) ...
+    expect(exchange.settled).toEqual([receipt.uri]);
+    // ... but no balance moved: the ledger was never touched.
+    expect(ledgerApplied).toEqual([]);
+  });
+
   it("parks a receipt on resolve-failed and retries when the missing dep arrives", async () => {
     const jobUri = "at://did:plc:requester/dev.cocore.compute.job/job2";
     const attUri = "at://did:plc:provider/dev.cocore.compute.attestation/att2";

--- a/lexicons/README.md
+++ b/lexicons/README.md
@@ -65,6 +65,34 @@ calls beyond the federated AT Protocol layer:
 Any failure in this chain invalidates the unit of work without requiring
 agreement from any other party.
 
+## Pro bono receipts
+
+A provider can elect to serve work **pro bono** — free, unmetered, and with
+no exchange cut — via the `proBono` policy on its
+`dev.cocore.compute.provider` record:
+
+- `proBono.mode: "any"` serves every requester pro bono.
+- `proBono.mode: "direct"` serves only the requester DIDs in `proBono.dids`
+  (the owner's direct pro bono relationships) and bills everyone else
+  normally. An absent policy, or an unknown `mode`, means pro bono is off —
+  readers fail closed to paid.
+
+Pro bono is purely **additive**: a requester the policy doesn't cover is
+still served as a normal paid job, so opting in never costs the machine paid
+work. The election is the provider's alone — there is no central pro bono
+registry, consistent with the no-coordinator invariant.
+
+When a provider serves a job pro bono it still publishes a signed receipt
+(the provider's PDS stays the source of truth for work done), but the receipt
+carries `proBono: true` and, by invariant, `price.amount: 0` and
+`tokens: { in: 0, out: 0 }` — the work is explicitly not counted, so neither
+figure is a billing claim. The flag is covered by `enclaveSignature`, so the
+carve-out is part of the signed, self-verifying record rather than an
+off-record side channel. A verifier MUST reject a `proBono: true` receipt
+whose price or token counts are non-zero. An exchange settling such a receipt
+takes no fee and moves no balance: `amountCharged`, `providerPayout`, and
+`exchangeFee` are all `0`.
+
 ## Federation invariants
 
 These two properties together are what "no privileged operator" means in

--- a/lexicons/dev/cocore/compute/provider.json
+++ b/lexicons/dev/cocore/compute/provider.json
@@ -122,6 +122,11 @@
             "items": { "type": "string", "format": "did" },
             "description": "Exchange DIDs this provider will accept settlement from. Empty/absent means any exchange is acceptable."
           },
+          "proBono": {
+            "type": "ref",
+            "ref": "#proBonoPolicy",
+            "description": "The owner's pro-bono election for this machine: it serves matching jobs for free — no tokens metered, no exchange cut taken. Owner-written INTENT (set from the console / tray), like `desiredModels`/`active`: the agent reconciles toward it (it serves a matching job pro bono by writing a receipt with `proBono: true`, `price.amount: 0`, and `tokens: { in: 0, out: 0 }`) but NEVER authors it, so it must PRESERVE whatever it finds on every re-publish. Absent ≡ off: the machine meters and bills every job exactly as before. Pro bono is purely ADDITIVE — a requester that does not match the policy is still served as a normal paid job, so opting in never costs the machine paid work. This is the carve-out for explicitly unlimited usage: a matched requester is never metered or charged, and a requester with no balance is admissible against a machine offering them pro bono. Optional / additive; pre-2026-06 agents ignore it."
+          },
           "contactEndpoint": {
             "type": "string",
             "format": "uri",
@@ -178,6 +183,24 @@
             }
           },
           "createdAt": { "type": "string", "format": "datetime" }
+        }
+      }
+    },
+    "proBonoPolicy": {
+      "type": "object",
+      "required": ["mode"],
+      "description": "How this machine holds itself out for pro-bono (free, unmetered, no-cut) work. `mode: any` opts the machine into pro bono for EVERY requester — held out for any pro-bono work. `mode: direct` restricts the carve-out to the requesters listed in `dids` — the owner's direct pro-bono relationships — and serves everyone else as a normal paid job. An absent policy (or an unknown `mode` a reader doesn't understand) means pro bono is off and the machine bills normally; readers MUST fail closed to paid rather than assume free.",
+      "properties": {
+        "mode": {
+          "type": "string",
+          "knownValues": ["any", "direct"],
+          "description": "`any`: serve every requester pro bono. `direct`: serve only the requesters in `dids` pro bono; all others are normal paid jobs."
+        },
+        "dids": {
+          "type": "array",
+          "maxLength": 1024,
+          "items": { "type": "string", "format": "did" },
+          "description": "Requester DIDs this machine serves pro bono when `mode` is `direct` — the owner's explicit pro-bono relationships. Ignored when `mode` is `any` (everyone is already free). Empty/absent under `direct` means the machine currently serves no one pro bono (every job is paid), which is the safe default for a half-configured policy."
         }
       }
     }

--- a/lexicons/dev/cocore/compute/receipt.json
+++ b/lexicons/dev/cocore/compute/receipt.json
@@ -104,6 +104,10 @@
             "type": "ref",
             "ref": "dev.cocore.compute.defs#tier",
             "description": "The confidentiality tier this job actually ran under. Set by the provider to `attested-confidential` only when the input was sealed to a verified, enclave-bound ephemeral session key AND served by a measured native engine under a hardware-attested posture; otherwise `best-effort`. A requester recomputes this from the receipt's attestation + sessionKeyCommitment rather than trusting the field. Optional / additive; absent equivalent to `best-effort`."
+          },
+          "proBono": {
+            "type": "boolean",
+            "description": "True when the provider served this job pro bono under its `dev.cocore.compute.provider.proBono` election — free, unmetered, no exchange cut. A pro-bono receipt MUST carry `price.amount: 0` and `tokens: { in: 0, out: 0 }`: the work is explicitly not counted, so neither figure is a billing claim. An exchange settling a `proBono: true` receipt takes no fee and moves no balance (`amountCharged`, `providerPayout`, and `exchangeFee` are all 0). Covered by `enclaveSignature` like every other field, so the carve-out is part of the signed, self-verifying record rather than an off-record side channel. Absent/false ≡ a normal metered, billable receipt. Optional / additive; pre-2026-06 readers ignore it and still see a well-formed zero-price receipt."
           }
         }
       }

--- a/packages/exchange/src/exchange.ts
+++ b/packages/exchange/src/exchange.ts
@@ -161,13 +161,23 @@ export class Exchange {
     // Fee math (in tokens, not USD). Self-loop receipts get the
     // policy's waiver — typically zero so the user pays nothing
     // extra to run on their own machine via the exchange.
+    //
+    // Pro-bono receipts are the explicit no-cut carve-out: the provider
+    // served the job for free (price.amount is 0, verified to be so by
+    // checkProBonoInvariant above), so the exchange takes no fee and the
+    // settlement is all zeros. Short-circuit BEFORE computeFeeWithSelfLoop —
+    // a non-zero fee floor (minMinor) on a zero-price receipt would otherwise
+    // drive providerShare negative and break amountCharged = payout + fee.
+    const isProBono = receiptIndexed.body.proBono === true;
     const isSelfLoop = jobRow.repo === receiptIndexed.repo;
-    const fee = computeFeeWithSelfLoop(
-      receiptIndexed.body.price.amount,
-      this.cfg.feePolicy,
-      this.cfg.selfLoop,
-      isSelfLoop,
-    );
+    const fee = isProBono
+      ? 0
+      : computeFeeWithSelfLoop(
+          receiptIndexed.body.price.amount,
+          this.cfg.feePolicy,
+          this.cfg.selfLoop,
+          isSelfLoop,
+        );
     const providerShare = receiptIndexed.body.price.amount - fee;
 
     // Build + publish the settlement. The processor reference tags

--- a/packages/exchange/src/pro-bono.test.ts
+++ b/packages/exchange/src/pro-bono.test.ts
@@ -1,0 +1,352 @@
+// Exercises the real `Exchange.onReceipt` pro-bono path end to end —
+// not the fake exchange the pipeline test uses. The point is to cover
+// the `isProBono` short-circuit in `exchange.ts`: a `proBono: true`
+// receipt must settle to all-zero amounts even when the fee policy has
+// a non-zero `minMinor` floor, which on a zero-price receipt would
+// otherwise drive `providerShare` negative (amountCharged 0, fee 5 →
+// payout -5) and break the `amountCharged = payout + fee` invariant.
+//
+// The receipt + attestation are really ES256-signed so the receipt
+// clears `verifyForChargeStrict` before settlement — the same gate the
+// production exchange runs. Crypto helpers mirror validate.test.ts.
+
+import { describe, expect, it } from "vitest";
+import { webcrypto } from "node:crypto";
+
+import { canonicalize } from "@cocore/sdk/canonical";
+import type { IndexedRecord } from "@cocore/sdk";
+import type {
+  AttestationRecord,
+  JobRecord,
+  PaymentAuthorizationRecord,
+  ReceiptRecord,
+} from "@cocore/sdk/types";
+
+import { Exchange } from "./exchange.ts";
+import { SettlementPublisher } from "./publisher.ts";
+
+const { subtle } = webcrypto;
+
+const EX_DID = "did:web:exchange.example";
+const PROVIDER_DID = "did:plc:provider";
+const REQUESTER_DID = "did:plc:requester";
+
+// ── ES256 signing helpers (raw r||s → DER, mirroring a Rust signer) ──
+
+function base64Encode(buf: ArrayBuffer | Uint8Array): string {
+  const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin);
+}
+
+function stripLeadingZeros(b: Uint8Array): Uint8Array {
+  let i = 0;
+  while (i < b.length - 1 && b[i] === 0x00) i++;
+  return b.slice(i);
+}
+
+function encodeDerInteger(b: Uint8Array): Uint8Array {
+  const needsPad = (b[0]! & 0x80) !== 0;
+  const len = b.length + (needsPad ? 1 : 0);
+  const out = new Uint8Array(2 + len);
+  out[0] = 0x02;
+  out[1] = len;
+  if (needsPad) {
+    out[2] = 0x00;
+    out.set(b, 3);
+  } else {
+    out.set(b, 2);
+  }
+  return out;
+}
+
+function rawSigToDer(raw: Uint8Array): Uint8Array {
+  const r = stripLeadingZeros(raw.slice(0, 32));
+  const s = stripLeadingZeros(raw.slice(32, 64));
+  const rEnc = encodeDerInteger(r);
+  const sEnc = encodeDerInteger(s);
+  const seqLen = rEnc.length + sEnc.length;
+  const out = new Uint8Array(2 + seqLen);
+  out[0] = 0x30;
+  out[1] = seqLen;
+  out.set(rEnc, 2);
+  out.set(sEnc, 2 + rEnc.length);
+  return out;
+}
+
+function b64urlDecode(s: string): Uint8Array {
+  const pad = "=".repeat((4 - (s.length % 4)) % 4);
+  const b64 = (s + pad).replace(/-/g, "+").replace(/_/g, "/");
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i += 1) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+interface KeyPair {
+  publicKeyB64: string;
+  signRaw: (msg: Uint8Array) => Promise<Uint8Array>;
+}
+
+async function genP256Keypair(): Promise<KeyPair> {
+  const pair = await subtle.generateKey({ name: "ECDSA", namedCurve: "P-256" }, true, [
+    "sign",
+    "verify",
+  ]);
+  const jwk = (await subtle.exportKey("jwk", pair.publicKey)) as { x: string; y: string };
+  const pubRaw = new Uint8Array(64);
+  pubRaw.set(b64urlDecode(jwk.x), 0);
+  pubRaw.set(b64urlDecode(jwk.y), 32);
+  return {
+    publicKeyB64: base64Encode(pubRaw),
+    async signRaw(msg) {
+      const raw = new Uint8Array(
+        await subtle.sign({ name: "ECDSA", hash: { name: "SHA-256" } }, pair.privateKey, msg),
+      );
+      return rawSigToDer(raw);
+    },
+  };
+}
+
+// ── fixtures ─────────────────────────────────────────────────────────
+
+function fixtureJob(): JobRecord {
+  return {
+    model: "stub",
+    inputCommitment: "a".repeat(64),
+    maxTokensOut: 1000,
+    priceCeiling: { amount: 100, currency: "CC" },
+    acceptedTrustLevel: "self-attested",
+    paymentAuthorization: { uri: `at://${REQUESTER_DID}/auth/1`, cid: "bafyauth" },
+    expiresAt: "2026-05-07T13:00:00Z",
+    createdAt: "2026-05-07T12:00:00Z",
+  };
+}
+
+function fixtureAuth(): PaymentAuthorizationRecord {
+  return {
+    exchange: EX_DID,
+    ceiling: { amount: 100, currency: "CC" },
+    scope: "singleJob",
+    nonce: "a".repeat(32),
+    expiresAt: "2099-01-01T00:00:00Z",
+    createdAt: "2026-05-07T12:00:00Z",
+  };
+}
+
+function baseReceipt(overrides: Partial<ReceiptRecord>): ReceiptRecord {
+  return {
+    job: { uri: `at://${REQUESTER_DID}/job/1`, cid: "bafyjob" },
+    requester: REQUESTER_DID,
+    model: "stub",
+    inputCommitment: "a".repeat(64),
+    outputCommitment: "b".repeat(64),
+    tokens: { in: 32, out: 128 },
+    startedAt: "2026-05-07T12:00:00Z",
+    completedAt: "2026-05-07T12:00:03Z",
+    price: { amount: 50, currency: "CC" },
+    attestation: { uri: `at://${PROVIDER_DID}/attest/1`, cid: "bafyatt" },
+    enclaveSignature: "",
+    ...overrides,
+  };
+}
+
+async function signReceipt(kp: KeyPair, overrides: Partial<ReceiptRecord>): Promise<ReceiptRecord> {
+  const draft = baseReceipt(overrides);
+  const { enclaveSignature: _omit, ...signable } = draft;
+  const sig = await kp.signRaw(new TextEncoder().encode(canonicalize(signable)));
+  return { ...draft, enclaveSignature: base64Encode(sig) };
+}
+
+async function signAttestation(kp: KeyPair): Promise<AttestationRecord> {
+  const draft = {
+    publicKey: kp.publicKeyB64,
+    encryptionPubKey: "BBBB",
+    chipName: "Apple M3 Max",
+    hardwareModel: "Mac15,8",
+    serialNumberHash: "d".repeat(64),
+    osVersion: "15.0",
+    binaryHash: "e".repeat(64),
+    sipEnabled: true,
+    secureBootEnabled: true,
+    secureEnclaveAvailable: true,
+    authenticatedRootEnabled: true,
+    rdmaDisabled: true,
+    attestedAt: "2026-05-07T11:00:00Z",
+    expiresAt: "2026-05-08T11:00:00Z",
+    selfSignature: "",
+  } as unknown as AttestationRecord;
+  const { selfSignature: _omit, ...signable } = draft as unknown as Record<string, unknown>;
+  const sig = await kp.signRaw(new TextEncoder().encode(canonicalize(signable)));
+  return { ...draft, selfSignature: base64Encode(sig) };
+}
+
+function indexed<T>(uri: string, repo: string, collection: string, body: T): IndexedRecord<T> {
+  return {
+    uri,
+    cid: `bafy-${uri.split("/").pop()}`,
+    collection,
+    repo,
+    rkey: uri.split("/").pop() ?? "",
+    body,
+  } as IndexedRecord<T>;
+}
+
+// A fee policy WITH a non-zero floor — the case the isProBono guard
+// protects against. On a zero-price receipt, computeFee would return
+// max(0, 5) = 5, and providerShare would be 0 - 5 = -5 without the guard.
+const FEE_POLICY = { bps: 500, minMinor: 5 };
+
+describe("Exchange pro-bono settlement", () => {
+  it("settles a pro-bono receipt to an all-zero split despite a non-zero fee floor", async () => {
+    // Inspect the SettlementRecord the exchange hands the publisher by
+    // intercepting build() — the strongest assertion that the isProBono
+    // branch produced a conserved all-zero split rather than a negative one.
+    const kp = await genP256Keypair();
+    const receipt = await signReceipt(kp, {
+      proBono: true,
+      price: { amount: 0, currency: "CC" },
+      tokens: { in: 0, out: 0 },
+    });
+    const attestation = await signAttestation(kp);
+
+    const records = new Map<string, IndexedRecord>([
+      [
+        `at://${REQUESTER_DID}/job/1`,
+        indexed(
+          `at://${REQUESTER_DID}/job/1`,
+          REQUESTER_DID,
+          "dev.cocore.compute.job",
+          fixtureJob(),
+        ),
+      ],
+      [
+        `at://${REQUESTER_DID}/auth/1`,
+        indexed(
+          `at://${REQUESTER_DID}/auth/1`,
+          REQUESTER_DID,
+          "dev.cocore.compute.paymentAuthorization",
+          fixtureAuth(),
+        ),
+      ],
+      [
+        `at://${PROVIDER_DID}/attest/1`,
+        indexed(
+          `at://${PROVIDER_DID}/attest/1`,
+          PROVIDER_DID,
+          "dev.cocore.compute.attestation",
+          attestation,
+        ),
+      ],
+    ]);
+
+    const publisher = new SettlementPublisher(EX_DID);
+    const builtSplits: Array<{ charged: number; payout: number; fee: number }> = [];
+    const origBuild = publisher.build.bind(publisher);
+    publisher.build = (inputs) => {
+      builtSplits.push({
+        charged: inputs.amountCharged.amount,
+        payout: inputs.providerPayout.amount,
+        fee: inputs.exchangeFee.amount,
+      });
+      return origBuild(inputs);
+    };
+
+    const exchange = new Exchange({
+      exchangeDid: EX_DID,
+      feePolicy: FEE_POLICY,
+      publisher,
+      resolveRecord: async (uri: string) => records.get(uri) ?? null,
+    });
+
+    const outcome = await exchange.onReceipt(
+      indexed(
+        `at://${PROVIDER_DID}/dev.cocore.compute.receipt/pb2`,
+        PROVIDER_DID,
+        "dev.cocore.compute.receipt",
+        receipt,
+      ),
+    );
+
+    expect(outcome.kind).toBe("settled");
+    expect(builtSplits).toHaveLength(1);
+    // The whole point: zero charged, zero payout, zero fee — NOT charged 0
+    // with fee 5 and payout -5 (which the minMinor floor would have produced
+    // without the isProBono short-circuit). Split conserves: 0 = 0 + 0.
+    expect(builtSplits[0]).toEqual({ charged: 0, payout: 0, fee: 0 });
+  });
+
+  it("still charges the fee floor on a normal (non-pro-bono) receipt", async () => {
+    // Proves the floor is actually active under this policy, so the
+    // all-zero pro-bono result above is the guard's doing, not a no-op.
+    const kp = await genP256Keypair();
+    const receipt = await signReceipt(kp, {
+      price: { amount: 50, currency: "CC" },
+      tokens: { in: 32, out: 128 },
+    });
+    const attestation = await signAttestation(kp);
+
+    const records = new Map<string, IndexedRecord>([
+      [
+        `at://${REQUESTER_DID}/job/1`,
+        indexed(
+          `at://${REQUESTER_DID}/job/1`,
+          REQUESTER_DID,
+          "dev.cocore.compute.job",
+          fixtureJob(),
+        ),
+      ],
+      [
+        `at://${REQUESTER_DID}/auth/1`,
+        indexed(
+          `at://${REQUESTER_DID}/auth/1`,
+          REQUESTER_DID,
+          "dev.cocore.compute.paymentAuthorization",
+          fixtureAuth(),
+        ),
+      ],
+      [
+        `at://${PROVIDER_DID}/attest/1`,
+        indexed(
+          `at://${PROVIDER_DID}/attest/1`,
+          PROVIDER_DID,
+          "dev.cocore.compute.attestation",
+          attestation,
+        ),
+      ],
+    ]);
+
+    const publisher = new SettlementPublisher(EX_DID);
+    const builtSplits: Array<{ charged: number; payout: number; fee: number }> = [];
+    const origBuild = publisher.build.bind(publisher);
+    publisher.build = (inputs) => {
+      builtSplits.push({
+        charged: inputs.amountCharged.amount,
+        payout: inputs.providerPayout.amount,
+        fee: inputs.exchangeFee.amount,
+      });
+      return origBuild(inputs);
+    };
+
+    const exchange = new Exchange({
+      exchangeDid: EX_DID,
+      feePolicy: FEE_POLICY,
+      publisher,
+      resolveRecord: async (uri: string) => records.get(uri) ?? null,
+    });
+
+    const outcome = await exchange.onReceipt(
+      indexed(
+        `at://${PROVIDER_DID}/dev.cocore.compute.receipt/normal1`,
+        PROVIDER_DID,
+        "dev.cocore.compute.receipt",
+        receipt,
+      ),
+    );
+
+    expect(outcome.kind).toBe("settled");
+    // 50 CC at 500 bps = 2 by bps, floored up to minMinor 5 → fee 5, payout 45.
+    expect(builtSplits[0]).toEqual({ charged: 50, payout: 45, fee: 5 });
+  });
+});

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -44,6 +44,12 @@ export interface ProviderRecord {
    *  not opted in (serves exactly as before). Mirrors `desiredModels`. */
   desiredTier?: Tier;
   acceptedExchanges?: string[];
+  /** The owner's pro-bono election: serve matching jobs free, unmetered, with
+   *  no exchange cut. `mode: "any"` serves every requester pro bono; `mode:
+   *  "direct"` serves only the requesters in `dids` (the owner's direct
+   *  pro-bono relationships) and bills everyone else normally. Absent ≡ off.
+   *  Owner-written INTENT, like `desiredModels`/`desiredTier`. */
+  proBono?: ProBonoPolicy;
   contactEndpoint?: string;
   active?: boolean;
   /** True while the agent is still loading its engine after serve start —
@@ -61,6 +67,18 @@ export interface ModelPrice {
   inputPricePerMTok: number;
   outputPricePerMTok: number;
   currency: string;
+}
+
+/** The owner's pro-bono election for a machine. Mirrors the lexicon
+ *  `dev.cocore.compute.provider#proBonoPolicy`. */
+export interface ProBonoPolicy {
+  /** `"any"`: serve every requester pro bono. `"direct"`: serve only the
+   *  requesters in `dids` pro bono; all others are normal paid jobs. An
+   *  unknown value is treated as off (fail closed to paid). */
+  mode: "any" | "direct";
+  /** Requester DIDs served pro bono under `mode: "direct"`. Ignored when
+   *  `mode` is `"any"`. */
+  dids?: string[];
 }
 
 export interface AttestationRecord {
@@ -174,6 +192,12 @@ export interface ReceiptRecord {
   /** Confidentiality tier this job ran under. Recompute from attestation +
    *  sessionKeyCommitment; absent = best-effort. */
   tier?: Tier;
+  /** True when the provider served this job pro bono under its `proBono`
+   *  election — free, unmetered, no exchange cut. A pro-bono receipt MUST
+   *  carry `price.amount: 0` and `tokens: { in: 0, out: 0 }`, and an exchange
+   *  settling it takes no fee and moves no balance. Covered by
+   *  `enclaveSignature`. Absent/false ≡ a normal metered, billable receipt. */
+  proBono?: boolean;
 }
 
 export interface PaymentAuthorizationRecord {

--- a/packages/sdk/src/validate.test.ts
+++ b/packages/sdk/src/validate.test.ts
@@ -119,6 +119,49 @@ test("missing signature fails", () => {
   assert.ok(r.findings.some((f) => f.code === "no-signature"));
 });
 
+test("pro-bono receipt with zero price and zero tokens verifies", () => {
+  // The carve-out for explicitly unlimited usage: free + unmetered.
+  const r = verifyReceipt(
+    fixtureReceipt({
+      proBono: true,
+      price: { amount: 0, currency: "USD" },
+      tokens: { in: 0, out: 0 },
+    }),
+    fixtureJob(),
+    fixtureAttestation(),
+  );
+  assert.equal(r.ok, true, JSON.stringify(r.findings));
+});
+
+test("pro-bono receipt that still charges is rejected", () => {
+  // A provider can't fly the pro-bono flag while billing.
+  const r = verifyReceipt(
+    fixtureReceipt({
+      proBono: true,
+      price: { amount: 50, currency: "USD" },
+      tokens: { in: 0, out: 0 },
+    }),
+    fixtureJob(),
+    fixtureAttestation(),
+  );
+  assert.equal(r.ok, false);
+  assert.ok(r.findings.some((f) => f.code === "pro-bono-nonzero-price"));
+});
+
+test("pro-bono receipt that still meters tokens is rejected", () => {
+  const r = verifyReceipt(
+    fixtureReceipt({
+      proBono: true,
+      price: { amount: 0, currency: "USD" },
+      tokens: { in: 32, out: 128 },
+    }),
+    fixtureJob(),
+    fixtureAttestation(),
+  );
+  assert.equal(r.ok, false);
+  assert.ok(r.findings.some((f) => f.code === "pro-bono-nonzero-tokens"));
+});
+
 const fixtureAuth = (
   overrides: Partial<PaymentAuthorizationRecord> = {},
 ): PaymentAuthorizationRecord => ({

--- a/packages/sdk/src/validate.ts
+++ b/packages/sdk/src/validate.ts
@@ -44,6 +44,30 @@ function err(out: Finding[], code: string, message: string): void {
   out.push({ severity: "error", code, message });
 }
 
+/** A `proBono: true` receipt is the explicit carve-out for free, unmetered
+ *  work: the provider commits to taking no payment and counting no tokens.
+ *  Enforce that invariant so a provider can't fly the pro-bono flag while
+ *  still charging — `price.amount` and both token counts MUST be zero. A
+ *  non-pro-bono receipt is unaffected. Shared by {@link verifyReceipt} and
+ *  {@link verifyForCharge}. */
+function checkProBonoInvariant(receipt: ReceiptRecord, findings: Finding[]): void {
+  if (receipt.proBono !== true) return;
+  if (receipt.price.amount !== 0) {
+    err(
+      findings,
+      "pro-bono-nonzero-price",
+      `receipt.proBono is true but price.amount is ${receipt.price.amount}, not 0`,
+    );
+  }
+  if (receipt.tokens.in !== 0 || receipt.tokens.out !== 0) {
+    err(
+      findings,
+      "pro-bono-nonzero-tokens",
+      `receipt.proBono is true but tokens are { in: ${receipt.tokens.in}, out: ${receipt.tokens.out} }, not zero`,
+    );
+  }
+}
+
 function ok(findings: Finding[]): boolean {
   return findings.every((f) => f.severity !== "error");
 }
@@ -83,6 +107,7 @@ export function verifyReceipt(
       `receipt.price.amount ${receipt.price.amount} exceeds priceCeiling ${job.priceCeiling.amount}`,
     );
   }
+  checkProBonoInvariant(receipt, findings);
 
   const completedAt = Date.parse(receipt.completedAt);
   const jobExpires = Date.parse(job.expiresAt);
@@ -282,6 +307,7 @@ export function verifyForCharge(ctx: PreChargeContext, inputs: PreChargeInputs):
       `receipt.price.amount ${receipt.price.amount} > authorization.ceiling ${authorization.ceiling.amount}`,
     );
   }
+  checkProBonoInvariant(receipt, findings);
   if (
     job.acceptedExchanges &&
     job.acceptedExchanges.length > 0 &&

--- a/provider/src/advisor.rs
+++ b/provider/src/advisor.rs
@@ -24,7 +24,7 @@ use crate::crypto::ProviderKeypair;
 use crate::engines::{DeltaChannel, Engine, EngineRegistry};
 use crate::error::{ProviderError, Result};
 use crate::hypervisor;
-use crate::pds::PdsClient;
+use crate::pds::{PdsClient, ProBonoPolicy};
 use crate::pricing;
 use crate::protocol::{
     AdvisorMessage, AttestationChallenge, AttestationResponse, ChunkChannel,
@@ -85,6 +85,12 @@ struct ServeContext<'a> {
     /// falling back to the stub (which would let the stub-engine's
     /// echo masquerade as a real model's reply).
     engines: &'a EngineRegistry,
+    /// The owner's pro-bono election, read from this machine's provider
+    /// record at serve start. A request from a requester this policy
+    /// matches is served free: the receipt carries `proBono: true` with a
+    /// zero price and zero token counts, and the exchange takes no cut.
+    /// An off / non-matching policy serves the job as a normal paid job.
+    pro_bono: &'a ProBonoPolicy,
 }
 
 impl AdvisorClient {
@@ -128,6 +134,10 @@ impl AdvisorClient {
         // that never registered for push — the corresponding `select!` arm is
         // then inert and the loop behaves exactly as before.
         mut push_rx: Option<&mut mpsc::UnboundedReceiver<String>>,
+        // The owner's pro-bono election, read from this machine's provider
+        // record at serve start. Threaded into `ServeContext` so each job
+        // can decide, per requester, whether to serve free + unmetered.
+        pro_bono: &ProBonoPolicy,
     ) -> Result<()> {
         tracing::info!(url = %self.url, "connecting to advisor");
         let (ws, _resp) =
@@ -174,6 +184,7 @@ impl AdvisorClient {
             pds,
             attestation,
             engines,
+            pro_bono,
         };
         // A shared reference the per-job futures copy in (each `async move`
         // would otherwise move `ctx` itself, leaving none for the next job).
@@ -1169,18 +1180,36 @@ async fn handle_inference_request_inner(
         topPMilli: None,
     };
 
+    // Pro bono decision: if the owner has elected to serve this requester
+    // for free, the job is explicitly NOT counted — we publish a receipt
+    // (the provider's PDS stays the source of truth for work done) but with
+    // zero tokens and a zero price, and flag it so the exchange takes no cut.
+    // A non-matching / off policy falls through to normal metering below.
+    let pro_bono = ctx.pro_bono.applies_to(&req.requester_did);
+
     let rate = pricing::rate_for(&req.model);
-    let tokens_in = if engine_tokens_in > 0 {
-        engine_tokens_in
+    let (tokens_in, tokens_out, price_minor) = if pro_bono {
+        tracing::info!(
+            session_id = %session_id,
+            requester = %req.requester_did,
+            mode = %ctx.pro_bono.mode,
+            "serving job pro bono — unmetered, zero price, no exchange cut",
+        );
+        (0u64, 0u64, 0u64)
     } else {
-        pricing::estimate_tokens(&plaintext)
+        let tokens_in = if engine_tokens_in > 0 {
+            engine_tokens_in
+        } else {
+            pricing::estimate_tokens(&plaintext)
+        };
+        let tokens_out = if engine_tokens_out > 0 {
+            engine_tokens_out
+        } else {
+            pricing::estimate_tokens(reply.as_bytes())
+        };
+        let price_minor = pricing::price_minor(rate, tokens_in, tokens_out);
+        (tokens_in, tokens_out, price_minor)
     };
-    let tokens_out = if engine_tokens_out > 0 {
-        engine_tokens_out
-    } else {
-        pricing::estimate_tokens(reply.as_bytes())
-    };
-    let price_minor = pricing::price_minor(rate, tokens_in, tokens_out);
 
     let (receipt_uri, receipt_commit) = match (req.job_cid.as_ref(), ctx.attestation) {
         (Some(job_cid), Some(attestation)) => publish_stub_receipt(
@@ -1201,6 +1230,7 @@ async fn handle_inference_request_inner(
                 amount: price_minor,
                 currency: rate.currency.into(),
             },
+            pro_bono,
         )
         .await
         .unwrap_or_default(),
@@ -1303,6 +1333,7 @@ async fn publish_stub_receipt(
     tokens_in: u64,
     tokens_out: u64,
     price: Money,
+    pro_bono: bool,
 ) -> std::result::Result<(String, Option<crate::pds::RepoCommit>), ()> {
     let inputs = ReceiptInputs {
         job: StrongRef {
@@ -1323,6 +1354,7 @@ async fn publish_stub_receipt(
         completed_at,
         price,
         attestation: attestation.clone(),
+        pro_bono,
     };
     let (record, _canonical) = match receipt::build(inputs, ctx.signer) {
         Ok(t) => t,
@@ -1661,6 +1693,15 @@ mod tests {
         })
     }
 
+    /// An "off" pro-bono policy shared by the test contexts below — no
+    /// requester is served pro bono, so these tests exercise the normal
+    /// metered path. Returned as `'static` so `ctx` can hand `ServeContext`
+    /// a reference without each call site owning a binding.
+    fn off_pro_bono() -> &'static ProBonoPolicy {
+        static P: std::sync::OnceLock<ProBonoPolicy> = std::sync::OnceLock::new();
+        P.get_or_init(ProBonoPolicy::default)
+    }
+
     fn ctx<'a>(
         signer: &'a dyn SigningIdentity,
         kp: &'a ProviderKeypair,
@@ -1674,6 +1715,7 @@ mod tests {
             pds,
             attestation,
             engines,
+            pro_bono: off_pro_bono(),
         }
     }
 

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -3,7 +3,7 @@ use clap::{Parser, Subcommand};
 use cocore_provider::{
     advisor::AdvisorClient,
     attestation, oauth,
-    pds::{EngineFault, ModelPrice, PdsClient, ProviderRecord, TrustLevel},
+    pds::{EngineFault, ModelPrice, PdsClient, ProBonoPolicy, ProviderRecord, TrustLevel},
     pricing,
     protocol::Register,
     receipt::StrongRef,
@@ -539,6 +539,10 @@ fn preserve_console_fields(record: &mut ProviderRecord, existing: &serde_json::V
         .get("desiredTier")
         .and_then(|v| v.as_str())
         .map(str::to_string);
+    // The owner's pro-bono election (console / tray "serve pro bono"). Like
+    // the others it's console-written; carry it through or a serve restart
+    // would silently drop the owner's choice to give work away free.
+    record.proBono = ProBonoPolicy::from_record_value(existing);
 }
 
 /// Find this machine's existing provider record (if any) on the
@@ -1032,6 +1036,9 @@ async fn cmd_serve(
             active: None,
             desiredModels: None,
             desiredTier: None,
+            // Owner's pro-bono election — preserved from the existing record
+            // by dedup, like active/desiredModels/desiredTier.
+            proBono: None,
             provisioning: Some(true),
             // NOT serving yet: this record is published immediately (so the
             // machine is visible) while the engine is still loading/downloading.
@@ -1076,26 +1083,33 @@ async fn cmd_serve(
     // of an unmeasured Python child, defeating the tier). We still read
     // `desiredModels` below so a change still triggers a reload restart.
     let confidential = push_rx.is_some();
-    let (desired_at_start, desired_tier_at_start): (Vec<String>, Option<String>) =
-        match find_my_provider_record(&pds, &attestation_pub_key).await {
-            Ok((_, value, _)) => {
-                let models = value
-                    .get("desiredModels")
-                    .and_then(|v| v.as_array())
-                    .map(|a| {
-                        a.iter()
-                            .filter_map(|m| m.as_str().map(str::to_string))
-                            .collect()
-                    })
-                    .unwrap_or_default();
-                let tier = value
-                    .get("desiredTier")
-                    .and_then(|v| v.as_str())
-                    .map(str::to_string);
-                (models, tier)
-            }
-            Err(_) => (Vec::new(), None),
-        };
+    let (desired_at_start, desired_tier_at_start, pro_bono_at_start): (
+        Vec<String>,
+        Option<String>,
+        ProBonoPolicy,
+    ) = match find_my_provider_record(&pds, &attestation_pub_key).await {
+        Ok((_, value, _)) => {
+            let models = value
+                .get("desiredModels")
+                .and_then(|v| v.as_array())
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|m| m.as_str().map(str::to_string))
+                        .collect()
+                })
+                .unwrap_or_default();
+            let tier = value
+                .get("desiredTier")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+            // The owner's pro-bono election, read off our own record so each
+            // served job can decide per-requester whether it's free. Absent /
+            // malformed ≡ off (every job metered + billed).
+            let pro_bono = ProBonoPolicy::from_record_value(&value).unwrap_or_default();
+            (models, tier, pro_bono)
+        }
+        Err(_) => (Vec::new(), None, ProBonoPolicy::default()),
+    };
     match inference_models_action(confidential, &desired_at_start) {
         InferenceModelsAction::Clear => {
             // Confidential = native-only. Inference MUST stay inside the
@@ -1331,6 +1345,8 @@ async fn cmd_serve(
         desiredModels: None,
         // Owner's confidential opt-in — preserved by dedup like the others.
         desiredTier: None,
+        // Owner's pro-bono election — preserved by dedup like the others.
+        proBono: None,
         // Engine is loaded by this point — clear the provisioning flag we
         // set on the early publish above, so the console flips the row
         // from "provisioning" to live.
@@ -1493,6 +1509,7 @@ async fn cmd_serve(
                             &model_schedules,
                             &configured_models,
                             push_rx.as_mut(),
+                            &pro_bono_at_start,
                         )
                         .await;
                     let lived = connected_at.elapsed();
@@ -1552,7 +1569,7 @@ async fn cmd_serve(
                         );
                         let client = AdvisorClient::new(advisor_url);
                         tokio::select! {
-                            res = client.run(register.clone(), &*signer, &enc, &pds, attestation, &eng, provider_rkey.as_deref(), &desired_at_start, desired_tier_at_start.as_deref(), &model_schedules, &configured_models, push_rx.as_mut()) => {
+                            res = client.run(register.clone(), &*signer, &enc, &pds, attestation, &eng, provider_rkey.as_deref(), &desired_at_start, desired_tier_at_start.as_deref(), &model_schedules, &configured_models, push_rx.as_mut(), &pro_bono_at_start) => {
                                 if let Err(e) = res {
                                     tracing::warn!(error = %e, "advisor run ended; reconnecting within window in 5s");
                                 }
@@ -2453,6 +2470,7 @@ mod offline_marker_tests {
             active: None,
             desiredModels: None,
             desiredTier: None,
+            proBono: None,
             provisioning: Some(false),
             serving: Some(true),
             engineFault: None,

--- a/provider/src/pds.rs
+++ b/provider/src/pds.rs
@@ -114,6 +114,14 @@ pub struct ProviderRecord {
     /// in, serves exactly as before.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub desiredTier: Option<String>,
+    /// The owner's pro-bono election: serve matching jobs free, unmetered,
+    /// no exchange cut. Owner-written INTENT, like `desiredModels`/`active`/
+    /// `desiredTier`: the agent reconciles toward it (a matching job gets a
+    /// `proBono: true`, zero-price, zero-token receipt) but NEVER authors it,
+    /// so it must PRESERVE whatever it finds on every re-publish. Absent ≡
+    /// off (every job is metered and billed).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proBono: Option<ProBonoPolicy>,
     /// True while the agent is still loading its inference engine. Set on
     /// the early "provisioning" publish at serve start so the machine
     /// appears on the console immediately; cleared (set false) on the
@@ -134,6 +142,43 @@ pub struct ProviderRecord {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub engineFault: Option<EngineFault>,
     pub createdAt: chrono::DateTime<chrono::Utc>,
+}
+
+/// The owner's pro-bono election for a machine, mirroring the lexicon
+/// `dev.cocore.compute.provider#proBonoPolicy`. Decides, per requester,
+/// whether a job is served free + unmetered with no exchange cut.
+#[allow(non_snake_case)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct ProBonoPolicy {
+    /// `any` — every requester is served pro bono. `direct` — only the
+    /// requesters in `dids` are. Any other / empty value is treated as
+    /// off (paid), failing closed.
+    pub mode: String,
+    /// Requester DIDs served pro bono under `mode: direct`. Ignored when
+    /// `mode` is `any`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dids: Vec<String>,
+}
+
+impl ProBonoPolicy {
+    /// Does this policy serve `requester_did` pro bono? `any` ⇒ always;
+    /// `direct` ⇒ only when the DID is listed; anything else ⇒ never.
+    /// Fails closed (paid) on an unrecognized mode.
+    pub fn applies_to(&self, requester_did: &str) -> bool {
+        match self.mode.as_str() {
+            "any" => true,
+            "direct" => self.dids.iter().any(|d| d == requester_did),
+            _ => false,
+        }
+    }
+
+    /// Parse a policy from a raw provider-record JSON value (the shape
+    /// `find_my_provider_record` returns). Returns `None` when the field
+    /// is absent or malformed — both equivalent to "no pro bono".
+    pub fn from_record_value(value: &serde_json::Value) -> Option<Self> {
+        let obj = value.get("proBono")?;
+        serde_json::from_value(obj.clone()).ok()
+    }
 }
 
 /// A content-safe description of why the inference engine failed to
@@ -557,6 +602,54 @@ impl PdsClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn pro_bono_mode_any_serves_everyone() {
+        let p = ProBonoPolicy {
+            mode: "any".into(),
+            dids: vec![],
+        };
+        assert!(p.applies_to("did:plc:anyone"));
+        assert!(p.applies_to("did:plc:someone-else"));
+    }
+
+    #[test]
+    fn pro_bono_mode_direct_serves_only_listed_dids() {
+        let p = ProBonoPolicy {
+            mode: "direct".into(),
+            dids: vec!["did:plc:friend".into()],
+        };
+        assert!(p.applies_to("did:plc:friend"));
+        // A non-listed requester is NOT pro bono — served as a normal paid job.
+        assert!(!p.applies_to("did:plc:stranger"));
+    }
+
+    #[test]
+    fn pro_bono_off_and_unknown_modes_fail_closed() {
+        // Absent policy ≡ default ≡ off.
+        assert!(!ProBonoPolicy::default().applies_to("did:plc:anyone"));
+        // An unrecognized mode (e.g. a future value) fails closed to paid.
+        let weird = ProBonoPolicy {
+            mode: "future-mode".into(),
+            dids: vec!["did:plc:friend".into()],
+        };
+        assert!(!weird.applies_to("did:plc:friend"));
+    }
+
+    #[test]
+    fn pro_bono_from_record_value_parses_and_tolerates_absence() {
+        let rec = serde_json::json!({
+            "machineLabel": "m",
+            "proBono": { "mode": "direct", "dids": ["did:plc:a", "did:plc:b"] }
+        });
+        let p = ProBonoPolicy::from_record_value(&rec).expect("policy present");
+        assert_eq!(p.mode, "direct");
+        assert!(p.applies_to("did:plc:b"));
+
+        // No proBono field → None (off).
+        let bare = serde_json::json!({ "machineLabel": "m" });
+        assert!(ProBonoPolicy::from_record_value(&bare).is_none());
+    }
 
     fn fake_session(api_base: &str) -> Session {
         Session {

--- a/provider/src/pds.rs
+++ b/provider/src/pds.rs
@@ -147,7 +147,6 @@ pub struct ProviderRecord {
 /// The owner's pro-bono election for a machine, mirroring the lexicon
 /// `dev.cocore.compute.provider#proBonoPolicy`. Decides, per requester,
 /// whether a job is served free + unmetered with no exchange cut.
-#[allow(non_snake_case)]
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct ProBonoPolicy {
     /// `any` — every requester is served pro bono. `direct` — only the

--- a/provider/src/receipt.rs
+++ b/provider/src/receipt.rs
@@ -55,6 +55,14 @@ pub struct ReceiptInputs {
     pub completed_at: DateTime<Utc>,
     pub price: Money,
     pub attestation: StrongRef,
+    /// True when this job was served pro bono under the provider's
+    /// `proBono` election — free, unmetered, no exchange cut. When set,
+    /// the caller MUST pass `price.amount == 0` and `tokens_in ==
+    /// tokens_out == 0`; the work is explicitly not counted. Emitted as
+    /// `proBono: true` and covered by the enclave signature so the
+    /// carve-out is part of the signed record. `false` omits the field
+    /// entirely (a normal metered receipt).
+    pub pro_bono: bool,
 }
 
 /// Sampling parameters committed to in a receipt. Integer-only because
@@ -95,6 +103,12 @@ pub struct ReceiptRecord {
     pub completedAt: String,
     pub price: MoneyValue,
     pub attestation: StrongRefValue,
+    /// Present (as `true`) only when this job was served pro bono.
+    /// Omitted on a normal metered receipt so the byte layout — and
+    /// thus the signed canonical form — is identical to a pre-proBono
+    /// record.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub proBono: bool,
     /// Base64 of the DER-encoded ECDSA-P256 signature over the
     /// canonical bytes of every other field in this record.
     pub enclaveSignature: String,
@@ -171,6 +185,15 @@ pub fn build(
             .unwrap()
             .insert("outputCipherURL".into(), Value::String(url.clone()));
     }
+    // Only emit `proBono` when true, mirroring the typed record's
+    // `skip_serializing_if` — a normal receipt canonicalises to the
+    // exact bytes a pre-proBono verifier derives.
+    if inputs.pro_bono {
+        unsigned
+            .as_object_mut()
+            .unwrap()
+            .insert("proBono".into(), Value::Bool(true));
+    }
     let canonical = to_canonical_bytes(&unsigned)?;
     let sig = signer
         .sign(&canonical)
@@ -204,6 +227,7 @@ pub fn build(
                 uri: inputs.attestation.uri,
                 cid: inputs.attestation.cid,
             },
+            proBono: inputs.pro_bono,
             enclaveSignature: B64.encode(&sig),
         },
         canonical,
@@ -247,6 +271,7 @@ mod tests {
                 uri: "at://did:plc:p/dev.cocore.compute.attestation/1".into(),
                 cid: "bafyatt".into(),
             },
+            pro_bono: false,
         }
     }
 
@@ -348,6 +373,46 @@ mod tests {
         let sig = Signature::from_der(&sig_der).unwrap();
         vk.verify(&message, &sig)
             .expect("signature must verify with cipher commitment + params present");
+    }
+
+    #[test]
+    fn pro_bono_field_present_and_signed_when_set() {
+        let signer = load_or_create_identity().unwrap();
+
+        // A normal receipt omits proBono entirely — byte-identical to a
+        // pre-proBono record so old verifiers see the same canonical form.
+        let (rec, _) = build(fixture(chrono::Utc::now()), &*signer).unwrap();
+        let body = serde_json::to_value(&rec).unwrap();
+        assert!(body.get("proBono").is_none());
+
+        // A pro-bono receipt: free + unmetered, so price and tokens are zero.
+        let mut inputs = fixture(chrono::Utc::now());
+        inputs.pro_bono = true;
+        inputs.tokens_in = 0;
+        inputs.tokens_out = 0;
+        inputs.price = Money {
+            amount: 0,
+            currency: "CC".into(),
+        };
+        let (rec, _) = build(inputs, &*signer).unwrap();
+        let mut signed = serde_json::to_value(&rec).unwrap();
+        assert_eq!(signed["proBono"], json!(true));
+        assert_eq!(signed["price"]["amount"], json!(0));
+        assert_eq!(signed["tokens"], json!({ "in": 0, "out": 0 }));
+
+        // The flag is covered by the signature (verifies against record minus sig).
+        signed.as_object_mut().unwrap().remove("enclaveSignature");
+        let message = to_canonical_bytes(&signed).unwrap();
+        let sig_der = B64.decode(rec.enclaveSignature.as_bytes()).unwrap();
+        let pub_raw = B64.decode(signer.public_key_b64()).unwrap();
+        let mut uncompressed = [0u8; 65];
+        uncompressed[0] = 0x04;
+        uncompressed[1..].copy_from_slice(&pub_raw);
+        let point = EncodedPoint::from_bytes(uncompressed).unwrap();
+        let vk = VerifyingKey::from_encoded_point(&point).unwrap();
+        let sig = Signature::from_der(&sig_der).unwrap();
+        vk.verify(&message, &sig)
+            .expect("signature must verify with proBono present");
     }
 
     #[test]

--- a/provider/tests/cross_lang_fixture.rs
+++ b/provider/tests/cross_lang_fixture.rs
@@ -59,6 +59,9 @@ fn writes_cross_lang_fixture() {
             uri: "at://did:plc:provider/dev.cocore.compute.attestation/x".into(),
             cid: "bafyatt".into(),
         },
+        // Off here too — a metered receipt omits proBono, keeping the pinned
+        // canonical bytes identical to a pre-proBono record.
+        pro_bono: false,
     };
     let (record, canonical) = build(inputs, &*signer).unwrap();
 


### PR DESCRIPTION
## What

A "pro bono" carve-out for chat completions. A provider can elect to hold a machine out for **free, unmetered, no-cut** work — either for **any** requester, or only for its **direct pro bono relationships**. When a job qualifies, we don't count tokens at all and the exchange takes no cut: the carve-out for explicitly unlimited usage.

Two design decisions (confirmed up front):
- **Direct relationships** are a provider-side DID allowlist on the provider record (points provider→requester — the correct direction for "I serve these people free"), not reused `account.friend` records.
- Pro bono is **purely additive**: a requester who is *not* on the list is still served as a normal paid job, so opting in never costs the machine paid work.

## How it maps to the invariants

- **Provider's PDS is the source of truth.** A pro bono job still produces a provider-signed receipt; it just carries `proBono: true`, `price.amount: 0`, and `tokens: { in: 0, out: 0 }`. The flag is covered by `enclaveSignature`, so the carve-out is part of the signed, self-verifying record — not an off-record side channel.
- **Lexicons evolve additively.** New optional `proBono` policy on `provider`, new optional `proBono` boolean on `receipt`. Pre-2026-06 readers ignore both and still see a well-formed zero-price receipt. Unknown `mode` values fail closed to paid.
- **No coordinator.** The election lives on the provider's own record and the decision is made locally by the agent per request.

## Changes

**Lexicon (spec)**
- `provider.json` — `proBono` policy: `mode: any|direct` + `dids` allowlist. Owner-written intent, absent ≡ off.
- `receipt.json` — optional `proBono` boolean; a pro bono receipt MUST be zero-price and zero-token.

**Provider (Rust)**
- `ProBonoPolicy` on the provider record, read at serve start and preserved on re-publish like `desiredModels`/`desiredTier`.
- `handle_inference_request` decides per-requester (`mode: any` ⇒ everyone; `direct` ⇒ listed DIDs only); when pro bono it zeroes tokens + price and stamps `proBono: true` on the signed receipt.

**Exchange / SDK (TS)**
- `exchange.onReceipt` short-circuits fee / payout / charge to zero for a pro bono receipt — **before** the fee floor (`minMinor`) could otherwise drive the split negative on a zero-price receipt.
- `validate` enforces `proBono ⇒ price.amount === 0 && tokens === {0,0}` in both `verifyReceipt` and `verifyForCharge`.
- The settlement pipeline already moves no balance for a zero-price receipt, so no tokens flow.

## Tests

- Rust: receipt signing covers `proBono`; policy predicate for `any`/`direct`/off + unknown-mode fail-closed; `from_record_value` parsing.
- TS: SDK invariant (zero-price/zero-token passes; charging or metering under the flag is rejected); pipeline test proving a pro bono receipt **settles but moves zero tokens**.
- Full provider lib suite (141), SDK (117), exchange (31), services (12), cross-lang fixtures, and all-workspace typecheck pass.

## Follow-up (not in this PR)

- Console UI toggle to set the election (the owner-written field plugs into the same `desiredModels`/`desiredTier` console-write + agent-preserve pattern; `ProviderRecord` already carries `proBono` in the shared SDK types).
- Optional matchmaker/admission change so a zero-balance requester is routed to / admitted against a machine offering them pro bono.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCKjd7D5veRG1n5ixLPJ7p

---
_Generated by [Claude Code](https://claude.ai/code/session_01HCKjd7D5veRG1n5ixLPJ7p)_