### PR TITLE
Document pro-bono completions route and country routing

### DIFF
--- a/packages/console/src/components/inference-docs/pages/api-reference.tsx
+++ b/packages/console/src/components/inference-docs/pages/api-reference.tsx
@@ -56,7 +56,16 @@ export function InferenceApiReferencePage({ baseUrl }: { baseUrl: string }) {
 { "error": { "type": "service_unavailable_error", "code": "no_friends_available", "message": "..." } }
 
 // 404 — friends-only, but no friend serves this model
-{ "error": { "type": "invalid_request_error", "code": "no_friends_for_model", "message": "..." } }`}
+{ "error": { "type": "invalid_request_error", "code": "no_friends_for_model", "message": "..." } }
+
+// 503 — country set, but no provider in that region serves this model
+{ "error": { "type": "service_unavailable_error", "code": "no_providers_for_country", "message": "..." } }
+
+// 503 — pro-bono route, but no connected provider currently serves you free
+{ "error": { "type": "service_unavailable_error", "code": "no_pro_bono_providers", "message": "..." } }
+
+// 502 — pro-bono route, the provider lookup itself failed (try again)
+{ "error": { "type": "server_error", "code": "pro_bono_lookup_failed", "message": "..." } }`}
                 />
               ) : (
                 <>

--- a/packages/console/src/lib/inference-docs/catalog.ts
+++ b/packages/console/src/lib/inference-docs/catalog.ts
@@ -40,7 +40,7 @@ export const INFERENCE_API_CATALOG: Array<InferenceApiCatalogEntry> = [
     method: "POST",
     path: "/chat/completions",
     description:
-      "OpenAI-compatible chat completion. Routes to an attested provider serving the requested model. Set country to an ISO 3166-1 alpha-2 code (e.g. US) to route only to providers advertising that region — an advisory provider self-claim — failing closed with no_providers_for_country when none match. country is accepted on every completion route below.",
+      "OpenAI-compatible chat completion. Routes to an attested provider serving the requested model. Set country to an ISO 3166-1 alpha-2 code (e.g. US) to route only to providers advertising that region — an advisory provider self-claim — failing closed with no_providers_for_country when none match.",
     auth: "required",
     params: [
       { name: "model", type: "string", required: true },
@@ -91,7 +91,7 @@ export const INFERENCE_API_CATALOG: Array<InferenceApiCatalogEntry> = [
     method: "POST",
     path: "/private/chat/completions",
     description:
-      "Same request shape as chat/completions, but routing is limited to providers run by DIDs on your friends list.",
+      "Same request shape as chat/completions, but routing is limited to providers run by DIDs on your friends list. country still narrows by region.",
     auth: "required",
     params: [
       { name: "model", type: "string", required: true },
@@ -119,7 +119,7 @@ export const INFERENCE_API_CATALOG: Array<InferenceApiCatalogEntry> = [
     method: "POST",
     path: "/verified/chat/completions",
     description:
-      'Same request shape as chat/completions, but routing is limited to providers whose attestation is cryptographically verified (recomputed from the signed Apple-rooted attestation, not the self-asserted label). Set min_trust to "hardware-attested" (default) or "confidential" to pick the floor. Fails closed with no_verified_providers when none qualify.',
+      'Same request shape as chat/completions, but routing is limited to providers whose attestation is cryptographically verified (recomputed from the signed Apple-rooted attestation, not the self-asserted label). Set min_trust to "hardware-attested" (default) or "confidential" to pick the floor. Fails closed with no_verified_providers when none qualify. country still narrows by region.',
     auth: "required",
     params: [
       { name: "model", type: "string", required: true },

--- a/packages/console/src/lib/inference-docs/catalog.ts
+++ b/packages/console/src/lib/inference-docs/catalog.ts
@@ -40,13 +40,14 @@ export const INFERENCE_API_CATALOG: Array<InferenceApiCatalogEntry> = [
     method: "POST",
     path: "/chat/completions",
     description:
-      "OpenAI-compatible chat completion. Routes to an attested provider serving the requested model.",
+      "OpenAI-compatible chat completion. Routes to an attested provider serving the requested model. Set country to an ISO 3166-1 alpha-2 code (e.g. US) to route only to providers advertising that region — an advisory provider self-claim — failing closed with no_providers_for_country when none match. country is accepted on every completion route below.",
     auth: "required",
     params: [
       { name: "model", type: "string", required: true },
       { name: "messages", type: "array", required: true },
       { name: "stream", type: "boolean" },
       { name: "max_tokens", type: "integer" },
+      { name: "country", type: "string" },
     ],
     controls: [
       { kind: "text", param: "model", label: "model", placeholder: "stub" },
@@ -57,6 +58,7 @@ export const INFERENCE_API_CATALOG: Array<InferenceApiCatalogEntry> = [
         placeholder: "Hello",
       },
       { kind: "text", param: "max_tokens", label: "max_tokens", placeholder: "256" },
+      { kind: "text", param: "country", label: "country", placeholder: "US" },
     ],
     example: { body: CHAT_BODY, canRun: false },
   },
@@ -96,6 +98,7 @@ export const INFERENCE_API_CATALOG: Array<InferenceApiCatalogEntry> = [
       { name: "messages", type: "array", required: true },
       { name: "stream", type: "boolean" },
       { name: "max_tokens", type: "integer" },
+      { name: "country", type: "string" },
     ],
     controls: [
       { kind: "text", param: "model", label: "model", placeholder: "stub" },
@@ -106,6 +109,7 @@ export const INFERENCE_API_CATALOG: Array<InferenceApiCatalogEntry> = [
         placeholder: "Hello",
       },
       { kind: "text", param: "max_tokens", label: "max_tokens", placeholder: "256" },
+      { kind: "text", param: "country", label: "country", placeholder: "US" },
     ],
     example: { body: CHAT_BODY, canRun: false },
   },
@@ -123,6 +127,7 @@ export const INFERENCE_API_CATALOG: Array<InferenceApiCatalogEntry> = [
       { name: "min_trust", type: "string" },
       { name: "stream", type: "boolean" },
       { name: "max_tokens", type: "integer" },
+      { name: "country", type: "string" },
     ],
     controls: [
       { kind: "text", param: "model", label: "model", placeholder: "stub" },
@@ -139,6 +144,35 @@ export const INFERENCE_API_CATALOG: Array<InferenceApiCatalogEntry> = [
         placeholder: "hardware-attested",
       },
       { kind: "text", param: "max_tokens", label: "max_tokens", placeholder: "256" },
+      { kind: "text", param: "country", label: "country", placeholder: "US" },
+    ],
+    example: { body: CHAT_BODY, canRun: false },
+  },
+  {
+    id: "inference-api-probono-chat-completions",
+    navLabel: "probono/chat/completions",
+    method: "POST",
+    path: "/probono/chat/completions",
+    description:
+      "Same request shape as chat/completions, but routing is limited to providers whose proBono policy elects to serve YOU for free (mode any, or mode direct with your DID listed). A matched job is unmetered, zero-price, and takes no exchange cut, so a balance-less requester can still get a completion. Fails closed with no_pro_bono_providers (503) when no connected provider currently offers you pro bono, or pro_bono_lookup_failed (502) when the provider lookup itself fails. country still narrows by region.",
+    auth: "required",
+    params: [
+      { name: "model", type: "string", required: true },
+      { name: "messages", type: "array", required: true },
+      { name: "stream", type: "boolean" },
+      { name: "max_tokens", type: "integer" },
+      { name: "country", type: "string" },
+    ],
+    controls: [
+      { kind: "text", param: "model", label: "model", placeholder: "stub" },
+      {
+        kind: "text",
+        param: "message",
+        label: "user message",
+        placeholder: "Hello",
+      },
+      { kind: "text", param: "max_tokens", label: "max_tokens", placeholder: "256" },
+      { kind: "text", param: "country", label: "country", placeholder: "US" },
     ],
     example: { body: CHAT_BODY, canRun: false },
   },


### PR DESCRIPTION
## Why

The inference API ships two features that the API-reference page never documented:

- **`POST /v1/probono/chat/completions`** — implemented in `openai-routes.server.ts` (`handleProBonoChatCompletions`) / `inference-dispatch.server.ts`, but absent from the docs catalog.
- **`country` region routing** — the optional ISO 3166-1 alpha-2 body param (`filterByCountry`) that narrows dispatch to providers advertising a region. Also undocumented.

So the catalog only listed `chat`, `models`, `private`, and `verified` completions, and the country filter wasn't mentioned anywhere. This adds them.

## What

- New `probono/chat/completions` entry in `catalog.ts` — auth required, same wire shape as `chat/completions`, with the pro-bono semantics (unmetered, zero-price, no exchange cut) and its fail-closed codes `no_pro_bono_providers` (503) / `pro_bono_lookup_failed` (502).
- Documented the optional **`country`** param on every completion route (chat, private, verified, probono), with the `US`-style placeholder in the interactive controls.
- Added the `no_providers_for_country` (503), `no_pro_bono_providers` (503), and `pro_bono_lookup_failed` (502) error codes to the **Dispatch errors** snippet.

Nav and scroll-spy derive from the catalog, so the new endpoint wires up automatically — no nav edits needed.

## Not in scope

`country` is a **JSON body parameter**, not TLD/hostname-derived routing. If `us.cocore.dev`-style TLD routing is wanted, that's new dispatch-layer code, not a docs change — happy to spec it separately if you want it.

## Verification

`tsc`, `oxlint`, and `oxfmt --check` pass on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RPyoMZW2PcSJgmpDzfCJa6)_