### PR TITLE
fix(dispatch): don't prefer an own machine for a model it can't serve (#103)

### DIFF
--- a/packages/sdk/src/provider-selection.test.ts
+++ b/packages/sdk/src/provider-selection.test.ts
@@ -22,9 +22,14 @@ describe("ownMachineCandidates", () => {
     expect(ownMachineCandidates([mineOtherModel], ME, "m", new Set())).toEqual([]);
   });
 
-  it("treats a machine advertising no models as serving everything", () => {
-    const wildcard = { did: ME, supportedModels: [], lastSeen: "2026-01-05T00:00:00Z" };
-    expect(ownMachineCandidates([wildcard], ME, "m", new Set())).toEqual([wildcard]);
+  it("does NOT prefer an own machine that advertises no models (must match explicitly)", () => {
+    // An empty supportedModels means the agent has no health-gated engine to
+    // serve, so self-preference must NOT grab it — that would route the job to
+    // a box that hits its for_model miss and completes without a receipt
+    // (the job then sits pending → expired; graze-social/cocore#103). Falling
+    // through to [] lets the open pool find a provider that actually serves it.
+    const empty = { did: ME, supportedModels: [], lastSeen: "2026-01-05T00:00:00Z" };
+    expect(ownMachineCandidates([empty], ME, "m", new Set())).toEqual([]);
   });
 
   it("excludes own DIDs already burned by a prior failover attempt", () => {

--- a/packages/sdk/src/provider-selection.ts
+++ b/packages/sdk/src/provider-selection.ts
@@ -27,10 +27,7 @@ export function ownMachineCandidates<
 >(attested: T[], requesterDid: string, model: string, excludeDids: Set<string>): T[] {
   return attested
     .filter(
-      (c) =>
-        c.did === requesterDid &&
-        !excludeDids.has(c.did) &&
-        c.supportedModels.includes(model),
+      (c) => c.did === requesterDid && !excludeDids.has(c.did) && c.supportedModels.includes(model),
     )
     .sort((a, b) => Date.parse(b.lastSeen) - Date.parse(a.lastSeen));
 }

--- a/packages/sdk/src/provider-selection.ts
+++ b/packages/sdk/src/provider-selection.ts
@@ -2,7 +2,26 @@
 // cores.
 
 /** The requester's own machines that serve `model` and haven't been burned by a
- *  prior failover attempt, freshest-heartbeat first. */
+ *  prior failover attempt, freshest-heartbeat first.
+ *
+ *  Self-preference requires an EXPLICIT model match — `supportedModels` must
+ *  list `model`. We deliberately do NOT honor the "empty list ⇒ serves
+ *  everything" wildcard the open-pool filter uses, because preferring your own
+ *  machine is only a win when it can actually run the model:
+ *
+ *    * An agent advertises its health-gated `live_models()` set, so an empty
+ *      list means it has NO serveable engine right now — preferring it would
+ *      route the job to a box that can't serve it.
+ *    * The provider then hits its `for_model` miss path: it seals a
+ *      human-readable "no engine loaded for model X" string as the answer and
+ *      completes WITHOUT publishing a receipt. The OpenAI client sees a 200,
+ *      but the job never gets a receipt, so the dashboard shows it stuck in
+ *      `pending` until it `expires` (graze-social/cocore#103).
+ *
+ *  Falling through (returning []) sends the job to the open pool, where a
+ *  provider that genuinely serves the model writes a receipt as normal. This
+ *  matches #98's stated intent: prefer self "when providing a requested
+ *  model" — not for models self can't provide. */
 export function ownMachineCandidates<
   T extends { did: string; supportedModels: string[]; lastSeen: string },
 >(attested: T[], requesterDid: string, model: string, excludeDids: Set<string>): T[] {
@@ -11,7 +30,7 @@ export function ownMachineCandidates<
       (c) =>
         c.did === requesterDid &&
         !excludeDids.has(c.did) &&
-        (c.supportedModels.length === 0 || c.supportedModels.includes(model)),
+        c.supportedModels.includes(model),
     )
     .sort((a, b) => Date.parse(b.lastSeen) - Date.parse(a.lastSeen));
 }


### PR DESCRIPTION
## What & why

Fixes the bookkeeping side of #103: jobs that return output but sit in `pending` for hours, then flip to `expired`.

### Root cause

`/jobs` status is derived **solely** from a joined, indexed receipt (`packages/console/src/components/jobs/jobs.server.ts`). The provider streams the answer and emits `InferenceComplete` **independently** of whether a receipt was written — so "the agent loop succeeds" and "the job got a receipt" are decoupled. Any path that returns tokens without publishing a receipt looks exactly like the report: output to the client, `pending → expired` on the dashboard.

#98 (`prefer-own-machine`, merged to `main` 2026-06-24 03:58Z — ~27h before #103 was filed) added self-machine preference but reused the **open-pool** filter's wildcard:

```ts
c.supportedModels.length === 0 || c.supportedModels.includes(model)
```

For self-preference the `length === 0 ⇒ "serves everything"` arm is wrong. An agent advertises its **health-gated** `live_models()` set, so an empty list means it has *no* serveable engine right now. Preferring it anyway routes the job to a box that hits its `for_model` miss (`provider/src/advisor.rs:967`), which:

1. seals a human-readable `"[cocore provider] this provider has no engine loaded for model 'X'. Loaded models: …"` string as the **answer**, and
2. emits `InferenceComplete` with an **empty `receipt_uri` and no receipt published** (returns early, before the receipt block).

The OpenAI client sees a 200 with assistant content and keeps looping — so it looks like it's working — but no receipt is ever indexed, so the job expires. This matches #103 exactly: the requester asked for a model (`mlx-community/gemma-3-4b-it-qat-4bit`) their **own** machine wasn't serving.

### The fix

`ownMachineCandidates` now requires an **explicit** `supportedModels.includes(model)` match. A non-match falls through (returns `[]`) to the open pool, where a provider that actually serves the model writes a receipt as normal. This matches #98's stated intent — prefer self *"when providing a requested model"*, not for models self can't provide.

Scoped to the shared pure helper (`packages/sdk/src/provider-selection.ts`), so **both** dispatch cores (console + appview) pick it up. The **open-pool** filter keeps the legacy empty-list wildcard unchanged — only self-preference is tightened.

## Test

Updated `provider-selection.test.ts`: the case that asserted an empty-`supportedModels` own machine "serves everything" now asserts it is **not** preferred (falls through to the open pool). `pnpm --filter @cocore/sdk test provider-selection` → 4 passed.

## Scope / follow-ups (not in this PR)

This fixes the *routing regression*. The deeper issue remains worth a separate change: a provider that hits a `for_model` miss returns a **200-with-error-text and no receipt** instead of a proper error, so the failure is invisible at the OpenAI layer. Options to harden, for discussion:
- have the model-miss path surface a real dispatch error (so the client gets a 404 `model_not_found`, not a fake completion), and/or
- never advertise a model the agent can't actually `for_model`-resolve (tighten the advertised set / advisor matchmaking so a miss can't be routed in the first place).

Separately, the agent-side causes from the same window (secure-mode attestation build/publish failures → `ctx.attestation = None` → receipts disabled session-wide; and the #90 duplicate-confidential-worker churn) were fixed in releases ≥0.9.26 / #100–#101, so those are addressed by an agent upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCJ48hRgcDhAf13u13sBra)_