### PR TITLE
docs(inference): document image input on the inference API reference

### DIFF
--- a/packages/console/src/components/inference-docs/inference-docs-nav.tsx
+++ b/packages/console/src/components/inference-docs/inference-docs-nav.tsx
@@ -8,6 +8,7 @@ import { useDocsScrollSpyActive } from "@/components/docs/docs-scroll-spy-contex
 import {
   INFERENCE_API_CATALOG,
   INFERENCE_API_ERROR_SECTIONS,
+  INFERENCE_API_TOPIC_SECTIONS,
 } from "@/lib/inference-docs/catalog.ts";
 import { INFERENCE_API_INTRO_ID } from "@/lib/inference-docs/navigation-api.ts";
 import {
@@ -52,7 +53,9 @@ export function InferenceDocsNav() {
               <div {...stylex.props(docsStyles.refNavHeadingRow)}>
                 <span {...stylex.props(docsStyles.refNavHeading)}>{section}</span>
                 <span {...stylex.props(docsStyles.refNavHeadingCount)}>
-                  {INFERENCE_API_CATALOG.length + INFERENCE_API_ERROR_SECTIONS.length}
+                  {INFERENCE_API_CATALOG.length +
+                    INFERENCE_API_TOPIC_SECTIONS.length +
+                    INFERENCE_API_ERROR_SECTIONS.length}
                 </span>
               </div>
               {onApiReference ? (
@@ -79,6 +82,31 @@ export function InferenceDocsNav() {
                 </Link>
               )}
               {INFERENCE_API_CATALOG.map((entry) =>
+                onApiReference ? (
+                  <a
+                    key={entry.id}
+                    href={`#${entry.id}`}
+                    {...stylex.props(
+                      docsStyles.refNavLink,
+                      docsStyles.refNavLinkMono,
+                      active === entry.id && docsStyles.refNavLinkActive,
+                    )}
+                  >
+                    {entry.navLabel}
+                  </a>
+                ) : (
+                  <Link
+                    key={entry.id}
+                    to="/docs/inference/$slug"
+                    params={{ slug: "api-reference" }}
+                    hash={entry.id}
+                    {...stylex.props(docsStyles.refNavLink, docsStyles.refNavLinkMono)}
+                  >
+                    {entry.navLabel}
+                  </Link>
+                ),
+              )}
+              {INFERENCE_API_TOPIC_SECTIONS.map((entry) =>
                 onApiReference ? (
                   <a
                     key={entry.id}

--- a/packages/console/src/components/inference-docs/pages/api-reference.tsx
+++ b/packages/console/src/components/inference-docs/pages/api-reference.tsx
@@ -4,6 +4,7 @@ import * as stylex from "@stylexjs/stylex";
 import { Link } from "@tanstack/react-router";
 
 import { InferenceApiEndpoint } from "@/components/inference-docs/inference-api-endpoint.tsx";
+import { InferenceApiDocLink } from "@/components/inference-docs/inference-doc-link.tsx";
 import { docsStyles } from "@/components/docs/docs-page.stylex.tsx";
 import {
   HighlightedBlock,
@@ -12,6 +13,7 @@ import {
 import {
   INFERENCE_API_CATALOG,
   INFERENCE_API_ERROR_SECTIONS,
+  INFERENCE_API_TOPIC_SECTIONS,
 } from "@/lib/inference-docs/catalog.ts";
 import { INFERENCE_API_INTRO_ID } from "@/lib/inference-docs/navigation-api.ts";
 
@@ -35,6 +37,98 @@ export function InferenceApiReferencePage({ baseUrl }: { baseUrl: string }) {
 
       {INFERENCE_API_CATALOG.map((entry, index) => (
         <InferenceApiEndpoint key={entry.id} entry={entry} baseUrl={baseUrl} first={index === 0} />
+      ))}
+
+      {INFERENCE_API_TOPIC_SECTIONS.map((section) => (
+        <section key={section.id} id={section.id} {...stylex.props(docsStyles.endpoint)}>
+          <div {...stylex.props(docsStyles.endpointGrid)}>
+            <div {...stylex.props(docsStyles.endpointLeft)}>
+              <h2 {...stylex.props(docsStyles.h2)}>{section.title}</h2>
+              <p {...stylex.props(docsStyles.endpointDesc)}>{section.description}</p>
+              <p {...stylex.props(docsStyles.prose)}>
+                Any <code {...stylex.props(docsStyles.codeInline)}>chat/completions</code> route (open,{" "}
+                <code {...stylex.props(docsStyles.codeInline)}>private</code>, and{" "}
+                <code {...stylex.props(docsStyles.codeInline)}>verified</code>) accepts the OpenAI
+                array-of-parts <code {...stylex.props(docsStyles.codeInline)}>content</code> shape. A
+                message is either a plain string (text only) or an ordered list of{" "}
+                <code {...stylex.props(docsStyles.codeInline)}>text</code> and{" "}
+                <code {...stylex.props(docsStyles.codeInline)}>image_url</code> parts. There is no
+                separate upload endpoint — images travel inside the request body.
+              </p>
+              <HighlightedBlock
+                lang="json"
+                code={`{
+  "model": "your-vision-model",
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        { "type": "text", "text": "What's in this image?" },
+        {
+          "type": "image_url",
+          "image_url": {
+            "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg..."
+          }
+        }
+      ]
+    }
+  ]
+}`}
+              />
+              <p {...stylex.props(docsStyles.prose)}>
+                The <code {...stylex.props(docsStyles.codeInline)}>image_url.url</code> field takes one
+                of two forms:
+              </p>
+              <ul {...stylex.props(inferenceDocsSharedStyles.list)}>
+                <li {...stylex.props(inferenceDocsSharedStyles.bullet)}>
+                  <strong>Inline base64 data URI</strong> —{" "}
+                  <code {...stylex.props(docsStyles.codeInline)}>
+                    data:&lt;mime&gt;;base64,&lt;payload&gt;
+                  </code>
+                  . The MIME type must be <code {...stylex.props(docsStyles.codeInline)}>image/*</code>{" "}
+                  (e.g. <code {...stylex.props(docsStyles.codeInline)}>image/png</code>,{" "}
+                  <code {...stylex.props(docsStyles.codeInline)}>image/jpeg</code>). The bytes are
+                  sealed directly into the signed job, so the receipt verifies offline with no extra
+                  fetch.
+                </li>
+                <li {...stylex.props(inferenceDocsSharedStyles.bullet)}>
+                  <strong>Remote URL</strong> — an{" "}
+                  <code {...stylex.props(docsStyles.codeInline)}>http(s)://</code> link. co/core
+                  fetches it server-side, verifies the response is{" "}
+                  <code {...stylex.props(docsStyles.codeInline)}>image/*</code>, and inlines it as
+                  base64 before sealing, so the input stays self-contained.
+                </li>
+              </ul>
+              <h3 {...stylex.props(docsStyles.h2)}>Limits</h3>
+              <ul {...stylex.props(inferenceDocsSharedStyles.list)}>
+                <li {...stylex.props(inferenceDocsSharedStyles.bullet)}>
+                  Up to <strong>20 MiB</strong> of decoded image bytes per request, budgeted
+                  separately from the <strong>1 MiB</strong> text limit.
+                </li>
+                <li {...stylex.props(inferenceDocsSharedStyles.bullet)}>
+                  Up to <strong>256</strong> messages per request; images may be spread across them.
+                </li>
+                <li {...stylex.props(inferenceDocsSharedStyles.bullet)}>
+                  <strong>Images only.</strong> Non-image MIME types and arbitrary file attachments
+                  (PDFs, documents, audio) are rejected — there is no general file-upload part today.
+                </li>
+              </ul>
+              <h3 {...stylex.props(docsStyles.h2)}>Model support</h3>
+              <p {...stylex.props(docsStyles.prose)}>
+                Image input is not gated per model: any{" "}
+                <code {...stylex.props(docsStyles.codeInline)}>model</code> id you can route to will
+                accept an image-bearing request. Whether the image is actually understood depends on
+                the model — send images to a vision/multimodal model (the{" "}
+                <InferenceApiDocLink fragment="inference-api-models">
+                  models directory
+                </InferenceApiDocLink>{" "}
+                flags vision-capable models). A bad or unparseable{" "}
+                <code {...stylex.props(docsStyles.codeInline)}>image_url</code> with no accompanying
+                text returns <code {...stylex.props(docsStyles.codeInline)}>400 invalid_request_error</code>.
+              </p>
+            </div>
+          </div>
+        </section>
       ))}
 
       {INFERENCE_API_ERROR_SECTIONS.map((section) => (

--- a/packages/console/src/components/inference-docs/pages/api-reference.tsx
+++ b/packages/console/src/components/inference-docs/pages/api-reference.tsx
@@ -46,11 +46,11 @@ export function InferenceApiReferencePage({ baseUrl }: { baseUrl: string }) {
               <h2 {...stylex.props(docsStyles.h2)}>{section.title}</h2>
               <p {...stylex.props(docsStyles.endpointDesc)}>{section.description}</p>
               <p {...stylex.props(docsStyles.prose)}>
-                Any <code {...stylex.props(docsStyles.codeInline)}>chat/completions</code> route (open,{" "}
-                <code {...stylex.props(docsStyles.codeInline)}>private</code>, and{" "}
+                Any <code {...stylex.props(docsStyles.codeInline)}>chat/completions</code> route
+                (open, <code {...stylex.props(docsStyles.codeInline)}>private</code>, and{" "}
                 <code {...stylex.props(docsStyles.codeInline)}>verified</code>) accepts the OpenAI
-                array-of-parts <code {...stylex.props(docsStyles.codeInline)}>content</code> shape. A
-                message is either a plain string (text only) or an ordered list of{" "}
+                array-of-parts <code {...stylex.props(docsStyles.codeInline)}>content</code> shape.
+                A message is either a plain string (text only) or an ordered list of{" "}
                 <code {...stylex.props(docsStyles.codeInline)}>text</code> and{" "}
                 <code {...stylex.props(docsStyles.codeInline)}>image_url</code> parts. There is no
                 separate upload endpoint — images travel inside the request body.
@@ -76,8 +76,8 @@ export function InferenceApiReferencePage({ baseUrl }: { baseUrl: string }) {
 }`}
               />
               <p {...stylex.props(docsStyles.prose)}>
-                The <code {...stylex.props(docsStyles.codeInline)}>image_url.url</code> field takes one
-                of two forms:
+                The <code {...stylex.props(docsStyles.codeInline)}>image_url.url</code> field takes
+                one of two forms:
               </p>
               <ul {...stylex.props(inferenceDocsSharedStyles.list)}>
                 <li {...stylex.props(inferenceDocsSharedStyles.bullet)}>
@@ -85,8 +85,9 @@ export function InferenceApiReferencePage({ baseUrl }: { baseUrl: string }) {
                   <code {...stylex.props(docsStyles.codeInline)}>
                     data:&lt;mime&gt;;base64,&lt;payload&gt;
                   </code>
-                  . The MIME type must be <code {...stylex.props(docsStyles.codeInline)}>image/*</code>{" "}
-                  (e.g. <code {...stylex.props(docsStyles.codeInline)}>image/png</code>,{" "}
+                  . The MIME type must be{" "}
+                  <code {...stylex.props(docsStyles.codeInline)}>image/*</code> (e.g.{" "}
+                  <code {...stylex.props(docsStyles.codeInline)}>image/png</code>,{" "}
                   <code {...stylex.props(docsStyles.codeInline)}>image/jpeg</code>). The bytes are
                   sealed directly into the signed job, so the receipt verifies offline with no extra
                   fetch.
@@ -110,7 +111,8 @@ export function InferenceApiReferencePage({ baseUrl }: { baseUrl: string }) {
                 </li>
                 <li {...stylex.props(inferenceDocsSharedStyles.bullet)}>
                   <strong>Images only.</strong> Non-image MIME types and arbitrary file attachments
-                  (PDFs, documents, audio) are rejected — there is no general file-upload part today.
+                  (PDFs, documents, audio) are rejected — there is no general file-upload part
+                  today.
                 </li>
               </ul>
               <h3 {...stylex.props(docsStyles.h2)}>Model support</h3>
@@ -124,7 +126,8 @@ export function InferenceApiReferencePage({ baseUrl }: { baseUrl: string }) {
                 </InferenceApiDocLink>{" "}
                 flags vision-capable models). A bad or unparseable{" "}
                 <code {...stylex.props(docsStyles.codeInline)}>image_url</code> with no accompanying
-                text returns <code {...stylex.props(docsStyles.codeInline)}>400 invalid_request_error</code>.
+                text returns{" "}
+                <code {...stylex.props(docsStyles.codeInline)}>400 invalid_request_error</code>.
               </p>
             </div>
           </div>

--- a/packages/console/src/components/inference-docs/pages/index.tsx
+++ b/packages/console/src/components/inference-docs/pages/index.tsx
@@ -31,6 +31,12 @@ export function InferenceDocsOverviewPage({ baseUrl }: { baseUrl: string }) {
         <code {...stylex.props(docsStyles.codeInline)}>/v1/chat/completions</code>. Each request is
         matched to an online, attested provider and settled with a signed receipt.
       </p>
+      <p {...stylex.props(docsStyles.prose)}>
+        Requests can carry text or images: vision-capable models accept inline base64 or remote{" "}
+        <code {...stylex.props(docsStyles.codeInline)}>image_url</code> parts. See{" "}
+        <InferenceApiDocLink fragment="inference-api-image-input">image input</InferenceApiDocLink>{" "}
+        for the request shape and limits.
+      </p>
 
       <h2 {...stylex.props(docsStyles.h2)}>Before your first request</h2>
       <ol {...stylex.props(inferenceDocsSharedStyles.list)}>

--- a/packages/console/src/lib/inference-docs/catalog.ts
+++ b/packages/console/src/lib/inference-docs/catalog.ts
@@ -144,6 +144,16 @@ export const INFERENCE_API_CATALOG: Array<InferenceApiCatalogEntry> = [
   },
 ];
 
+export const INFERENCE_API_TOPIC_SECTIONS = [
+  {
+    id: "inference-api-image-input",
+    navLabel: "image input",
+    title: "Image input",
+    description:
+      "Vision-capable models accept images alongside text using OpenAI's multimodal content parts. Carried inline as base64 or fetched from a URL; no separate upload step.",
+  },
+] as const;
+
 export const INFERENCE_API_ERROR_SECTIONS = [
   {
     id: "inference-api-dispatch-errors",

--- a/packages/console/src/lib/inference-docs/navigation-api.ts
+++ b/packages/console/src/lib/inference-docs/navigation-api.ts
@@ -1,4 +1,8 @@
-import { INFERENCE_API_CATALOG, INFERENCE_API_ERROR_SECTIONS } from "./catalog.ts";
+import {
+  INFERENCE_API_CATALOG,
+  INFERENCE_API_ERROR_SECTIONS,
+  INFERENCE_API_TOPIC_SECTIONS,
+} from "./catalog.ts";
 
 export const INFERENCE_API_INTRO_ID = "inference-api-intro";
 
@@ -6,6 +10,7 @@ export function inferenceApiScrollSpyIds(): Array<string> {
   return [
     INFERENCE_API_INTRO_ID,
     ...INFERENCE_API_CATALOG.map((entry) => entry.id),
+    ...INFERENCE_API_TOPIC_SECTIONS.map((section) => section.id),
     ...INFERENCE_API_ERROR_SECTIONS.map((section) => section.id),
   ];
 }


### PR DESCRIPTION
## What

Adds documentation to **/docs/inference** explaining that the chat-completions endpoints accept image input, since the capability shipped without docs.

A new **"Image input"** section on the API reference page covers:

- The OpenAI-compatible multimodal request shape — `content` as an ordered array of `text` and `image_url` parts (with a JSON example).
- The two accepted `image_url.url` forms:
  - **Inline base64 data URI** (`data:<mime>;base64,...`, `image/*` only), sealed directly into the signed job.
  - **Remote `http(s)://` URL**, fetched server-side, verified as `image/*`, and inlined as base64 before sealing.
- **Limits:** 20 MiB decoded image bytes (budgeted separately from the 1 MiB text limit), 256 messages per request.
- **Images only:** non-image MIME types and arbitrary file uploads (PDFs, docs, audio) are rejected — there is no general file-upload part today.
- **Model support:** image input is *not* gated per model — any routable `model` id accepts an image-bearing request; whether it's understood depends on the model (the models directory flags vision-capable ones). Bad/unparseable `image_url` with no text → `400 invalid_request_error`.

The section is wired into the API-reference sidebar nav and scroll-spy, and cross-linked from the inference overview ("What you get").

## Why

The behavior is implemented (`packages/console/src/lib/openai-chat-completions.server.ts` + the `messages-v1` envelope in `@cocore/sdk`) but the public docs only described text. This documents what's already live; it answers the user's questions: yes to base64 image ingestion, no to arbitrary files, and no NSID/per-model gating.

## Scope

Docs content only — no behavior change. `pnpm --filter @cocore/console typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwgjBCtnpt4Bd64LmcuES2)_