### PR TITLE
Wire up region routing + pro-bono path in the product and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,31 @@ Either way the agent pairs to your identity, attests the machine, loads a
 local model, and starts publishing receipts as it earns. See
 [`docs/install-mac.md`](docs/install-mac.md) for the details.
 
+## Choosing where (and how) a job runs
+
+The completions API and the in-app chat take optional routing controls beyond
+just the model:
+
+- **By country.** Pass a `country` (ISO 3166-1 alpha-2, e.g. `US`) to route
+  only to providers advertising that coarse region. A machine opts into
+  publishing its country from its per-machine settings on the website (the
+  agent then geolocates the machine's IP and refreshes it each time it serves);
+  it's an advisory, self-asserted hint — a VPN moves it — so requests fail
+  closed (`no_providers_for_country`) rather than silently routing elsewhere.
+- **Pro bono.** The pro-bono completion path
+  (`POST /v1/probono/chat/completions`, or the toggle in chat) routes only to
+  providers that have elected to serve you for free. A provider configures this
+  per machine on the website: off, free for *anyone*, or free for an explicit
+  list of people (friends-only). Pro-bono jobs are unmetered and take no
+  exchange cut, so a balance-less requester can still be served.
+- **Verified / friends-only.** `/v1/verified/...` and `/v1/private/...` are the
+  existing trust- and friend-constrained paths.
+
+Full reference: the OpenAPI spec at
+[`packages/console/public/openapi.yaml`](packages/console/public/openapi.yaml)
+(also rendered at `console.cocore.dev/docs`) and the lexicon notes in
+[`lexicons/README.md`](lexicons/README.md).
+
 ## What's in here
 
 The lexicon is the source of truth. Everything else exists to make it

--- a/lexicons/README.md
+++ b/lexicons/README.md
@@ -93,6 +93,37 @@ whose price or token counts are non-zero. An exchange settling such a receipt
 takes no fee and moves no balance: `amountCharged`, `providerPayout`, and
 `exchangeFee` are all `0`.
 
+The `proBono` policy is **owner-written intent** (set from the console / a
+management UI), preserved by the agent across re-publishes like
+`desiredModels` / `desiredTier`. A requester can deliberately seek out a free
+machine via the **pro-bono completion path** (`/v1/probono/chat/completions`),
+which routes only to providers whose policy serves that requester; because a
+pro-bono receipt moves no balance, a requester with no token balance can still
+be served there.
+
+## Coarse location (region)
+
+A machine can **opt in** to publishing its coarse country, an ISO 3166-1
+alpha-2 code, so requesters can route to nearby compute:
+
+- `shareLocation` (boolean) on the `dev.cocore.compute.provider` record is the
+  owner's opt-in, set from the console. Owner-written intent, preserved by the
+  agent across re-publishes (like `proBono` / `desiredTier`).
+- When `shareLocation` is on, the agent resolves the machine's country from a
+  best-effort public-IP geolocation at serve start and stamps `region`
+  (plus `regionSource` and `regionObservedAt`), refreshed on every serve. When
+  it is off, those fields are omitted, so opting out drops the value on the
+  next re-publish.
+
+`region` is **advisory and self-asserted** (same trust posture as `tier`): a
+VPN or proxy moves it, and there is no signed-location primitive, so a verifier
+MUST NOT gate anything security-relevant on it. It exists purely as a routing
+hint. Requesters narrow by it with the `country` parameter on the completions
+endpoints; a provider that isn't sharing a region is never matched by a country
+filter, and the request fails closed (`no_providers_for_country`) rather than
+silently routing elsewhere. The advisor echoes `region` from the record so
+country routing needs no PDS read.
+
 ## Federation invariants
 
 These two properties together are what "no privileged operator" means in

--- a/lexicons/dev/cocore/compute/provider.json
+++ b/lexicons/dev/cocore/compute/provider.json
@@ -182,11 +182,15 @@
               }
             }
           },
+          "shareLocation": {
+            "type": "boolean",
+            "description": "The owner's opt-in to publishing this machine's coarse country. Owner-written INTENT, set from a management UI (the console's per-machine settings), like `desiredModels`/`desiredTier`/`active`: the agent reconciles toward it but NEVER authors it, so it must PRESERVE whatever it finds on every re-publish. When `true`, the agent resolves this machine's country from a best-effort public-IP geolocation at serve start and stamps `region`/`regionSource`/`regionObservedAt`; when absent/`false` it omits those fields, so turning sharing off drops any previously-shared value on the next re-publish (opt-out clears the data). Absent ≡ not sharing. Optional / additive; pre-2026-06 agents ignore it."
+          },
           "region": {
             "type": "string",
             "minLength": 2,
             "maxLength": 2,
-            "description": "Coarse, opt-in country of this machine as an ISO 3166-1 alpha-2 code (e.g. 'US'). AGENT-published and ADVISORY: a self-asserted claim derived from a best-effort public-IP geolocation at serve start, NOT a proof of location — a VPN or proxy moves it, and Apple exposes no signed-location primitive — so a verifier MUST treat it as unverified and MUST NOT gate anything security-relevant on it (same trust posture as `tier`). Present only when the machine's owner has opted into location sharing from the tray; the agent re-resolves it on every serve (refresh-on-serve) and OMITS it when sharing is off, so opting out drops the value on the next re-publish. Optional / additive; absent ≡ location not shared. A future revision may add finer fields (e.g. integer-rounded lat/lon) additively if needed."
+            "description": "Coarse, opt-in country of this machine as an ISO 3166-1 alpha-2 code (e.g. 'US'). AGENT-published and ADVISORY: a self-asserted claim derived from a best-effort public-IP geolocation at serve start, NOT a proof of location — a VPN or proxy moves it, and Apple exposes no signed-location primitive — so a verifier MUST treat it as unverified and MUST NOT gate anything security-relevant on it (same trust posture as `tier`). Present only when the machine's owner has opted into location sharing by setting `shareLocation` (from the console); the agent re-resolves it on every serve (refresh-on-serve) and OMITS it when sharing is off, so opting out drops the value on the next re-publish. Optional / additive; absent ≡ location not shared. A future revision may add finer fields (e.g. integer-rounded lat/lon) additively if needed."
           },
           "regionSource": {
             "type": "string",

--- a/packages/appview/src/inference/dispatch.test.ts
+++ b/packages/appview/src/inference/dispatch.test.ts
@@ -86,6 +86,19 @@ describe("filterByAllowedDids", () => {
   it("an empty allow-set filters everything out", () => {
     expect(filterByAllowedDids(rows, new Set())).toEqual([]);
   });
+
+  it("a `did:machineId` composite matches only that machine (pro-bono granularity)", () => {
+    // Same owner, two machines — a composite key must not widen to the other.
+    const m1 = { did: "did:plc:a", machineId: "rkeyA" };
+    const m2 = { did: "did:plc:a", machineId: "rkeyB" };
+    expect(filterByAllowedDids([m1, m2], new Set(["did:plc:a:rkeyA"]))).toEqual([m1]);
+  });
+
+  it("a bare DID still matches every machine of that owner (friends/verified)", () => {
+    const m1 = { did: "did:plc:a", machineId: "rkeyA" };
+    const m2 = { did: "did:plc:a", machineId: "rkeyB" };
+    expect(filterByAllowedDids([m1, m2], new Set(["did:plc:a"]))).toEqual([m1, m2]);
+  });
 });
 
 describe("classifyDispatchError", () => {

--- a/packages/appview/src/inference/dispatch.test.ts
+++ b/packages/appview/src/inference/dispatch.test.ts
@@ -8,6 +8,7 @@ import {
   ProviderPayoutsNotEligibleError,
   TargetProviderNotConnectedError,
   classifyDispatchError,
+  filterByAllowedDids,
   filterByPayoutsEligibility,
   openFromProvider,
   sealToProvider,
@@ -67,6 +68,23 @@ describe("filterByPayoutsEligibility", () => {
       selfLoopExempt: "did:plc:a",
     });
     expect(out.map((r) => r.did).sort()).toEqual(["did:plc:a", "did:plc:b"]);
+  });
+});
+
+describe("filterByAllowedDids", () => {
+  const rows = [{ did: "did:plc:a" }, { did: "did:plc:b" }, { did: "did:plc:c" }];
+
+  it("passes through verbatim when no allow-set", () => {
+    expect(filterByAllowedDids(rows, undefined)).toEqual(rows);
+  });
+
+  it("keeps only DIDs in the allow-set (pro-bono / friends / verified)", () => {
+    const out = filterByAllowedDids(rows, new Set(["did:plc:a", "did:plc:c"]));
+    expect(out.map((r) => r.did)).toEqual(["did:plc:a", "did:plc:c"]);
+  });
+
+  it("an empty allow-set filters everything out", () => {
+    expect(filterByAllowedDids(rows, new Set())).toEqual([]);
   });
 });
 

--- a/packages/appview/src/inference/dispatch.ts
+++ b/packages/appview/src/inference/dispatch.ts
@@ -61,10 +61,12 @@ export interface DispatchInputs {
    *  after the model filter. Advisory routing (region is a provider
    *  self-claim); not applied to an explicit `targetProviderDid`. */
   country?: string;
-  /** Restrict provider selection to this DID set. The console resolves it
-   *  (friends / verified / pro-bono allow-sets it computes from the AppView)
-   *  and forwards it here, so the AppView core only has to filter. Ignored on
-   *  an explicit `targetProviderDid`. Absent ≡ no constraint. */
+  /** Restrict provider selection to this allow-set, resolved by the console
+   *  (friends / verified / pro-bono) and forwarded here so the AppView core
+   *  only has to filter. Each entry is either a bare DID (owner-granular:
+   *  friends / verified) or a `${did}:${machineId}` composite (machine-granular:
+   *  pro-bono, per provider record). {@link filterByAllowedDids} matches either.
+   *  Ignored on an explicit `targetProviderDid`. Absent ≡ no constraint. */
   allowedProviderDids?: Set<string>;
 }
 
@@ -280,12 +282,19 @@ export function filterByPayoutsEligibility<T extends { did: string }>(
 /** Pure filter for an allow-set (friends / verified / pro-bono). `undefined`
  *  passes the list through verbatim; otherwise keeps only candidates whose DID
  *  is in `allowedDids`. The console computes the set and forwards it. */
-export function filterByAllowedDids<T extends { did: string }>(
+export function filterByAllowedDids<T extends { did: string; machineId?: string }>(
   candidates: T[],
   allowedDids: Set<string> | undefined,
 ): T[] {
   if (!allowedDids) return candidates;
-  return candidates.filter((c) => allowedDids.has(c.did));
+  // An entry is either a bare DID — owner-granular (friends / verified) — or a
+  // `${did}:${machineId}` composite — machine-granular (pro-bono, where the
+  // election is per provider record). Match either, so a pro-bono allow-set
+  // never widens to an owner's other, billed machines.
+  return candidates.filter(
+    (c) =>
+      allowedDids.has(c.did) || (c.machineId != null && allowedDids.has(`${c.did}:${c.machineId}`)),
+  );
 }
 
 /** GET the advisor's provider registry. Runs on the module o11y runtime

--- a/packages/appview/src/inference/dispatch.ts
+++ b/packages/appview/src/inference/dispatch.ts
@@ -61,6 +61,11 @@ export interface DispatchInputs {
    *  after the model filter. Advisory routing (region is a provider
    *  self-claim); not applied to an explicit `targetProviderDid`. */
   country?: string;
+  /** Restrict provider selection to this DID set. The console resolves it
+   *  (friends / verified / pro-bono allow-sets it computes from the AppView)
+   *  and forwards it here, so the AppView core only has to filter. Ignored on
+   *  an explicit `targetProviderDid`. Absent ≡ no constraint. */
+  allowedProviderDids?: Set<string>;
 }
 
 /** The slice of a provider's indexed profile the credit line needs.
@@ -272,6 +277,17 @@ export function filterByPayoutsEligibility<T extends { did: string }>(
   });
 }
 
+/** Pure filter for an allow-set (friends / verified / pro-bono). `undefined`
+ *  passes the list through verbatim; otherwise keeps only candidates whose DID
+ *  is in `allowedDids`. The console computes the set and forwards it. */
+export function filterByAllowedDids<T extends { did: string }>(
+  candidates: T[],
+  allowedDids: Set<string> | undefined,
+): T[] {
+  if (!allowedDids) return candidates;
+  return candidates.filter((c) => allowedDids.has(c.did));
+}
+
 /** GET the advisor's provider registry. Runs on the module o11y runtime
  *  behind a span so the public async API stays a plain Promise. On a
  *  non-2xx response it rejects with `new Error(`advisor /providers
@@ -305,6 +321,10 @@ async function pickProvider(
   /** Optional ISO 3166-1 alpha-2 country filter (uppercased). Applied after
    *  the model filter; not applied to an explicit `targetDid`. */
   country: string | undefined,
+  /** Optional DID allow-set (friends / verified / pro-bono), computed by the
+   *  console and forwarded. Applied before the model filter; not applied to an
+   *  explicit `targetDid`. */
+  allowedDids: Set<string> | undefined,
   /** Providers already tried this dispatch (a prior attempt's `/jobs`
    *  failed because they'd flapped out). Excluded from re-selection so
    *  failover lands on a DIFFERENT machine. Never applied to an explicit
@@ -326,10 +346,14 @@ async function pickProvider(
   const own = ownMachineCandidates(attested, requesterDid, model, excludeDids ?? new Set());
   if (own.length > 0) return own[0]!;
 
-  const pool =
+  const excluded =
     excludeDids && excludeDids.size > 0
       ? attested.filter((p) => !excludeDids.has(p.did))
       : attested;
+  // Constrain to the forwarded allow-set (pro-bono / friends / verified) before
+  // the model filter, so "no provider for model X" still reads naturally within
+  // the constrained pool.
+  const pool = filterByAllowedDids(excluded, allowedDids);
 
   const fits = pool.filter(
     (p) => p.supportedModels.length === 0 || p.supportedModels.includes(model),
@@ -494,8 +518,10 @@ export async function* runDispatch(
         input.did,
         input.targetProviderDid,
         { payoutsEligibleDids: null, selfLoopExempt: null },
-        // No country filter on an explicit pin — the user chose that machine.
+        // No country / allow-set filter on an explicit pin — the user chose
+        // that machine.
         input.targetProviderDid ? undefined : input.country,
+        input.targetProviderDid ? undefined : input.allowedProviderDids,
         excludeDids,
       );
     } catch (e) {

--- a/packages/appview/src/inference/routes.ts
+++ b/packages/appview/src/inference/routes.ts
@@ -66,6 +66,9 @@ interface DispatchBody {
   targetProviderDid?: unknown;
   /** Optional ISO 3166-1 alpha-2 country to route by (advisory). */
   country?: unknown;
+  /** Optional DID allow-set the console resolved (pro-bono / friends /
+   *  verified) and forwarded. Constrains provider selection. */
+  allowedProviderDids?: unknown;
 }
 
 type ParsedDispatch = Omit<DispatchInputs, "did">;
@@ -101,6 +104,16 @@ function parseDispatch(body: DispatchBody): ParsedDispatch | string {
     }
     country = body.country.trim().toUpperCase();
   }
+  let allowedProviderDids: Set<string> | undefined;
+  if (body.allowedProviderDids !== undefined) {
+    if (
+      !Array.isArray(body.allowedProviderDids) ||
+      !body.allowedProviderDids.every((d): d is string => typeof d === "string")
+    ) {
+      return "allowedProviderDids must be an array of DID strings";
+    }
+    allowedProviderDids = new Set(body.allowedProviderDids);
+  }
   // Build the messages-v1 envelope when the client sent images.
   let envelope: Pick<DispatchInputs, "payloadBytes" | "inputFormat"> = {};
   if (body.messages !== undefined) {
@@ -120,6 +133,7 @@ function parseDispatch(body: DispatchBody): ParsedDispatch | string {
       ? { targetProviderDid: body.targetProviderDid }
       : {}),
     ...(country ? { country } : {}),
+    ...(allowedProviderDids ? { allowedProviderDids } : {}),
   };
 }
 

--- a/packages/console/public/openapi.yaml
+++ b/packages/console/public/openapi.yaml
@@ -179,6 +179,55 @@ paths:
             application/json:
               schema: { $ref: "#/components/schemas/ErrorEnvelope" }
 
+  /v1/probono/chat/completions:
+    post:
+      tags: [Inference]
+      operationId: createProBonoChatCompletion
+      summary: Create a chat completion (pro-bono / free routing)
+      description: >
+        The pro-bono completion path. Identical wire format to
+        `/v1/chat/completions`, but routing is constrained to providers whose
+        `proBono` policy elects to serve THIS requester for free — either
+        `mode: any` (the provider serves everyone pro bono) or `mode: direct`
+        with the caller's DID in the provider's allowlist. A matched job is
+        served unmetered at zero price and the exchange takes no cut, so a
+        requester with **no token balance** can still get a completion. The
+        resulting receipt carries `proBono: true` with `price.amount: 0` and
+        `tokens: { in: 0, out: 0 }`.
+
+
+        The optional `country` field still narrows by region. Fails closed with
+        `no_pro_bono_providers` (503) when no connected provider currently
+        offers the caller pro bono, rather than silently billing the job — use
+        `/v1/chat/completions` for a normal paid request. Also available at the
+        legacy path `/api/v1/probono/chat/completions`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ChatCompletionRequest"
+      responses:
+        "200":
+          description: "A completion (or an SSE stream when `stream: true`)."
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ChatCompletion" }
+            text/event-stream:
+              schema: { type: string }
+        "401":
+          description: Missing or invalid API key.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorEnvelope" }
+        "503":
+          description: No connected provider currently offers you pro bono (`no_pro_bono_providers`).
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorEnvelope" }
+
   /v1/models:
     get:
       tags: [Directory]

--- a/packages/console/src/components/chat/ChatPage.tsx
+++ b/packages/console/src/components/chat/ChatPage.tsx
@@ -13,7 +13,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createLink } from "@tanstack/react-router";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Button as AriaButton } from "react-aria-components";
-import { ImagePlus, Square, X } from "lucide-react";
+import { ImagePlus, SlidersHorizontal, Square, X } from "lucide-react";
 import type { ReactElement } from "react";
 
 import { getMyBalanceQueryOptions } from "@/components/account/token-balance.functions.ts";
@@ -49,6 +49,7 @@ import { Kbd } from "@/design-system/kbd";
 import { breakpoints } from "@/design-system/theme/media-queries.stylex";
 import { Popover } from "@/design-system/popover";
 import { SearchField } from "@/design-system/search-field";
+import { Switch } from "@/design-system/switch";
 import { getSessionQueryOptions } from "@/integrations/auth/session.functions.ts";
 import { successColor, uiColor } from "@/design-system/theme/color.stylex";
 import { radius } from "@/design-system/theme/radius.stylex";
@@ -100,6 +101,29 @@ const CHAT_SUGGESTIONS = [
   "explain this rust lifetime error",
   "summarize my protocol notes",
   "draft release notes from a diff",
+];
+
+// Coarse region routing. `null` means "Any" — don't pin a region; otherwise
+// the ISO 3166-1 alpha-2 code is forwarded to the dispatch, which routes only
+// to providers advertising that region. A short curated list keeps the picker
+// scannable; the wire still accepts any valid code.
+interface CountryOption {
+  code: string | null;
+  label: string;
+}
+const COUNTRY_CHOICES: CountryOption[] = [
+  { code: null, label: "Any" },
+  { code: "US", label: "United States" },
+  { code: "CA", label: "Canada" },
+  { code: "GB", label: "United Kingdom" },
+  { code: "DE", label: "Germany" },
+  { code: "FR", label: "France" },
+  { code: "NL", label: "Netherlands" },
+  { code: "JP", label: "Japan" },
+  { code: "AU", label: "Australia" },
+  { code: "IN", label: "India" },
+  { code: "BR", label: "Brazil" },
+  { code: "SG", label: "Singapore" },
 ];
 
 // Prototype meta text sits at ~10.5px; the smallest token is 12px,
@@ -839,6 +863,37 @@ const styles = stylex.create({
   composerSend: {
     flexShrink: 0,
   },
+  advBtn: {
+    alignItems: "center",
+    appearance: "none",
+    backgroundColor: { default: uiColor.bgSubtle, ":hover": uiColor.bg },
+    borderColor: { default: uiColor.border1, ":hover": uiColor.border2 },
+    borderRadius: radius.xs,
+    cornerShape: "squircle",
+    borderStyle: "solid",
+    borderWidth: 1,
+    boxSizing: "border-box",
+    color: uiColor.text2,
+    cursor: "pointer",
+    display: "flex",
+    flexShrink: 0,
+    fontFamily: fontFamily.mono,
+    fontSize: fontSize.xs,
+    gap: gap.sm,
+    paddingBottom: "4px",
+    paddingLeft: horizontalSpace.md,
+    paddingRight: horizontalSpace.md,
+    paddingTop: "4px",
+    whiteSpace: "nowrap",
+  },
+  advBtnActive: {
+    borderColor: uiColor.text2,
+    color: uiColor.text2,
+  },
+  advCount: {
+    color: uiColor.text1,
+    fontVariantNumeric: "tabular-nums",
+  },
   privacyNote: {
     color: uiColor.text1,
     fontSize: MICRO,
@@ -921,6 +976,39 @@ const styles = stylex.create({
     fontSize: MICRO,
     fontVariantNumeric: "tabular-nums",
   },
+  advPop: {
+    display: "flex",
+    flexDirection: "column",
+    gap: verticalSpace.md,
+    width: "min(360px, calc(100vw - 48px))",
+  },
+  countryGrid: {
+    display: "flex",
+    flexWrap: "wrap",
+    gap: gap.sm,
+  },
+  proBonoRow: {
+    alignItems: "flex-start",
+    display: "flex",
+    gap: gap.lg,
+    justifyContent: "space-between",
+  },
+  proBonoText: {
+    display: "flex",
+    flexDirection: "column",
+    gap: gap.xs,
+    minWidth: 0,
+  },
+  proBonoTitle: {
+    color: uiColor.text2,
+    fontSize: fontSize.xs,
+    fontWeight: fontWeight.semibold,
+  },
+  proBonoHint: {
+    color: uiColor.text1,
+    fontSize: MICRO,
+    lineHeight: 1.5,
+  },
 });
 
 interface MachineOption {
@@ -988,6 +1076,22 @@ function fmtClock(iso: string): string {
 
 function fmtTok(n: number): string {
   return n >= 1024 ? `${Math.round(n / 1024)}k` : `${n}`;
+}
+
+/** Friendlier copy for the advanced-routing dispatch errors. Falls back to
+ *  the server-supplied reason for everything else (including the country-miss
+ *  codes, whose server message already reads well). */
+function friendlyDispatchReason(code: string, reason: string): string {
+  switch (code) {
+    case "no-pro-bono-providers":
+    case "no_pro_bono_providers":
+      return "No machine is offering you free compute right now.";
+    case "no-providers-for-country":
+    case "no_providers_for_country":
+      return reason || "No machine is serving that region right now.";
+    default:
+      return reason;
+  }
 }
 
 function ModelPicker({
@@ -1179,6 +1283,75 @@ function ModelPicker({
   );
 }
 
+/** Advanced routing options tucked behind a "advanced" chip in the composer
+ *  toolbar: coarse region routing (ISO 3166-1 alpha-2, "Any" = unpinned) and
+ *  a pro-bono toggle that routes only to providers serving this user for
+ *  free. Both are advisory hints forwarded to the dispatch. */
+function AdvancedOptions({
+  country,
+  proBono,
+  onCountry,
+  onProBono,
+}: {
+  country: string | null;
+  proBono: boolean;
+  onCountry: (code: string | null) => void;
+  onProBono: (on: boolean) => void;
+}): ReactElement {
+  const [open, setOpen] = useState(false);
+  const activeCount = (country ? 1 : 0) + (proBono ? 1 : 0);
+  return (
+    <Popover
+      isOpen={open}
+      onOpenChange={setOpen}
+      placement="top end"
+      trigger={
+        <AriaButton {...stylex.props(styles.advBtn, activeCount > 0 && styles.advBtnActive)}>
+          <SlidersHorizontal size={12} aria-hidden />
+          advanced
+          {activeCount > 0 ? <span {...stylex.props(styles.advCount)}>· {activeCount}</span> : null}
+        </AriaButton>
+      }
+      style={styles.advPop}
+    >
+      <div {...stylex.props(styles.popSectHead)}>
+        <span>route to</span>
+        <span {...stylex.props(styles.popSectHint)}>coarse region — advisory</span>
+      </div>
+      <div {...stylex.props(styles.countryGrid)}>
+        {COUNTRY_CHOICES.map((c) => (
+          <Button
+            key={c.code ?? "any"}
+            size="sm"
+            variant={country === c.code ? "primary" : "outline"}
+            onPress={() => onCountry(c.code)}
+          >
+            {c.code ?? "Any"}
+          </Button>
+        ))}
+      </div>
+
+      <div {...stylex.props(styles.popSectHead)}>
+        <span>pro bono</span>
+        <span {...stylex.props(styles.popSectHint)}>free compute only</span>
+      </div>
+      <div {...stylex.props(styles.proBonoRow)}>
+        <span {...stylex.props(styles.proBonoText)}>
+          <span {...stylex.props(styles.proBonoTitle)}>request pro-bono (free) compute</span>
+          <span {...stylex.props(styles.proBonoHint)}>
+            routes only to machines whose pro-bono policy serves you for free.
+          </span>
+        </span>
+        <Switch
+          aria-label="request pro-bono (free) compute"
+          isSelected={proBono}
+          onChange={onProBono}
+        />
+      </div>
+    </Popover>
+  );
+}
+
 interface ChatSessionsPanelProps {
   visible: ChatSession[];
   activeId: string | null;
@@ -1304,6 +1477,13 @@ export function ChatPage(): ReactElement {
   // no longer holds them — then we show a "had image" indicator.
   const [msgImages, setMsgImages] = useState<Record<string, string[] | "lost">>({});
   const [streamingId, setStreamingId] = useState<string | null>(null);
+
+  // Advanced routing options, kept at page scope: a coarse region (ISO
+  // 3166-1 alpha-2, null = "Any") and a pro-bono toggle. They apply to every
+  // turn in this page session and reset on reload (intentionally not
+  // persisted — they're per-sitting routing hints, not session content).
+  const [country, setCountry] = useState<string | null>(null);
+  const [proBono, setProBono] = useState(false);
 
   // Settings for the not-yet-created session shown by "new chat".
   const [draftModelId, setDraftModelId] = useState<string | null>(null);
@@ -1650,6 +1830,10 @@ export function ChatPage(): ReactElement {
         maxTokensOut,
         targetProviderDid,
         targetMachineId,
+        // null country = "Any" (the dispatch treats null/absent as unpinned);
+        // proBono only forwarded when on.
+        country,
+        ...(proBono ? { proBono: true } : {}),
         signal: abort.signal,
         onMeta: (meta) => {
           const entry = models.find((m) => m.modelId === modelId);
@@ -1688,10 +1872,11 @@ export function ChatPage(): ReactElement {
     } catch (e) {
       if (e instanceof DOMException && e.name === "AbortError") return;
       const isDispatch = e instanceof ChatDispatchError;
+      const rawReason = e instanceof Error ? e.message : String(e);
       patchMessage(sessionId, assistantMsg.id, (m) => ({
         ...m,
         errorCode: isDispatch ? e.code : "unknown",
-        errorReason: e instanceof Error ? e.message : String(e),
+        errorReason: isDispatch ? friendlyDispatchReason(e.code, rawReason) : rawReason,
       }));
     } finally {
       abortRef.current = null;
@@ -1859,6 +2044,15 @@ export function ChatPage(): ReactElement {
                       }`}
                 </span>
               </span>
+              {country ? (
+                <span {...stylex.props(styles.hostChip)}>
+                  <span {...stylex.props(styles.stripLabel)}>region</span>
+                  {country}
+                </span>
+              ) : null}
+              {proBono ? (
+                <span {...stylex.props(styles.hostChip)}>pro bono</span>
+              ) : null}
               <span {...stylex.props(styles.stripItem)}>
                 <span {...stylex.props(styles.stripLabel)}>ctx</span>
                 <span {...stylex.props(styles.emphasis)}>
@@ -2061,6 +2255,12 @@ export function ChatPage(): ReactElement {
                     onMaxTokens={setMaxTokens}
                   />
                 </div>
+                <AdvancedOptions
+                  country={country}
+                  proBono={proBono}
+                  onCountry={setCountry}
+                  onProBono={setProBono}
+                />
                 <span {...stylex.props(styles.rateNote)}>
                   {balance ? `${formatTokensCompact(balance.balance)} tok left · ` : ""}
                   billed per generated token

--- a/packages/console/src/components/chat/ChatPage.tsx
+++ b/packages/console/src/components/chat/ChatPage.tsx
@@ -1325,6 +1325,9 @@ function AdvancedOptions({
             size="sm"
             variant={country === c.code ? "primary" : "outline"}
             onPress={() => onCountry(c.code)}
+            // Compact 2-letter code is shown; the full country name is the
+            // accessible label (screen readers + hover) so "US" isn't opaque.
+            aria-label={c.label}
           >
             {c.code ?? "Any"}
           </Button>

--- a/packages/console/src/components/chat/ChatPage.tsx
+++ b/packages/console/src/components/chat/ChatPage.tsx
@@ -2050,9 +2050,7 @@ export function ChatPage(): ReactElement {
                   {country}
                 </span>
               ) : null}
-              {proBono ? (
-                <span {...stylex.props(styles.hostChip)}>pro bono</span>
-              ) : null}
+              {proBono ? <span {...stylex.props(styles.hostChip)}>pro bono</span> : null}
               <span {...stylex.props(styles.stripItem)}>
                 <span {...stylex.props(styles.stripLabel)}>ctx</span>
                 <span {...stylex.props(styles.emphasis)}>

--- a/packages/console/src/components/chat/chat-dispatch.ts
+++ b/packages/console/src/components/chat/chat-dispatch.ts
@@ -32,6 +32,12 @@ export interface ChatDispatchInputs {
   /** Specific machine under targetProviderDid. null/undefined → any machine
    *  for that DID. Ignored when targetProviderDid is not set. */
   targetMachineId?: string | null;
+  /** Optional ISO 3166-1 alpha-2 country (e.g. "US"). When set, routes only to
+   *  providers advertising that coarse region. Advisory. */
+  country?: string | null;
+  /** When true, route ONLY to providers whose pro-bono policy serves this
+   *  requester for free (the pro-bono completion path). */
+  proBono?: boolean;
   signal?: AbortSignal;
   onMeta?: (meta: { providerDid: string; jobUri: string }) => void;
   onChunk?: (text: string) => void;
@@ -145,6 +151,8 @@ export async function dispatchChatTurn(inputs: ChatDispatchInputs): Promise<Chat
       ...(inputs.targetProviderDid && inputs.targetMachineId
         ? { targetMachineId: inputs.targetMachineId }
         : {}),
+      ...(inputs.country ? { country: inputs.country } : {}),
+      ...(inputs.proBono ? { proBono: true } : {}),
     }),
     ...(inputs.signal ? { signal: inputs.signal } : {}),
   });

--- a/packages/console/src/components/machines/MachineDetail.tsx
+++ b/packages/console/src/components/machines/MachineDetail.tsx
@@ -34,6 +34,7 @@ import { Heading1, Heading4, InlineCode, LabelText, SmallBody } from "@/design-s
 
 import { Goober } from "@/components/Goober.tsx";
 import {
+  AdvancedSettingsDialogContent,
   ManageModelsDialogContent,
   RenameMachineDialogContent,
 } from "@/components/machines/MachinesDashboard.tsx";
@@ -44,6 +45,8 @@ import {
   setMyProviderDesiredModelsMutationOptions,
   setMyProviderDesiredTierMutationOptions,
   setMyProviderMachineLabelMutationOptions,
+  setMyProviderProBonoMutationOptions,
+  setMyProviderShareLocationMutationOptions,
 } from "@/components/machines/machines.functions.ts";
 import type { MachineWorkItem } from "@/components/machines/machines.server.ts";
 import { formatTokens } from "@/lib/token-display.ts";
@@ -326,6 +329,7 @@ export function MachineDetail({ rkey }: { rkey: string }) {
 
   const [manageModelsOpen, setManageModelsOpen] = useState(false);
   const [renameOpen, setRenameOpen] = useState(false);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
 
   const invalidate = () => {
     void queryClient.invalidateQueries({ queryKey: myMachineDetailQueryOptions(rkey).queryKey });
@@ -356,6 +360,18 @@ export function MachineDetail({ rkey }: { rkey: string }) {
   // machine to exactly its prior behavior — nothing here breaks serving.
   const desiredTierM = useMutation({
     ...setMyProviderDesiredTierMutationOptions,
+    onSuccess: invalidate,
+  });
+  // Advanced, per-machine owner intents. Both write to the provider record;
+  // the agent re-derives behavior on its next serve. Share-location toggles
+  // the coarse country opt-in; pro-bono sets (or clears, via null) the
+  // free-serving policy. Same invalidate-on-success as every control above.
+  const shareLocationM = useMutation({
+    ...setMyProviderShareLocationMutationOptions,
+    onSuccess: invalidate,
+  });
+  const proBonoM = useMutation({
+    ...setMyProviderProBonoMutationOptions,
     onSuccess: invalidate,
   });
 
@@ -479,6 +495,9 @@ export function MachineDetail({ rkey }: { rkey: string }) {
         </Button>
         <Button variant="outline" size="sm" onPress={() => setRenameOpen(true)}>
           Rename…
+        </Button>
+        <Button variant="outline" size="sm" onPress={() => setAdvancedOpen(true)}>
+          Advanced settings…
         </Button>
       </div>
 
@@ -703,6 +722,54 @@ export function MachineDetail({ rkey }: { rkey: string }) {
               },
             )
           }
+        />
+      </Dialog>
+
+      <Dialog
+        isOpen={advancedOpen}
+        onOpenChange={setAdvancedOpen}
+        trigger={
+          <button type="button" {...stylex.props(styles.hiddenTrigger)} tabIndex={-1} aria-hidden />
+        }
+      >
+        <AdvancedSettingsDialogContent
+          key={m.id}
+          machine={m}
+          isSharePending={shareLocationM.isPending}
+          isProBonoPending={proBonoM.isPending}
+          onShareLocation={(share) =>
+            shareLocationM.mutate(
+              { rkey: m.id, share },
+              {
+                onSuccess: () =>
+                  showToast(
+                    share
+                      ? `${m.alias}: sharing country on the next serve`
+                      : `${m.alias}: country sharing off`,
+                  ),
+                onError: (e) =>
+                  showToast(e instanceof Error ? e.message : "Could not update country sharing"),
+              },
+            )
+          }
+          onSaveProBono={(policy) =>
+            proBonoM.mutate(
+              { rkey: m.id, policy },
+              {
+                onSuccess: () =>
+                  showToast(
+                    policy === null
+                      ? `${m.alias}: pro bono off`
+                      : policy.mode === "any"
+                        ? `${m.alias}: serving everyone pro bono`
+                        : `${m.alias}: pro bono updated`,
+                  ),
+                onError: (e) =>
+                  showToast(e instanceof Error ? e.message : "Could not update pro bono"),
+              },
+            )
+          }
+          onClose={() => setAdvancedOpen(false)}
         />
       </Dialog>
     </Page.Root>

--- a/packages/console/src/components/machines/MachinesDashboard.tsx
+++ b/packages/console/src/components/machines/MachinesDashboard.tsx
@@ -31,7 +31,9 @@ import { Kbd } from "@/design-system/kbd";
 import { ListBoxSeparator } from "@/design-system/listbox";
 import { Menu, MenuItem } from "@/design-system/menu";
 import { SegmentedControl, SegmentedControlItem } from "@/design-system/segmented-control";
+import { Switch } from "@/design-system/switch";
 import { Tag, TagGroup } from "@/design-system/tag-group";
+import { TextArea } from "@/design-system/text-area";
 import { TextField } from "@/design-system/text-field";
 import {
   Table,
@@ -1374,6 +1376,132 @@ export function RenameMachineDialogContent({
             onPress={() => onSave(trimmed)}
           >
             {isPending ? "Saving…" : "Save"}
+          </Button>
+        </Flex>
+      </DialogFooter>
+    </>
+  );
+}
+
+/** Pro-bono policy as the proBono mutation expects it (`null` ≡ off). */
+type ProBonoPolicy = { mode: "any" | "direct"; dids?: string[] } | null;
+
+/** Split a free-text DID list (newline / comma / whitespace separated) into
+ *  trimmed, de-duped, non-empty entries — what the `direct` allowlist wants. */
+function parseDidList(raw: string): string[] {
+  const out: string[] = [];
+  for (const part of raw.split(/[\s,]+/)) {
+    const t = part.trim();
+    if (t.length > 0 && !out.includes(t)) out.push(t);
+  }
+  return out;
+}
+
+export function AdvancedSettingsDialogContent({
+  machine,
+  isSharePending,
+  isProBonoPending,
+  onShareLocation,
+  onSaveProBono,
+  onClose,
+}: {
+  machine: Machine;
+  isSharePending: boolean;
+  isProBonoPending: boolean;
+  onShareLocation: (share: boolean) => void;
+  onSaveProBono: (policy: ProBonoPolicy) => void;
+  onClose: () => void;
+}) {
+  // Three-way pro-bono state seeded from the record. Off = no policy; `any`
+  // serves everyone free; `direct` serves only the listed DIDs free.
+  type ProBonoMode = "off" | "any" | "direct";
+  const initialMode: ProBonoMode = machine.proBonoMode ?? "off";
+  const [mode, setMode] = useState<ProBonoMode>(initialMode);
+  const [didDraft, setDidDraft] = useState<string>((machine.proBonoDids ?? []).join("\n"));
+
+  const dids = parseDidList(didDraft);
+  const nextPolicy: ProBonoPolicy =
+    mode === "off" ? null : mode === "any" ? { mode: "any" } : { mode: "direct", dids };
+
+  // Has the owner changed the pro-bono policy versus what's on the record?
+  const initialDids = machine.proBonoDids ?? [];
+  const proBonoDirty =
+    mode !== initialMode ||
+    (mode === "direct" &&
+      (dids.length !== initialDids.length || dids.some((d, i) => d !== initialDids[i])));
+
+  return (
+    <>
+      <DialogHeader>Advanced settings — {machine.alias}</DialogHeader>
+      <DialogDescription>
+        Optional per-machine controls. Both are written to this machine's provider record; the agent
+        picks them up the next time it serves.
+      </DialogDescription>
+      <DialogBody>
+        <Flex direction="column" gap="2xl">
+          <Flex direction="column" gap="md">
+            <Switch
+              isSelected={machine.shareLocation === true}
+              isDisabled={isSharePending}
+              onChange={onShareLocation}
+            >
+              Share country
+            </Switch>
+            <SmallBody variant="secondary">
+              Publishes only a coarse, advisory country derived from this machine's IP — a VPN moves
+              it and it isn't verified. It's refreshed each time the machine serves; turning it off
+              removes the country on the next serve.
+            </SmallBody>
+            {machine.shareLocation && machine.region ? (
+              <LabelText variant="secondary">
+                Currently sharing: <InlineCode>{machine.region}</InlineCode>
+              </LabelText>
+            ) : null}
+          </Flex>
+
+          <Flex direction="column" gap="md">
+            <LabelText variant="secondary">Pro bono</LabelText>
+            <SegmentedControl
+              size="sm"
+              selectedKeys={new Set([mode])}
+              onSelectionChange={(keys) => {
+                const k = [...keys][0] as ProBonoMode | undefined;
+                if (k) setMode(k);
+              }}
+            >
+              <SegmentedControlItem id="off">Off</SegmentedControlItem>
+              <SegmentedControlItem id="any">Anyone</SegmentedControlItem>
+              <SegmentedControlItem id="direct">Specific people</SegmentedControlItem>
+            </SegmentedControl>
+            <SmallBody variant="secondary">
+              Pro-bono jobs are served free and unmetered, with no exchange cut. “Anyone” serves
+              every requester free; “Specific people” serves only the listed DIDs free — everyone
+              else is still a normal paid job. “Off” bills every job.
+            </SmallBody>
+            {mode === "direct" ? (
+              <TextArea
+                label="Requester DIDs served free"
+                value={didDraft}
+                onChange={setDidDraft}
+                placeholder={"did:plc:abc…\ndid:web:example.com"}
+                description="One per line (commas and spaces also work). Blanks are dropped on save."
+              />
+            ) : null}
+          </Flex>
+        </Flex>
+      </DialogBody>
+      <DialogFooter>
+        <Flex direction="row" gap="md">
+          <Button variant="secondary" size="sm" onPress={onClose}>
+            Close
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            isDisabled={isProBonoPending || !proBonoDirty}
+            onPress={() => onSaveProBono(nextPolicy)}
+          >
+            {isProBonoPending ? "Saving…" : "Save pro bono"}
           </Button>
         </Flex>
       </DialogFooter>

--- a/packages/console/src/components/machines/machines-data.ts
+++ b/packages/console/src/components/machines/machines-data.ts
@@ -86,4 +86,19 @@ export interface Machine {
    *  {@link standingKnown} true means the machine isn't connected to the
    *  grid right now. */
   advisorConnected?: boolean;
+  /** Whether the owner opted this machine into publishing its coarse country
+   *  (the provider record's `shareLocation` switch). Drives the "Share
+   *  country" toggle in per-machine settings. Absent ≡ off. */
+  shareLocation?: boolean;
+  /** Coarse, opt-in ISO 3166-1 alpha-2 country the agent published when
+   *  {@link shareLocation} is on (the provider record's `region`). Advisory
+   *  self-claim; absent when not sharing or not yet resolved. */
+  region?: string;
+  /** The owner's pro-bono election from the provider record's `proBono`
+   *  policy: `any` (serve everyone free) or `direct` (serve only the listed
+   *  {@link proBonoDids} free). Absent ≡ pro bono off (every job billed). */
+  proBonoMode?: "any" | "direct";
+  /** Requester DIDs served pro bono under `direct` mode. Empty/absent under
+   *  `direct` means no one is currently served free. */
+  proBonoDids?: string[];
 }

--- a/packages/console/src/components/machines/machines.functions.ts
+++ b/packages/console/src/components/machines/machines.functions.ts
@@ -38,6 +38,8 @@ import {
   setProviderRecordDesiredModels,
   setProviderRecordDesiredTier,
   setProviderRecordMachineLabel,
+  setProviderRecordProBono,
+  setProviderRecordShareLocation,
 } from "@/lib/provider-record-pds.server.ts";
 import { authMiddleware } from "@/middleware/auth.ts";
 
@@ -59,6 +61,21 @@ const setProviderDesiredTierSchema = providerRkeySchema.extend({
 
 const setProviderMachineLabelSchema = providerRkeySchema.extend({
   label: z.string().min(1).max(200),
+});
+
+const setProviderShareLocationSchema = providerRkeySchema.extend({
+  share: z.boolean(),
+});
+
+const setProviderProBonoSchema = providerRkeySchema.extend({
+  // null clears the policy (pro bono off). `direct` carries an optional DID
+  // allowlist; `any` ignores it (everyone is already free).
+  policy: z
+    .object({
+      mode: z.enum(["any", "direct"]),
+      dids: z.array(z.string()).max(1024).optional(),
+    })
+    .nullable(),
 });
 
 export type MyMachinesPayload = {
@@ -431,6 +448,28 @@ const setMyProviderMachineLabelServerFn = createServerFn({ method: "POST" })
     return { ok: true as const };
   });
 
+const setMyProviderShareLocationServerFn = createServerFn({ method: "POST" })
+  .middleware([authMiddleware])
+  .inputValidator(setProviderShareLocationSchema)
+  .handler(async ({ context, data }) => {
+    // Owner INTENT only. The agent reads `shareLocation` off its own record at
+    // serve start and re-derives (or clears) the coarse `region` from its IP.
+    await setProviderRecordShareLocation(context.oauthSession, data.rkey, data.share);
+    await nudgeAdvisorControl(context.did);
+    return { ok: true as const };
+  });
+
+const setMyProviderProBonoServerFn = createServerFn({ method: "POST" })
+  .middleware([authMiddleware])
+  .inputValidator(setProviderProBonoSchema)
+  .handler(async ({ context, data }) => {
+    // Owner INTENT only. The agent reconciles toward it and serves a matching
+    // requester free; clearing it (null) bills every job again.
+    await setProviderRecordProBono(context.oauthSession, data.rkey, data.policy);
+    await nudgeAdvisorControl(context.did);
+    return { ok: true as const };
+  });
+
 const deleteMyProviderRecordServerFn = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
   .inputValidator(providerRkeySchema)
@@ -482,6 +521,19 @@ export const setMyProviderDesiredTierMutationOptions = mutationOptions({
 export const setMyProviderMachineLabelMutationOptions = mutationOptions({
   mutationFn: (variables: SetMyProviderMachineLabelInput) =>
     setMyProviderMachineLabelServerFn({ data: variables }),
+});
+
+export type SetMyProviderShareLocationInput = z.infer<typeof setProviderShareLocationSchema>;
+export type SetMyProviderProBonoInput = z.infer<typeof setProviderProBonoSchema>;
+
+export const setMyProviderShareLocationMutationOptions = mutationOptions({
+  mutationFn: (variables: SetMyProviderShareLocationInput) =>
+    setMyProviderShareLocationServerFn({ data: variables }),
+});
+
+export const setMyProviderProBonoMutationOptions = mutationOptions({
+  mutationFn: (variables: SetMyProviderProBonoInput) =>
+    setMyProviderProBonoServerFn({ data: variables }),
 });
 
 export const deleteMyProviderRecordMutationOptions = mutationOptions({

--- a/packages/console/src/components/machines/machines.server.ts
+++ b/packages/console/src/components/machines/machines.server.ts
@@ -49,6 +49,9 @@ type ProviderRecordBody = {
   supportedModels?: string[];
   desiredModels?: string[];
   engineFault?: EngineFaultBody;
+  shareLocation?: boolean;
+  region?: string;
+  proBono?: { mode?: string; dids?: string[] };
 };
 
 type ReceiptRecordBody = {
@@ -98,7 +101,23 @@ function parseProviderBody(body: unknown): ProviderRecordBody {
       ? o.desiredModels.filter((m): m is string => typeof m === "string")
       : undefined,
     engineFault: parseEngineFault(o.engineFault),
+    shareLocation: typeof o.shareLocation === "boolean" ? o.shareLocation : undefined,
+    region: typeof o.region === "string" ? o.region : undefined,
+    proBono: parseProBono(o.proBono),
   };
+}
+
+/** Parse the provider record's `proBono` policy (mode + optional DID
+ *  allowlist), tolerating malformed shapes (treated as off). */
+function parseProBono(raw: unknown): { mode?: string; dids?: string[] } | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const o = raw as Record<string, unknown>;
+  const mode = typeof o.mode === "string" ? o.mode : undefined;
+  if (mode !== "any" && mode !== "direct") return undefined;
+  const dids = Array.isArray(o.dids)
+    ? o.dids.filter((d): d is string => typeof d === "string")
+    : undefined;
+  return { mode, ...(dids && dids.length > 0 ? { dids } : {}) };
 }
 
 function parseEngineFault(raw: unknown): EngineFaultBody | undefined {
@@ -678,6 +697,12 @@ export function providerRowsToMachines(
       faultCode: body.engineFault?.code,
       faultReason: body.engineFault?.message,
       faultModels: body.engineFault?.models,
+      shareLocation: body.shareLocation,
+      region: body.region,
+      proBonoMode: body.proBono?.mode === "any" || body.proBono?.mode === "direct"
+        ? body.proBono.mode
+        : undefined,
+      proBonoDids: body.proBono?.dids,
     };
 
     if (body.active === false) {

--- a/packages/console/src/components/machines/machines.server.ts
+++ b/packages/console/src/components/machines/machines.server.ts
@@ -699,9 +699,10 @@ export function providerRowsToMachines(
       faultModels: body.engineFault?.models,
       shareLocation: body.shareLocation,
       region: body.region,
-      proBonoMode: body.proBono?.mode === "any" || body.proBono?.mode === "direct"
-        ? body.proBono.mode
-        : undefined,
+      proBonoMode:
+        body.proBono?.mode === "any" || body.proBono?.mode === "direct"
+          ? body.proBono.mode
+          : undefined,
       proBonoDids: body.proBono?.dids,
     };
 

--- a/packages/console/src/lib/inference-dispatch.server.ts
+++ b/packages/console/src/lib/inference-dispatch.server.ts
@@ -57,9 +57,13 @@ export interface DispatchInputs {
   /** OAuth session to publish records under. Required — every
    *  authoritative record must hit the user's PDS. */
   oauthSession: OAuthSession;
-  /** Restrict provider selection to this set of DIDs. Used by the
-   *  friends-only chat-completions endpoint, which fetches the
-   *  user's friend records from their PDS and passes the DID set
+  /** Restrict provider selection to this allow-set. Each entry is either a
+   *  bare DID — owner-granular, used by the friends-only + verified endpoints —
+   *  or a `${did}:${machineId}` composite — machine-granular, used by the
+   *  pro-bono path (the election is per provider record, so it must not widen
+   *  to an owner's other billed machines). {@link filterByAllowedDids} matches
+   *  either form. Used by the friends-only chat-completions endpoint, which
+   *  fetches the user's friend records from their PDS and passes the DID set
    *  through to constrain pickProvider.
    *
    *  Empty set is meaningful and DIFFERENT from `undefined`:
@@ -336,12 +340,19 @@ export function filterByPayoutsEligibility<T extends { did: string }>(
  *  meaningful "filter everything out" signal that the caller
  *  should distinguish — the route layer turns that into
  *  NoFriendsAvailableError. */
-export function filterByAllowedDids<T extends { did: string }>(
+export function filterByAllowedDids<T extends { did: string; machineId?: string }>(
   candidates: T[],
   allowedDids: Set<string> | undefined,
 ): T[] {
   if (!allowedDids) return candidates;
-  return candidates.filter((c) => allowedDids.has(c.did));
+  // An entry is either a bare DID — owner-granular (friends / verified) — or a
+  // `${did}:${machineId}` composite — machine-granular (pro-bono, where the
+  // election is per provider record). Match either, so a pro-bono allow-set
+  // never widens to an owner's other, billed machines.
+  return candidates.filter(
+    (c) =>
+      allowedDids.has(c.did) || (c.machineId != null && allowedDids.has(`${c.did}:${c.machineId}`)),
+  );
 }
 
 /** Pure filter for country routing. `undefined`/empty country passes the

--- a/packages/console/src/lib/inference-dispatch.test.ts
+++ b/packages/console/src/lib/inference-dispatch.test.ts
@@ -93,6 +93,22 @@ describe("filterByAllowedDids", () => {
     const out = filterByAllowedDids([A, B], new Set(["did:plc:carol", "did:plc:alice"]));
     assert.deepEqual(out, [A]);
   });
+
+  test("a `did:machineId` composite matches only that machine (pro-bono granularity)", () => {
+    // Same owner DID, two machines — one pro bono, one not. A composite key
+    // must match ONLY the pro-bono machine, never widen to the billed one.
+    const m1 = { did: "did:plc:alice", machineId: "rkeyA" };
+    const m2 = { did: "did:plc:alice", machineId: "rkeyB" };
+    const out = filterByAllowedDids([m1, m2], new Set(["did:plc:alice:rkeyA"]));
+    assert.deepEqual(out, [m1]);
+  });
+
+  test("a bare DID still matches every machine of that owner (friends/verified)", () => {
+    const m1 = { did: "did:plc:alice", machineId: "rkeyA" };
+    const m2 = { did: "did:plc:alice", machineId: "rkeyB" };
+    const out = filterByAllowedDids([m1, m2], new Set(["did:plc:alice"]));
+    assert.deepEqual(out, [m1, m2]);
+  });
 });
 
 describe("classifyDispatchError", () => {

--- a/packages/console/src/lib/openai-chat-completions.server.ts
+++ b/packages/console/src/lib/openai-chat-completions.server.ts
@@ -208,7 +208,9 @@ export function parseRequest(raw: OpenAiChatRequest): ParsedRequest | string {
   }
   const stream = typeof raw.stream === "boolean" ? raw.stream : false;
   let country: string | undefined;
-  if (raw.country !== undefined) {
+  // `null` (an explicit "no country") is treated the same as absent, so a
+  // client that sends `country: null` isn't rejected with a misleading 400.
+  if (raw.country !== undefined && raw.country !== null) {
     if (typeof raw.country !== "string" || !/^[A-Za-z]{2}$/.test(raw.country.trim())) {
       return "country must be a 2-letter ISO 3166-1 alpha-2 code";
     }

--- a/packages/console/src/lib/openai-routes.server.ts
+++ b/packages/console/src/lib/openai-routes.server.ts
@@ -26,7 +26,7 @@ import { appviewBackedSession, appviewSessionInfo } from "@/lib/appview-backed-s
 import { isAppviewForwardConfigured } from "@/lib/appview-pds-forward.server.ts";
 import { type DispatchInputs, runDispatch } from "@/lib/inference-dispatch.server.ts";
 import { listMyFriendDids } from "@/lib/friends.server.ts";
-import { resolveProBonoProviderDids } from "@/lib/pro-bono.server.ts";
+import { resolveProBonoProviderKeys } from "@/lib/pro-bono.server.ts";
 import {
   buildJobInput,
   bufferedResponse,
@@ -321,12 +321,14 @@ export async function handleProBonoChatCompletions(request: Request): Promise<Re
   const parsed = parseRequest(raw);
   if (typeof parsed === "string") return jsonError(400, parsed);
 
-  // Resolve the providers that currently serve this DID pro bono BEFORE
-  // submitting the job. A lookup failure surfaces as a transport error (so the
-  // caller can tell "nobody offers me pro bono" from "the AppView coughed").
+  // Resolve the specific MACHINES that currently serve this DID pro bono BEFORE
+  // submitting the job (composite `did:machineId` keys — pro bono is per-machine,
+  // so we can't widen to an owner's other billed machines). A lookup failure
+  // surfaces as a transport error (so the caller can tell "nobody offers me pro
+  // bono" from "the AppView coughed").
   let allowedProviderDids: Set<string>;
   try {
-    allowedProviderDids = await resolveProBonoProviderDids(auth.did);
+    allowedProviderDids = await resolveProBonoProviderKeys(auth.did);
   } catch (e) {
     return jsonError(
       502,

--- a/packages/console/src/lib/openai-routes.server.ts
+++ b/packages/console/src/lib/openai-routes.server.ts
@@ -26,6 +26,7 @@ import { appviewBackedSession, appviewSessionInfo } from "@/lib/appview-backed-s
 import { isAppviewForwardConfigured } from "@/lib/appview-pds-forward.server.ts";
 import { type DispatchInputs, runDispatch } from "@/lib/inference-dispatch.server.ts";
 import { listMyFriendDids } from "@/lib/friends.server.ts";
+import { resolveProBonoProviderDids } from "@/lib/pro-bono.server.ts";
 import {
   buildJobInput,
   bufferedResponse,
@@ -288,6 +289,79 @@ export async function handleVerifiedChatCompletions(request: Request): Promise<R
     priceCeiling: DEFAULT_PRICE_CEILING,
     // Same mechanism as the friends path, but the set is the proof-backed
     // verified-provider list rather than the caller's friends.
+    allowedProviderDids,
+    country: parsed.country,
+  };
+
+  if (parsed.stream) {
+    return streamingResponse(id, parsed.model, runDispatch(inputs));
+  }
+  return await bufferedResponse(id, parsed.model, runDispatch(inputs));
+}
+
+/** POST /v1/probono/chat/completions — the pro-bono completion path. Routes
+ *  ONLY to providers whose `proBono` policy elects to serve THIS requester for
+ *  free (`mode: any`, or `mode: direct` with the caller's DID listed). A
+ *  matched job is served unmetered at zero price with no exchange cut, so a
+ *  requester with no token balance can still get a completion. Identical wire
+ *  format to `/v1/chat/completions` (and `country` still narrows by region).
+ *  Fails CLOSED with a 503 when no connected provider currently offers the
+ *  caller pro bono, rather than silently falling back to a billed job. Same
+ *  `allowedProviderDids` mechanism as the friends + verified paths. */
+export async function handleProBonoChatCompletions(request: Request): Promise<Response> {
+  const auth = await authenticate(request);
+  if (auth instanceof Response) return auth;
+
+  let raw: OpenAiChatRequest;
+  try {
+    raw = (await request.json()) as OpenAiChatRequest;
+  } catch {
+    return jsonError(400, "Body must be JSON");
+  }
+  const parsed = parseRequest(raw);
+  if (typeof parsed === "string") return jsonError(400, parsed);
+
+  // Resolve the providers that currently serve this DID pro bono BEFORE
+  // submitting the job. A lookup failure surfaces as a transport error (so the
+  // caller can tell "nobody offers me pro bono" from "the AppView coughed").
+  let allowedProviderDids: Set<string>;
+  try {
+    allowedProviderDids = await resolveProBonoProviderDids(auth.did);
+  } catch (e) {
+    return jsonError(
+      502,
+      `failed to resolve pro-bono providers: ${(e as Error).message}`,
+      "server_error",
+      "pro_bono_lookup_failed",
+    );
+  }
+  if (allowedProviderDids.size === 0) {
+    return jsonError(
+      503,
+      "no provider currently offers you pro-bono compute; use /v1/chat/completions for a normal (billed) request",
+      "service_unavailable_error",
+      "no_pro_bono_providers",
+    );
+  }
+
+  const id = `chatcmpl-${crypto.randomUUID().replace(/-/g, "")}`;
+  let payload: Awaited<ReturnType<typeof buildJobInput>>;
+  try {
+    payload = await buildJobInput(parsed.messages);
+  } catch (e) {
+    return jsonError(400, `failed to prepare input: ${(e as Error).message}`);
+  }
+  const inputs: DispatchInputs = {
+    did: auth.did,
+    oauthSession: auth.oauthSession,
+    model: parsed.model,
+    prompt: "",
+    payloadBytes: payload.payloadBytes,
+    inputFormat: payload.inputFormat,
+    maxTokensOut: parsed.maxTokens,
+    priceCeiling: DEFAULT_PRICE_CEILING,
+    // Constrain routing to providers that serve this requester free — same
+    // gate as the friends/verified paths, just a different allow-set.
     allowedProviderDids,
     country: parsed.country,
   };

--- a/packages/console/src/lib/pro-bono.server.ts
+++ b/packages/console/src/lib/pro-bono.server.ts
@@ -44,18 +44,26 @@ interface ProviderRecordView {
   proBono?: ProBonoPolicyView;
 }
 
-/** The set of provider DIDs that currently offer `requesterDid` pro-bono work,
- *  resolved from the AppView's provider-record mirror. Deduped by DID (a single
- *  owner may run several machines; routing is DID-scoped here, then the live
- *  advisor intersect in pickProvider narrows to connected machines). Throws on
- *  an AppView failure so the caller can distinguish "nobody offers you pro
- *  bono" (empty set) from "the lookup failed". */
-export async function resolveProBonoProviderDids(requesterDid: string): Promise<Set<string>> {
+/** The set of MACHINE keys (`${did}:${machineId}`, where machineId is the
+ *  provider-record rkey) that currently offer `requesterDid` pro-bono work,
+ *  resolved from the AppView's provider-record mirror. Keyed per MACHINE, not
+ *  per owner DID, because `proBono` is a per-record election: an owner can run
+ *  one machine pro bono and another billed, so a DID-scoped allow-set could
+ *  route a balance-less requester to the owner's *billing* machine and bust the
+ *  pro-bono guarantee. The composite key is matched by {@link filterByAllowedDids}
+ *  against the advisor row's `(did, machineId)`. Throws on an AppView failure so
+ *  the caller can distinguish "nobody offers you pro bono" (empty set) from "the
+ *  lookup failed". */
+export async function resolveProBonoProviderKeys(requesterDid: string): Promise<Set<string>> {
   const res = await runTraced("proBono.listProviders", appviewListProvidersEffect);
   const out = new Set<string>();
   for (const row of res.providers) {
     const body = row.body as ProviderRecordView;
-    if (proBonoApplies(body.proBono, requesterDid)) out.add(row.repo);
+    // Need the rkey to address the specific machine; a record without one
+    // can't be matched to an advisor row, so it can't be offered pro bono.
+    if (row.rkey && proBonoApplies(body.proBono, requesterDid)) {
+      out.add(`${row.repo}:${row.rkey}`);
+    }
   }
   return out;
 }

--- a/packages/console/src/lib/pro-bono.server.ts
+++ b/packages/console/src/lib/pro-bono.server.ts
@@ -1,0 +1,58 @@
+// Requester-side pro-bono routing.
+//
+// A provider elects to serve some requesters pro bono (free, unmetered, no
+// exchange cut) by writing a `proBono` policy onto its provider record (see
+// the lexicon `dev.cocore.compute.provider#proBonoPolicy`). The PROVIDER
+// decides this per-job locally, so a normal dispatch already lands on a free
+// receipt when it happens to pick a provider whose policy matches. This module
+// powers the OPT-IN "route me only to a provider that serves me free" path: it
+// reads the AppView's mirror of provider records, parses each `proBono` policy,
+// and returns the set of provider DIDs whose policy applies to a given
+// requester. That set feeds the existing `allowedProviderDids` routing gate
+// (the same mechanism behind the friends-only + verified paths), so a balance-
+// less requester can be guaranteed a free machine.
+//
+// Provider records are public on the PDS (and already surfaced via the AppView
+// listProviders mirror), so the DID allowlist a provider publishes under
+// `mode: direct` is not newly exposed here.
+
+import { appviewListProvidersEffect } from "@/integrations/appview/appview.server.ts";
+import { runTraced } from "@/lib/o11y.server.ts";
+
+interface ProBonoPolicyView {
+  mode?: unknown;
+  dids?: unknown;
+}
+
+/** Whether a provider's pro-bono policy serves `requesterDid` for free.
+ *  `any` ⇒ everyone; `direct` ⇒ only the listed DIDs; anything else (absent /
+ *  unknown mode) ⇒ no (fail closed to paid, matching the provider agent's
+ *  `ProBonoPolicy::applies_to`). Pure + exported for testing. */
+export function proBonoApplies(policy: ProBonoPolicyView | undefined, requesterDid: string): boolean {
+  if (!policy) return false;
+  if (policy.mode === "any") return true;
+  if (policy.mode === "direct") {
+    return Array.isArray(policy.dids) && policy.dids.some((d) => d === requesterDid);
+  }
+  return false;
+}
+
+interface ProviderRecordView {
+  proBono?: ProBonoPolicyView;
+}
+
+/** The set of provider DIDs that currently offer `requesterDid` pro-bono work,
+ *  resolved from the AppView's provider-record mirror. Deduped by DID (a single
+ *  owner may run several machines; routing is DID-scoped here, then the live
+ *  advisor intersect in pickProvider narrows to connected machines). Throws on
+ *  an AppView failure so the caller can distinguish "nobody offers you pro
+ *  bono" (empty set) from "the lookup failed". */
+export async function resolveProBonoProviderDids(requesterDid: string): Promise<Set<string>> {
+  const res = await runTraced("proBono.listProviders", appviewListProvidersEffect);
+  const out = new Set<string>();
+  for (const row of res.providers) {
+    const body = row.body as ProviderRecordView;
+    if (proBonoApplies(body.proBono, requesterDid)) out.add(row.repo);
+  }
+  return out;
+}

--- a/packages/console/src/lib/pro-bono.server.ts
+++ b/packages/console/src/lib/pro-bono.server.ts
@@ -28,7 +28,10 @@ interface ProBonoPolicyView {
  *  `any` ⇒ everyone; `direct` ⇒ only the listed DIDs; anything else (absent /
  *  unknown mode) ⇒ no (fail closed to paid, matching the provider agent's
  *  `ProBonoPolicy::applies_to`). Pure + exported for testing. */
-export function proBonoApplies(policy: ProBonoPolicyView | undefined, requesterDid: string): boolean {
+export function proBonoApplies(
+  policy: ProBonoPolicyView | undefined,
+  requesterDid: string,
+): boolean {
   if (!policy) return false;
   if (policy.mode === "any") return true;
   if (policy.mode === "direct") {

--- a/packages/console/src/lib/pro-bono.test.ts
+++ b/packages/console/src/lib/pro-bono.test.ts
@@ -1,0 +1,36 @@
+// Unit tests for the pure pro-bono policy predicate. The AppView-bound
+// `resolveProBonoProviderDids` is exercised by the e2e stack; this file
+// only covers `proBonoApplies` so we can iterate without a live AppView.
+
+import assert from "node:assert/strict";
+import { test } from "vitest";
+
+import { proBonoApplies } from "./pro-bono.server.ts";
+
+const ALICE = "did:plc:alice";
+const BOB = "did:plc:bob";
+
+test("absent / undefined policy is never pro bono (fail closed to paid)", () => {
+  assert.equal(proBonoApplies(undefined, ALICE), false);
+  assert.equal(proBonoApplies({}, ALICE), false);
+});
+
+test("mode 'any' serves every requester", () => {
+  assert.equal(proBonoApplies({ mode: "any" }, ALICE), true);
+  assert.equal(proBonoApplies({ mode: "any", dids: [] }, BOB), true);
+});
+
+test("mode 'direct' serves only listed DIDs", () => {
+  const policy = { mode: "direct", dids: [ALICE] };
+  assert.equal(proBonoApplies(policy, ALICE), true);
+  assert.equal(proBonoApplies(policy, BOB), false);
+});
+
+test("mode 'direct' with no/empty list serves no one", () => {
+  assert.equal(proBonoApplies({ mode: "direct" }, ALICE), false);
+  assert.equal(proBonoApplies({ mode: "direct", dids: [] }, ALICE), false);
+});
+
+test("an unknown mode fails closed (paid)", () => {
+  assert.equal(proBonoApplies({ mode: "everyone" }, ALICE), false);
+});

--- a/packages/console/src/lib/provider-record-pds.server.ts
+++ b/packages/console/src/lib/provider-record-pds.server.ts
@@ -185,6 +185,69 @@ export async function setProviderRecordDesiredModels(
   await putMyProviderRecord(session, rkey, next, cid);
 }
 
+/** Opt a machine into (or out of) publishing its coarse country by writing
+ *  the owner-INTENT `shareLocation` switch onto its provider record. The agent
+ *  reads this off its own record at serve start: when `true` it resolves the
+ *  machine's country from its public IP and stamps `region` (refreshed every
+ *  serve); when off it omits the region fields, so the next re-publish drops
+ *  any previously-shared value. `false` DELETES the key (absent ≡ off), keeping
+ *  the record minimal. Same get→put-with-swap→bridge-mirror path as
+ *  {@link setProviderRecordActive}. */
+export async function setProviderRecordShareLocation(
+  session: OAuthSession,
+  rkey: string,
+  share: boolean,
+): Promise<void> {
+  const { cid, value } = await getMyProviderRecord(session, rkey);
+  const next = { ...value };
+  if (share) {
+    next["shareLocation"] = true;
+  } else {
+    delete next["shareLocation"];
+  }
+  await putMyProviderRecord(session, rkey, next, cid);
+}
+
+/** The owner's pro-bono election for a machine, mirroring the lexicon
+ *  `dev.cocore.compute.provider#proBonoPolicy`. `null` clears the policy. */
+export type ProBonoPolicyInput = { mode: "any" | "direct"; dids?: string[] } | null;
+
+/** Set (or clear) a machine's pro-bono policy by writing `proBono` onto its
+ *  provider record — the owner's INTENT, like `desiredModels`/`desiredTier`.
+ *  The agent reconciles toward it: a matching requester is served free
+ *  (`proBono: true`, zero price, zero tokens; the exchange takes no cut).
+ *  `null` (or `mode` neither `any`/`direct`) DELETES the key, turning pro bono
+ *  off so the machine bills every job again. Under `direct`, `dids` is trimmed,
+ *  deduped, and emptied of blanks — an empty list means "serve no one pro bono
+ *  yet" (the safe default for a half-configured policy). Same
+ *  get→put-with-swap→bridge-mirror path as {@link setProviderRecordActive}. */
+export async function setProviderRecordProBono(
+  session: OAuthSession,
+  rkey: string,
+  policy: ProBonoPolicyInput,
+): Promise<void> {
+  const { cid, value } = await getMyProviderRecord(session, rkey);
+  const next = { ...value };
+  if (policy && (policy.mode === "any" || policy.mode === "direct")) {
+    if (policy.mode === "direct") {
+      const cleaned: string[] = [];
+      const seen = new Set<string>();
+      for (const d of policy.dids ?? []) {
+        const trimmed = d.trim();
+        if (trimmed.length === 0 || seen.has(trimmed)) continue;
+        seen.add(trimmed);
+        cleaned.push(trimmed);
+      }
+      next["proBono"] = { mode: "direct", ...(cleaned.length > 0 ? { dids: cleaned } : {}) };
+    } else {
+      next["proBono"] = { mode: "any" };
+    }
+  } else {
+    delete next["proBono"];
+  }
+  await putMyProviderRecord(session, rkey, next, cid);
+}
+
 /** Rename a machine by writing `machineLabel` onto its provider record.
  *  The console writes the field directly; the agent normally sets it from
  *  `COCORE_MACHINE_LABEL`, but the record's `machineLabel` is the value the

--- a/packages/console/src/routes/_header-layout.models.tsx
+++ b/packages/console/src/routes/_header-layout.models.tsx
@@ -526,6 +526,29 @@ const styles = stylex.create({
       backgroundColor: uiColor.bgSubtle,
     },
   },
+  hostCell: {
+    alignItems: "center",
+    display: "flex",
+    flexWrap: "wrap",
+    gap: gap.sm,
+  },
+  regionChip: {
+    alignItems: "center",
+    backgroundColor: uiColor.bgSubtle,
+    borderColor: uiColor.border1,
+    borderRadius: radius.sm,
+    borderStyle: "solid",
+    borderWidth: 1,
+    color: uiColor.text1,
+    display: "inline-flex",
+    flexShrink: 0,
+    fontSize: fontSize.xs,
+    gap: gap.xs,
+    letterSpacing: "0.03em",
+    lineHeight: lineHeight.sm,
+    paddingBlock: 2,
+    paddingInline: horizontalSpace.sm,
+  },
   snippetRow: {
     alignItems: "flex-start",
     display: "flex",
@@ -691,6 +714,16 @@ const COMPACT_NUMBER_FMT = new Intl.NumberFormat("en-US", {
 function fmtCompact(n: number): string {
   if (!Number.isFinite(n) || n === 0) return "0";
   return COMPACT_NUMBER_FMT.format(n);
+}
+
+/** ISO 3166-1 alpha-2 country code (e.g. "US") → regional-indicator flag
+ *  emoji (e.g. "🇺🇸"). Returns null for anything that isn't two ASCII
+ *  letters so a malformed self-claim renders as plain text, not garbage. */
+function regionFlag(code: string): string | null {
+  const cc = code.trim().toUpperCase();
+  if (!/^[A-Z]{2}$/.test(cc)) return null;
+  const base = 0x1f1e6 - 0x41;
+  return String.fromCodePoint(base + cc.charCodeAt(0), base + cc.charCodeAt(1));
 }
 
 function uniqueOperatorCount(models: ModelDirectoryEntry[]): number {
@@ -1098,12 +1131,25 @@ function ModelsPage() {
                             <TrustTierBadge tier={mach.verifiedTier} />
                           </td>
                           <td {...stylex.props(styles.td, isLast && styles.tdLastRow)}>
-                            <OperatorChip
-                              did={mach.did}
-                              handle={mach.host?.handle ?? null}
-                              displayName={mach.host?.displayName ?? null}
-                              avatarUrl={mach.host?.avatarUrl ?? null}
-                            />
+                            <div {...stylex.props(styles.hostCell)}>
+                              <OperatorChip
+                                did={mach.did}
+                                handle={mach.host?.handle ?? null}
+                                displayName={mach.host?.displayName ?? null}
+                                avatarUrl={mach.host?.avatarUrl ?? null}
+                              />
+                              {mach.region ? (
+                                <span
+                                  {...stylex.props(styles.regionChip)}
+                                  title={`Provider-claimed region · ${mach.region.toUpperCase()}`}
+                                >
+                                  {regionFlag(mach.region) ? (
+                                    <span aria-hidden="true">{regionFlag(mach.region)}</span>
+                                  ) : null}
+                                  {mach.region.toUpperCase()}
+                                </span>
+                              ) : null}
+                            </div>
                           </td>
                           <td {...stylex.props(styles.td, isLast && styles.tdLastRow)}>
                             <SmallBody variant="secondary">

--- a/packages/console/src/routes/_header-layout.models.tsx
+++ b/packages/console/src/routes/_header-layout.models.tsx
@@ -1117,6 +1117,9 @@ function ModelsPage() {
                   <tbody>
                     {selected.machines.map((mach, i) => {
                       const isLast = i === selected.machines.length - 1;
+                      // Derive the flag emoji once (it's null for a non-2-letter
+                      // self-claim); reused in the region chip below.
+                      const regionFlagEmoji = mach.region ? regionFlag(mach.region) : null;
                       return (
                         <tr
                           key={`${selected.modelId}-${mach.attestationPubKey ?? mach.did}`}
@@ -1143,8 +1146,8 @@ function ModelsPage() {
                                   {...stylex.props(styles.regionChip)}
                                   title={`Provider-claimed region · ${mach.region.toUpperCase()}`}
                                 >
-                                  {regionFlag(mach.region) ? (
-                                    <span aria-hidden="true">{regionFlag(mach.region)}</span>
+                                  {regionFlagEmoji ? (
+                                    <span aria-hidden="true">{regionFlagEmoji}</span>
                                   ) : null}
                                   {mach.region.toUpperCase()}
                                 </span>

--- a/packages/console/src/routes/api.v1.probono.chat.completions.ts
+++ b/packages/console/src/routes/api.v1.probono.chat.completions.ts
@@ -1,0 +1,19 @@
+// POST /api/v1/probono/chat/completions
+//
+// Pro-bono sibling of `/api/v1/chat/completions`: same OpenAI wire format, but
+// routing is constrained to providers whose `proBono` policy serves THIS
+// requester for free. See the canonical `/v1/probono/chat/completions` mount
+// for the full contract; both routes call the same handler in
+// `@/lib/openai-routes.server.ts`.
+
+import { createFileRoute } from "@tanstack/react-router";
+
+import { handleProBonoChatCompletions } from "@/lib/openai-routes.server.ts";
+
+export const Route = createFileRoute("/api/v1/probono/chat/completions")({
+  server: {
+    handlers: {
+      POST: ({ request }) => handleProBonoChatCompletions(request),
+    },
+  },
+});

--- a/packages/console/src/routes/api/xrpc/dev[.]cocore[.]inference[.]dispatch.ts
+++ b/packages/console/src/routes/api/xrpc/dev[.]cocore[.]inference[.]dispatch.ts
@@ -172,7 +172,10 @@ export const Route = createFileRoute("/api/xrpc/dev.cocore.inference.dispatch")(
                 {
                   error:
                     "no provider currently offers you pro-bono compute; turn off pro bono for a normal (billed) request",
-                  code: "no-pro-bono-providers",
+                  // snake_case to match the documented `no_pro_bono_providers`
+                  // code emitted by /v1/probono/chat/completions + openapi.yaml,
+                  // so the same failure has one spelling across both endpoints.
+                  code: "no_pro_bono_providers",
                 },
                 503,
               );

--- a/packages/console/src/routes/api/xrpc/dev[.]cocore[.]inference[.]dispatch.ts
+++ b/packages/console/src/routes/api/xrpc/dev[.]cocore[.]inference[.]dispatch.ts
@@ -30,7 +30,7 @@ import {
   isDispatchForwardConfigured,
 } from "@/lib/inference-dispatch-forward.server.ts";
 import { runDispatch } from "@/lib/inference-dispatch.server.ts";
-import { resolveProBonoProviderDids } from "@/lib/pro-bono.server.ts";
+import { resolveProBonoProviderKeys } from "@/lib/pro-bono.server.ts";
 import { getAtprotoSessionForRequest } from "@/middleware/auth.server.ts";
 
 interface DispatchBody {
@@ -160,15 +160,18 @@ export const Route = createFileRoute("/api/xrpc/dev.cocore.inference.dispatch")(
         const parsed = parseDispatch(body);
         if (typeof parsed === "string") return json({ error: parsed }, 400);
 
-        // The pro-bono path: route ONLY to providers whose policy serves this
-        // requester free. We resolve WHO offers them pro bono here (the console
-        // has the AppView read + the requester DID), then forward / pass the
-        // allow-set so either core just filters. Fail closed if nobody does.
+        // The pro-bono path: route ONLY to the specific machines whose policy
+        // serves this requester free. We resolve WHICH machines offer them pro
+        // bono here (the console has the AppView read + the requester DID) as
+        // composite `did:machineId` keys, then forward / pass the allow-set so
+        // either core just filters. Machine-granular (not DID-granular) so an
+        // owner's other, billed machines never satisfy the pro-bono request.
+        // Fail closed if nobody does.
         const { proBono, ...rest } = parsed;
         let allowedProviderDids: string[] | undefined;
         if (proBono) {
           try {
-            const set = await resolveProBonoProviderDids(session.did);
+            const set = await resolveProBonoProviderKeys(session.did);
             if (set.size === 0) {
               return json(
                 {

--- a/packages/console/src/routes/api/xrpc/dev[.]cocore[.]inference[.]dispatch.ts
+++ b/packages/console/src/routes/api/xrpc/dev[.]cocore[.]inference[.]dispatch.ts
@@ -97,7 +97,9 @@ function parseDispatch(body: DispatchBody): ParsedDispatch | string {
     return "targetMachineId must be a string when provided";
   }
   let country: string | undefined;
-  if (body.country !== undefined) {
+  // `null` (an explicit "no country") is treated the same as absent, so a
+  // client that sends `country: null` isn't rejected with a misleading 400.
+  if (body.country !== undefined && body.country !== null) {
     if (typeof body.country !== "string" || !/^[A-Za-z]{2}$/.test(body.country.trim())) {
       return "country must be a 2-letter ISO 3166-1 alpha-2 code";
     }

--- a/packages/console/src/routes/api/xrpc/dev[.]cocore[.]inference[.]dispatch.ts
+++ b/packages/console/src/routes/api/xrpc/dev[.]cocore[.]inference[.]dispatch.ts
@@ -30,6 +30,7 @@ import {
   isDispatchForwardConfigured,
 } from "@/lib/inference-dispatch-forward.server.ts";
 import { runDispatch } from "@/lib/inference-dispatch.server.ts";
+import { resolveProBonoProviderDids } from "@/lib/pro-bono.server.ts";
 import { getAtprotoSessionForRequest } from "@/middleware/auth.server.ts";
 
 interface DispatchBody {
@@ -43,6 +44,11 @@ interface DispatchBody {
   priceCeiling?: unknown;
   targetProviderDid?: unknown;
   targetMachineId?: unknown;
+  /** Optional ISO 3166-1 alpha-2 country to route by (advisory region match). */
+  country?: unknown;
+  /** When true, route ONLY to providers whose `proBono` policy serves this
+   *  requester for free (the pro-bono completion path). */
+  proBono?: unknown;
 }
 
 interface ParsedDispatch {
@@ -56,6 +62,11 @@ interface ParsedDispatch {
   /** Specific machine under targetProviderDid. Only forwarded when
    *  targetProviderDid is also set. */
   targetMachineId?: string;
+  /** Normalized ISO 3166-1 alpha-2 country filter (uppercased). */
+  country?: string;
+  /** True when the caller requested the pro-bono path. Resolved to an
+   *  `allowedProviderDids` allow-set in the handler (needs the requester DID). */
+  proBono: boolean;
 }
 
 function parseDispatch(body: DispatchBody): ParsedDispatch | string {
@@ -85,6 +96,16 @@ function parseDispatch(body: DispatchBody): ParsedDispatch | string {
   if (body.targetMachineId !== undefined && typeof body.targetMachineId !== "string") {
     return "targetMachineId must be a string when provided";
   }
+  let country: string | undefined;
+  if (body.country !== undefined) {
+    if (typeof body.country !== "string" || !/^[A-Za-z]{2}$/.test(body.country.trim())) {
+      return "country must be a 2-letter ISO 3166-1 alpha-2 code";
+    }
+    country = body.country.trim().toUpperCase();
+  }
+  if (body.proBono !== undefined && typeof body.proBono !== "boolean") {
+    return "proBono must be a boolean when provided";
+  }
   // `messages` is optional; only validated (and only matters) when images
   // ride along. An explicitly-present-but-malformed value is a 400.
   let messages: EnvelopeMessage[] | undefined;
@@ -105,6 +126,8 @@ function parseDispatch(body: DispatchBody): ParsedDispatch | string {
     ...(typeof body.targetProviderDid === "string" && typeof body.targetMachineId === "string"
       ? { targetMachineId: body.targetMachineId }
       : {}),
+    ...(country ? { country } : {}),
+    proBono: body.proBono === true,
   };
 }
 
@@ -135,18 +158,46 @@ export const Route = createFileRoute("/api/xrpc/dev.cocore.inference.dispatch")(
         const parsed = parseDispatch(body);
         if (typeof parsed === "string") return json({ error: parsed }, 400);
 
+        // The pro-bono path: route ONLY to providers whose policy serves this
+        // requester free. We resolve WHO offers them pro bono here (the console
+        // has the AppView read + the requester DID), then forward / pass the
+        // allow-set so either core just filters. Fail closed if nobody does.
+        const { proBono, ...rest } = parsed;
+        let allowedProviderDids: string[] | undefined;
+        if (proBono) {
+          try {
+            const set = await resolveProBonoProviderDids(session.did);
+            if (set.size === 0) {
+              return json(
+                {
+                  error:
+                    "no provider currently offers you pro-bono compute; turn off pro bono for a normal (billed) request",
+                  code: "no-pro-bono-providers",
+                },
+                503,
+              );
+            }
+            allowedProviderDids = [...set];
+          } catch (e) {
+            return json({ error: `pro-bono lookup failed: ${(e as Error).message}` }, 502);
+          }
+        }
+
         // Forward to the AppView when configured (it owns the dispatch core +
         // the requester's OAuth session); otherwise run the legacy in-process
         // core below. Both yield the same SSE shape. The forwarded body carries
         // the RAW `messages` (JSON-serializable) — the AppView route rebuilds
         // the envelope on its side; we don't ship binary payloadBytes.
         if (isDispatchForwardConfigured()) {
-          return forwardDispatch({ oauthSession: session.oauthSession, body: { ...parsed } });
+          return forwardDispatch({
+            oauthSession: session.oauthSession,
+            body: { ...rest, ...(allowedProviderDids ? { allowedProviderDids } : {}) },
+          });
         }
 
         // Local in-process core: seal the canonical multimodal envelope when
         // images are present, else the flattened prompt.
-        const { messages, ...textInputs } = parsed;
+        const { messages, ...textInputs } = rest;
         const envelope = messages
           ? { payloadBytes: buildEnvelopeBytes(messages), inputFormat: MESSAGES_V1 }
           : {};
@@ -155,6 +206,7 @@ export const Route = createFileRoute("/api/xrpc/dev.cocore.inference.dispatch")(
           oauthSession: session.oauthSession,
           ...textInputs,
           ...envelope,
+          ...(allowedProviderDids ? { allowedProviderDids: new Set(allowedProviderDids) } : {}),
         });
 
         const stream = new ReadableStream<Uint8Array>({

--- a/packages/console/src/routes/v1.probono.chat.completions.ts
+++ b/packages/console/src/routes/v1.probono.chat.completions.ts
@@ -1,0 +1,23 @@
+// POST /v1/probono/chat/completions
+//
+// The pro-bono completion path: same OpenAI wire format as
+// `/v1/chat/completions`, but routing is constrained to providers whose
+// `proBono` policy elects to serve THIS requester for free (`mode: any`, or
+// `mode: direct` with the caller's DID listed). A matched job is unmetered,
+// zero-price, and takes no exchange cut, so a balance-less requester can still
+// get a completion. Fails closed (503 `no_pro_bono_providers`) when no
+// connected provider currently offers the caller pro bono. `country` still
+// narrows by region. The handler is shared with the legacy
+// `/api/v1/probono/chat/completions` mount.
+
+import { createFileRoute } from "@tanstack/react-router";
+
+import { handleProBonoChatCompletions } from "@/lib/openai-routes.server.ts";
+
+export const Route = createFileRoute("/v1/probono/chat/completions")({
+  server: {
+    handlers: {
+      POST: ({ request }) => handleProBonoChatCompletions(request),
+    },
+  },
+});

--- a/packages/sdk/src/types.gen.ts
+++ b/packages/sdk/src/types.gen.ts
@@ -194,6 +194,7 @@ export interface ProviderRecord {
   tier?: Tier;
   desiredTier?: Tier;
   acceptedExchanges?: string[];
+  proBono?: Record<string, unknown>;
   contactEndpoint?: string;
   active?: boolean;
   provisioning?: boolean;
@@ -201,6 +202,7 @@ export interface ProviderRecord {
   payoutsEnabled?: boolean;
   binaryVersion?: string;
   engineFault?: { code: string; message: string; models?: string[]; at: string };
+  shareLocation?: boolean;
   region?: string;
   regionSource?: string;
   regionObservedAt?: string;
@@ -226,6 +228,7 @@ export interface ReceiptRecord {
   attestation: StrongRef;
   enclaveSignature: string;
   tier?: Tier;
+  proBono?: boolean;
 }
 
 export interface SettlementRecord {

--- a/provider-shell/Sources/CoCoreShell/AgentSupervisor.swift
+++ b/provider-shell/Sources/CoCoreShell/AgentSupervisor.swift
@@ -509,39 +509,11 @@ final class AgentSupervisor {
         }
     }
 
-    /// Write/clear the `~/.cocore/share-location` marker from the current
-    /// location-sharing toggle, then restart the agent so it re-resolves and
-    /// re-stamps (or clears) the provider record's coarse `region` on its next
-    /// serve. Same LaunchAgent-vs-supervised-child mode split as
-    /// `applyScheduleAndReconnect`. Unlike the network/schedule applies there's
-    /// no env var to edit — the agent reads the marker file at serve start —
-    /// so the LaunchAgent path just bounces to pick up the change.
-    func applyLocationSharingAndReconnect() async {
-        let on = UserDefaults.standard.bool(forKey: "shareLocation")
-        Self.setLocationSharingMarker(on)
-        if isLaunchAgentManaged {
-            Self.bounce(label: "dev.cocore.provider")
-        } else {
-            await stop()
-            await start()
-        }
-    }
-
-    /// Write (or remove) the `~/.cocore/share-location` marker — the durable
-    /// record of the owner's coarse-location-sharing intent. Mirrors the
-    /// Secure-Mode marker: a file's existence IS the boolean, and the Rust
-    /// agent reads it at serve start (`location_sharing_enabled`).
-    nonisolated static func setLocationSharingMarker(_ on: Bool) {
-        let path = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".cocore/share-location")
-        if on {
-            try? FileManager.default.createDirectory(
-                at: path.deletingLastPathComponent(), withIntermediateDirectories: true)
-            try? Data().write(to: path)
-        } else {
-            try? FileManager.default.removeItem(at: path)
-        }
-    }
+    // Coarse-location sharing is no longer a tray toggle: it's configured
+    // per-machine on the console (the `shareLocation` switch on the provider
+    // record). The agent reads that field off its own record at serve start and
+    // re-resolves / clears the coarse `region` accordingly — no local marker
+    // file, so there is nothing to apply from here.
 
     /// Apply the current per-model schedules (`COCORE_MODEL_SCHEDULES`) to the
     /// running agent and reload. Same mode split as the whole-app schedule:

--- a/provider-shell/Sources/CoCoreShell/PreferencesView.swift
+++ b/provider-shell/Sources/CoCoreShell/PreferencesView.swift
@@ -55,12 +55,10 @@ struct PreferencesView: View {
     @AppStorage("scheduleLimited") private var scheduleLimited = false
     @AppStorage("idleStart") private var idleStart = 22
     @AppStorage("idleEnd") private var idleEnd = 8
-    @AppStorage("shareLocation") private var shareLocation = false
 
     @State private var networkApplied = false
     @State private var nameApplied = false
     @State private var scheduleApplied = false
-    @State private var locationApplied = false
 
     // One grouped settings form. (Was its own nested TabView with a Status
     // sub-tab; that sub-tab is now the main window's Status tab, and tabs
@@ -156,23 +154,7 @@ struct PreferencesView: View {
                 }
             }
             Section("Location") {
-                Toggle("Share this machine's country", isOn: $shareLocation)
-                    .toggleStyle(.switch)
-                HStack {
-                    Button("Apply & restart agent") {
-                        Task {
-                            await supervisor.applyLocationSharingAndReconnect()
-                            locationApplied = true
-                        }
-                    }
-                    .tint(Color.primary)
-                    if locationApplied {
-                        Text("Applied — agent restarted")
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-                    }
-                }
-                Text("When on, this machine publishes only its coarse country (e.g. “US”) to its public record, refreshed each time it starts serving. It's an advisory signal derived from your IP address — not a precise or verified location. Turn it off and the country is removed on the next restart.")
+                Text("Sharing this machine's coarse country is now configured on the website — open this machine in the console and turn on “Share country”. It publishes only an advisory country (e.g. “US”) derived from your IP, refreshed each time the machine serves.")
                     .font(.footnote)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -543,6 +543,12 @@ fn preserve_console_fields(record: &mut ProviderRecord, existing: &serde_json::V
     // the others it's console-written; carry it through or a serve restart
     // would silently drop the owner's choice to give work away free.
     record.proBono = ProBonoPolicy::from_record_value(existing);
+    // The owner's location-sharing opt-in (console "Share country" switch).
+    // Console-written like the others — carry it through, or a serve restart
+    // would silently drop the owner's choice. The agent reads this to decide
+    // whether to stamp `region` (see `cmd_serve`); preserving it keeps the
+    // switch sticky across re-publishes.
+    record.shareLocation = existing.get("shareLocation").and_then(|v| v.as_bool());
 }
 
 /// Find this machine's existing provider record (if any) on the
@@ -675,23 +681,6 @@ fn clear_serving_paused() {
     if let Some(p) = serving_paused_path() {
         let _ = std::fs::remove_file(p);
     }
-}
-
-/// `~/.cocore/share-location` — present while the owner has opted this
-/// machine into coarse location sharing (the tray's "Share this machine's
-/// country" toggle, which mirrors the `secure-mode-desired` marker: a file's
-/// existence IS the boolean). The agent reads it at serve start and, when
-/// present, stamps the provider record's `region` from a best-effort
-/// IP→country lookup; when absent it omits the field, so the next re-publish
-/// drops any value shared on a prior serve (opt-out clears the data). The
-/// agent never writes this file — it's purely owner intent set by the tray.
-fn share_location_path() -> Option<std::path::PathBuf> {
-    dirs::home_dir().map(|h| h.join(".cocore").join("share-location"))
-}
-
-/// Whether the owner has opted this machine into coarse location sharing.
-fn location_sharing_enabled() -> bool {
-    share_location_path().map(|p| p.exists()).unwrap_or(false)
 }
 
 /// Block until the owner's `active` switch on our provider record is true,
@@ -1056,6 +1045,10 @@ async fn cmd_serve(
             // Owner's pro-bono election — preserved from the existing record
             // by dedup, like active/desiredModels/desiredTier.
             proBono: None,
+            // Owner's location-sharing opt-in — preserved from the existing
+            // record by dedup, like proBono. The provisioning publish never
+            // stamps region (no network lookup before the engine is up).
+            shareLocation: None,
             provisioning: Some(true),
             // NOT serving yet: this record is published immediately (so the
             // machine is visible) while the engine is still loading/downloading.
@@ -1106,10 +1099,11 @@ async fn cmd_serve(
     // of an unmeasured Python child, defeating the tier). We still read
     // `desiredModels` below so a change still triggers a reload restart.
     let confidential = push_rx.is_some();
-    let (desired_at_start, desired_tier_at_start, pro_bono_at_start): (
+    let (desired_at_start, desired_tier_at_start, pro_bono_at_start, share_location_at_start): (
         Vec<String>,
         Option<String>,
         ProBonoPolicy,
+        bool,
     ) = match find_my_provider_record(&pds, &attestation_pub_key).await {
         Ok((_, value, _)) => {
             let models = value
@@ -1125,13 +1119,20 @@ async fn cmd_serve(
                 .get("desiredTier")
                 .and_then(|v| v.as_str())
                 .map(str::to_string);
+            // The owner's location-sharing opt-in, read off our own record so
+            // this serve decides whether to geolocate + stamp `region`. Absent
+            // ≡ off (no country published).
+            let share_location = value
+                .get("shareLocation")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
             // The owner's pro-bono election, read off our own record so each
             // served job can decide per-requester whether it's free. Absent /
             // malformed ≡ off (every job metered + billed).
             let pro_bono = ProBonoPolicy::from_record_value(&value).unwrap_or_default();
-            (models, tier, pro_bono)
+            (models, tier, pro_bono, share_location)
         }
-        Err(_) => (Vec::new(), None, ProBonoPolicy::default()),
+        Err(_) => (Vec::new(), None, ProBonoPolicy::default(), false),
     };
     match inference_models_action(confidential, &desired_at_start) {
         InferenceModelsAction::Clear => {
@@ -1332,13 +1333,14 @@ async fn cmd_serve(
         Err(_) => (TrustLevel::SelfAttested, None),
     };
 
-    // Coarse, opt-in location (refresh-on-serve). Only when the owner flipped
-    // the tray's location-sharing toggle do we resolve this machine's country
-    // from its public IP and stamp it onto the record. ADVISORY/self-asserted
-    // (a VPN moves it) — published to the provider's OWN PDS, never trusted as
-    // proof. A failed lookup leaves it unset for this serve; sharing-off omits
-    // it entirely so the next re-publish drops any prior value.
-    let (region, region_source, region_observed_at) = if location_sharing_enabled() {
+    // Coarse, opt-in location (refresh-on-serve). Only when the owner opted in
+    // via the console's `shareLocation` switch (read off our record above) do we
+    // resolve this machine's country from its public IP and stamp it onto the
+    // record. ADVISORY/self-asserted (a VPN moves it) — published to the
+    // provider's OWN PDS, never trusted as proof. A failed lookup leaves it
+    // unset for this serve; sharing-off omits it entirely so the next
+    // re-publish drops any prior value.
+    let (region, region_source, region_observed_at) = if share_location_at_start {
         let http = reqwest::Client::new();
         match cocore_provider::geoip::resolve_country(&http).await {
             Some(cc) => {
@@ -1398,6 +1400,10 @@ async fn cmd_serve(
         desiredTier: None,
         // Owner's pro-bono election — preserved by dedup like the others.
         proBono: None,
+        // Owner's location-sharing opt-in — preserved by dedup like proBono.
+        // (The `region` below was already gated on its value, read at serve
+        // start; this carries the switch itself through the re-publish.)
+        shareLocation: None,
         // Engine is loaded by this point — clear the provisioning flag we
         // set on the early publish above, so the console flips the row
         // from "provisioning" to live.
@@ -2532,6 +2538,7 @@ mod offline_marker_tests {
             desiredModels: None,
             desiredTier: None,
             proBono: None,
+            shareLocation: None,
             provisioning: Some(false),
             serving: Some(true),
             engineFault: None,
@@ -2606,6 +2613,24 @@ mod offline_marker_tests {
         );
     }
 
+    /// The owner's console-written pro-bono election and location-sharing
+    /// opt-in ride the same preserve path — a re-publish must not drop them.
+    #[test]
+    fn preserve_carries_pro_bono_and_share_location() {
+        let mut rebuilt = agent_built_record();
+        let live = serde_json::json!({
+            "proBono": { "mode": "direct", "dids": ["did:plc:friend"] },
+            "shareLocation": true
+        });
+
+        preserve_console_fields(&mut rebuilt, &live);
+
+        let pro_bono = rebuilt.proBono.expect("pro-bono election preserved");
+        assert_eq!(pro_bono.mode, "direct");
+        assert_eq!(pro_bono.dids, vec!["did:plc:friend".to_string()]);
+        assert_eq!(rebuilt.shareLocation, Some(true));
+    }
+
     /// When the live record has no switches set (a brand-new machine), the
     /// fields stay `None` — we don't fabricate values.
     #[test]
@@ -2619,5 +2644,7 @@ mod offline_marker_tests {
         assert_eq!(offline.payoutsEnabled, None);
         assert_eq!(offline.desiredModels, None);
         assert_eq!(offline.desiredTier, None);
+        assert_eq!(offline.proBono.is_none(), true);
+        assert_eq!(offline.shareLocation, None);
     }
 }

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -2644,7 +2644,7 @@ mod offline_marker_tests {
         assert_eq!(offline.payoutsEnabled, None);
         assert_eq!(offline.desiredModels, None);
         assert_eq!(offline.desiredTier, None);
-        assert_eq!(offline.proBono.is_none(), true);
+        assert!(offline.proBono.is_none());
         assert_eq!(offline.shareLocation, None);
     }
 }

--- a/provider/src/pds.rs
+++ b/provider/src/pds.rs
@@ -122,6 +122,15 @@ pub struct ProviderRecord {
     /// off (every job is metered and billed).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub proBono: Option<ProBonoPolicy>,
+    /// The owner's opt-in to publishing this machine's coarse country. Owner-
+    /// written INTENT, like `desiredModels`/`active`/`desiredTier`/`proBono`:
+    /// the agent reconciles toward it (when true it geolocates the public IP at
+    /// serve start and stamps `region`/`regionSource`/`regionObservedAt`) but
+    /// NEVER authors it, so it must PRESERVE whatever it finds on every
+    /// re-publish. Absent ≡ not sharing; the agent then omits the region
+    /// fields so opting out clears any previously-shared value.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shareLocation: Option<bool>,
     /// True while the agent is still loading its inference engine. Set on
     /// the early "provisioning" publish at serve start so the machine
     /// appears on the console immediately; cleared (set false) on the
@@ -146,10 +155,11 @@ pub struct ProviderRecord {
     /// best-effort IP→country lookup at serve start, NOT a proof of location
     /// (a VPN moves it; verifiers MUST NOT trust it — same posture as
     /// `tier`). Set fresh on every serve when the owner has opted in via the
-    /// tray's location-sharing toggle (`~/.cocore/share-location`); `None`
-    /// when sharing is off, so a re-publish drops any previously-shared value
-    /// (opt-out clears the data). Unlike the console-authored switches it is
-    /// NOT carried through `preserve_console_fields` — the agent owns it.
+    /// console's `shareLocation` switch on this record; `None` when sharing is
+    /// off, so a re-publish drops any previously-shared value (opt-out clears
+    /// the data). Unlike the console-authored switches it is NOT carried
+    /// through `preserve_console_fields` — the agent re-derives it each serve
+    /// from `shareLocation`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub region: Option<String>,
     /// How `region` was derived (e.g. `ip-geo`). Present iff `region` is.


### PR DESCRIPTION
## Why

PRs #104 (country routing) and #105 (pro-bono carve-out) landed the lexicon / provider / exchange plumbing, but there was **no way to configure or use either feature from the website**, and neither was documented. This wires both features end to end — provider config UI, requester UI + API, and docs.

## Coarse location (region) — now site-configured

The geo opt-in used to be a local macOS-tray marker file (`~/.cocore/share-location`) read only by the agent. It's now a **site-configured field**:

- **Lexicon:** new owner-intent `shareLocation` boolean on `dev.cocore.compute.provider`. The agent reads it off its own record at serve start (same pattern as `desiredTier`/`proBono`), geolocates its public IP, and stamps `region` — refreshed every serve, cleared on the next re-publish when off. (You were right that the coordinator can geocode the origin IP on a cadence — the agent already does exactly that each serve, so the only change needed was moving the opt-in from the tray to a record field.)
- **Provider/tray:** agent gates region stamping on `shareLocation`; the dead marker functions and the tray "Location" toggle are removed (the tray now points owners at the website).
- **Console:** a per-machine **Advanced settings** dialog with a "Share country" switch (shows the current region when on). Region is surfaced in the `/models` directory.

## Pro-bono completion path

- **Provider config:** the same Advanced settings dialog configures the `proBono` policy — **off / anyone / friends-only** (an editable requester-DID allowlist) — written to the provider record.
- **Requester path:** a new **`POST /v1/probono/chat/completions`** endpoint (+ `/api/v1` mount) and an in-app chat toggle route **only** to providers whose policy serves the requester for free, reusing the existing `allowedProviderDids` gate. The allow-set is resolved from the AppView's provider records; it **fails closed** (`no_pro_bono_providers`, 503) when nobody offers the caller pro bono. Because a pro-bono receipt moves no balance, a balance-less requester can be served. The AppView dispatch core gained the allow-set filter the console core already had.

## Requester country picker

Added to the in-app chat (the API `country` param was already wired in #104). "Any" = unpinned.

## Docs

- `openapi.yaml`: documented the pro-bono endpoint + its `no_pro_bono_providers` error (country/region were already in there).
- `lexicons/README.md`: new "Coarse location (region)" section + pro-bono routing notes.
- root `README.md`: a "Choosing where (and how) a job runs" section covering country + pro-bono + the existing verified/friends paths.

## Tests / validation

- Provider: new `preserve_console_fields` coverage for `proBono` + `shareLocation`; **all 144 lib tests + 5 cross-language fixture tests pass**.
- New pure `proBonoApplies` predicate test (console).
- Console + AppView TypeScript typecheck clean (only the pre-existing `vite/client` sandbox-types error remains).
- Note: `vitest` and the linters aren't installed in this sandbox, so the TS unit tests and oxlint/oxfmt will run in CI.

## Notes for review

- Decision: the requester pro-bono path is delivered as a **dedicated endpoint** (mirrors `/v1/verified` and `/v1/private`) rather than a request flag, and the in-app chat uses the existing dispatch endpoint with a `proBono` body field resolved server-side. No advisor/Rust changes were needed for routing — `proBono` stays a provider-decided, owner-written field.
- Swift changes are unverified locally (no Swift toolchain in this sandbox); they're text-level deletions of the now-unused tray toggle + marker writer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBi32Ke745obh3mwS71Yva

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBi32Ke745obh3mwS71Yva)_