### PR TITLE
provider: fix re-attestation lifecycle + model-load diagnosis from provider bug reports

### DIFF
--- a/lexicons/dev/cocore/compute/provider.json
+++ b/lexicons/dev/cocore/compute/provider.json
@@ -182,6 +182,28 @@
               }
             }
           },
+          "attestationFault": {
+            "type": "object",
+            "description": "Present when the agent could not build or publish its `dev.cocore.compute.attestation` record. The machine still appears and may still answer inference, but it will NOT produce verifiable receipts (a receipt strong-refs an attestation; without a published one there is nothing to reference), so it stays effectively self-attested even when the hardware would support more. Consumers SHOULD surface this to the operator as a fault with remediation guidance — without it, a publish failure is invisible and the machine merely looks idle. Absence means the attestation published cleanly (the agent clears this field on every successful (re-)attestation). Additive / optional — pre-2026-06 readers ignore it.",
+            "required": ["code", "message", "at"],
+            "properties": {
+              "code": {
+                "type": "string",
+                "maxLength": 64,
+                "description": "Machine-readable fault class: `attestation-publish-failed` (the record could not be written to the PDS) or `attestation-build-failed` (the signed record could not be assembled)."
+              },
+              "message": {
+                "type": "string",
+                "maxLength": 600,
+                "description": "Human-readable, content-safe summary with remediation guidance. Never contains prompt or completion bytes."
+              },
+              "at": {
+                "type": "string",
+                "format": "datetime",
+                "description": "When the agent recorded the fault."
+              }
+            }
+          },
           "shareLocation": {
             "type": "boolean",
             "description": "The owner's opt-in to publishing this machine's coarse country. Owner-written INTENT, set from a management UI (the console's per-machine settings), like `desiredModels`/`desiredTier`/`active`: the agent reconciles toward it but NEVER authors it, so it must PRESERVE whatever it finds on every re-publish. When `true`, the agent resolves this machine's country from a best-effort public-IP geolocation at serve start and stamps `region`/`regionSource`/`regionObservedAt`; when absent/`false` it omits those fields, so turning sharing off drops any previously-shared value on the next re-publish (opt-out clears the data). Absent ≡ not sharing. Optional / additive; pre-2026-06 agents ignore it."

--- a/packages/console/src/routes/api/agent.status.ts
+++ b/packages/console/src/routes/api/agent.status.ts
@@ -151,7 +151,19 @@ export const Route = createFileRoute("/api/agent/status")({
           trustLevel?: string;
           binaryVersion?: string;
           desiredTier?: string;
+          attestationFault?: { code?: string; message?: string; at?: string };
         };
+
+        // Surface an attestation build/publish failure: a machine in this
+        // state is online but cannot produce verifiable receipts, so without
+        // this it just looks idle. Mirrors how engineFault is surfaced.
+        const attestationFault = body.attestationFault
+          ? {
+              code: body.attestationFault.code ?? null,
+              message: body.attestationFault.message ?? null,
+              at: body.attestationFault.at ?? null,
+            }
+          : null;
 
         // The owner's DURABLE intent (written by `agent confidential`), distinct
         // from the advisor's verified standing. The app needs both: intent that
@@ -178,6 +190,7 @@ export const Route = createFileRoute("/api/agent/status")({
             confidentialDesired,
             confidentialBlockedReason,
             agentVersion: body.binaryVersion ?? null,
+            attestationFault,
             needsReauth,
           }),
           { status: 200, headers: { "content-type": "application/json" } },

--- a/provider/src/advisor.rs
+++ b/provider/src/advisor.rs
@@ -40,7 +40,7 @@ use serde_json::json;
 use sha2::{Digest, Sha256};
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, RwLock};
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 use zeroize::Zeroizing;
 
@@ -67,15 +67,22 @@ impl Drop for ZeroizeOnDrop {
 
 /// Bundles the long-lived state that
 /// [`handle_inference_request`] needs to publish a receipt: the PDS
-/// client (signs its own DPoP), the active attestation strong-ref
-/// (`None` if attestation publish failed at boot — receipts skip
-/// publishing in that mode), and the signer + X25519 keypair
-/// already passed for chunk/complete construction.
+/// client (signs its own DPoP), the active attestation strong-ref, and
+/// the signer + X25519 keypair already passed for chunk/complete
+/// construction.
+///
+/// The attestation is a shared, refreshable cell rather than a plain
+/// reference: a background task in `cmd_serve` re-publishes the attestation
+/// ~1h before it expires (24h lifetime) and swaps the new strong-ref in here,
+/// so jobs always reference the CURRENT attestation. It reads `None` when
+/// attestation publish failed (at boot or on a refresh) — receipts skip
+/// publishing in that mode — and a job reads the freshest value at the moment
+/// it publishes its receipt.
 struct ServeContext<'a> {
     signer: &'a dyn SigningIdentity,
     encryption: &'a ProviderKeypair,
     pds: &'a PdsClient,
-    attestation: Option<&'a StrongRef>,
+    attestation: Arc<RwLock<Option<StrongRef>>>,
     /// Per-model engine registry. `cmd_serve` constructs the
     /// registry from `COCORE_INFERENCE_MODELS` (or the singular
     /// legacy form), with a `stub` entry always included for the
@@ -105,7 +112,11 @@ impl AdvisorClient {
         signer: &dyn SigningIdentity,
         encryption: &ProviderKeypair,
         pds: &PdsClient,
-        attestation: Option<&StrongRef>,
+        // Shared, refreshable attestation cell (see `ServeContext`). Cloned
+        // from `cmd_serve`, which also hands a clone to the refresh task; on
+        // reconnect `run` re-reads the same cell, so it always picks up any
+        // attestation refreshed mid-connection.
+        attestation: Arc<RwLock<Option<StrongRef>>>,
         engines: &EngineRegistry,
         // rkey of this machine's provider record, so we can read the owner's
         // `active` start/stop switch off our own PDS. `None` skips the check
@@ -1211,7 +1222,12 @@ async fn handle_inference_request_inner(
         (tokens_in, tokens_out, price_minor)
     };
 
-    let (receipt_uri, receipt_commit) = match (req.job_cid.as_ref(), ctx.attestation) {
+    // Snapshot the current attestation for this job. The refresh task may swap
+    // a newer one in between jobs; reading here means every receipt references
+    // whatever attestation is live at publish time.
+    let attestation_snapshot = ctx.attestation.read().await.clone();
+    let (receipt_uri, receipt_commit) = match (req.job_cid.as_ref(), attestation_snapshot.as_ref())
+    {
         (Some(job_cid), Some(attestation)) => publish_stub_receipt(
             ctx,
             &req,
@@ -1706,14 +1722,14 @@ mod tests {
         signer: &'a dyn SigningIdentity,
         kp: &'a ProviderKeypair,
         pds: &'a PdsClient,
-        attestation: Option<&'a StrongRef>,
+        attestation: Option<&StrongRef>,
         engines: &'a EngineRegistry,
     ) -> ServeContext<'a> {
         ServeContext {
             signer,
             encryption: kp,
             pds,
-            attestation,
+            attestation: Arc::new(RwLock::new(attestation.cloned())),
             engines,
             pro_bono: off_pro_bono(),
         }

--- a/provider/src/engines/subprocess.rs
+++ b/provider/src/engines/subprocess.rs
@@ -201,6 +201,44 @@ fn state_dir() -> Result<PathBuf> {
     Ok(home.join(".cocore"))
 }
 
+/// Max bytes for the assembled ABSOLUTE socket path. The macOS `sun_path`
+/// limit is 104; we hold a margin so a slightly longer sockets dir can
+/// never push us over and trigger `ENAMETOOLONG` in the wrapper's bind().
+const SOCKET_PATH_CEILING: usize = 100;
+
+/// Build a length-safe socket *filename* for `model_id` under `sockets_dir`,
+/// guaranteeing `sockets_dir.join(name)` stays within [`SOCKET_PATH_CEILING`].
+///
+/// The name is `engine-<model><-hash>-<pid>-<nonce>.sock`. Uniqueness comes
+/// entirely from `pid` + `nonce`; the model text is cosmetic (so `ls
+/// ~/.cocore/sockets` still tells you which model each socket serves) and is
+/// truncated to whatever byte budget remains after the fixed parts. An 8-hex
+/// SHA-256 prefix of the FULL model id keeps the name distinguishable and
+/// stable even when the model text is truncated to nothing on a pathological
+/// long home directory.
+fn socket_filename(sockets_dir: &Path, model_id: &str, pid: u32, nonce: u32) -> String {
+    use sha2::{Digest, Sha256};
+    // 8 hex chars from the full id — survives truncation of the model text.
+    let hash = hex::encode(&Sha256::digest(model_id.as_bytes())[..4]);
+    // HF NSIDs contain slashes (would create subdirs); keep only chars that
+    // are safe and readable in a filename.
+    let sanitized: String = model_id
+        .replace('/', "_")
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '_' || *c == '-')
+        .collect();
+    // Fixed overhead = sockets_dir + path separator + "engine-" + model_seg
+    // + "-" + hash(8) + "-" + pid + "-" + nonce(8) + ".sock". Everything but
+    // model_seg is constant for this call, so compute the budget left for it.
+    let suffix = format!("-{hash}-{pid}-{nonce:08x}.sock");
+    let prefix = "engine-";
+    let dir_len = sockets_dir.as_os_str().len() + 1; // + separator
+    let fixed = dir_len + prefix.len() + suffix.len();
+    let budget = SOCKET_PATH_CEILING.saturating_sub(fixed);
+    let model_seg: String = sanitized.chars().take(budget).collect();
+    format!("{prefix}{model_seg}{suffix}")
+}
+
 /// Readiness is **stall-based**, not a fixed total budget. A cold first
 /// run downloads the model weights from HuggingFace inside the child
 /// (can be tens of GB), then Metal-mmaps them — a 20 GB model at a
@@ -267,16 +305,15 @@ impl SubprocessEngine {
         // path. A per-instance path removes both failure modes: every
         // unlink now targets only the unlinker's own socket.
         //
-        // Sanitize the model id — HF NSIDs contain slashes which would
-        // create subdirectories — and cap its length so the assembled
-        // path stays well under the macOS `sun_path` limit (~104
-        // bytes). The model segment is cosmetic; uniqueness comes from
-        // the pid + nonce, so truncating it can never cause a
-        // collision.
-        let sanitized: String = model_id.replace('/', "_").chars().take(40).collect();
+        // The model segment is cosmetic — uniqueness comes from the pid +
+        // nonce — so `socket_filename` budgets it against the macOS
+        // `sun_path` limit: with a long $HOME, capping only the model
+        // segment (as an earlier revision did) still let the assembled
+        // ABSOLUTE path overflow, and the wrapper's bind() then raised
+        // `ENAMETOOLONG` and the engine never came up.
         let pid = std::process::id();
         let nonce: u32 = rand::random();
-        let socket_path = sockets_dir.join(format!("engine-{sanitized}-{pid}-{nonce:08x}.sock"));
+        let socket_path = sockets_dir.join(socket_filename(&sockets_dir, &model_id, pid, nonce));
         Ok(Self {
             model_id,
             venv_python,
@@ -1184,5 +1221,55 @@ mod tests {
                 "image_url": { "url": "data:image/png;base64,aGVsbG8=" },
             }),
         );
+    }
+
+    /// A pathological long home dir + a long model id must still produce an
+    /// absolute path within the `sun_path` ceiling — the bug that made the
+    /// wrapper's bind() raise `ENAMETOOLONG`.
+    #[test]
+    fn socket_filename_stays_under_ceiling() {
+        let dir = Path::new("/Users/some.very.long.username.here/.cocore/sockets");
+        let model = "lmstudio-community/gemma-4-12B-it-MLX-8bit-extra-long-suffix-padding";
+        let name = socket_filename(dir, model, 99999, 0xdeadbeef);
+        let full = dir.join(&name);
+        assert!(
+            full.as_os_str().len() <= SOCKET_PATH_CEILING,
+            "path {} is {} bytes, over ceiling {}",
+            full.display(),
+            full.as_os_str().len(),
+            SOCKET_PATH_CEILING
+        );
+        // Still recognizable as an engine socket for the stale-socket sweep.
+        assert!(name.starts_with("engine-") && name.ends_with(".sock"));
+    }
+
+    /// Uniqueness comes from pid + nonce; differing nonces differ.
+    #[test]
+    fn socket_filename_unique_per_nonce() {
+        let dir = Path::new("/Users/u/.cocore/sockets");
+        let model = "mlx-community/Qwen2.5-7B-Instruct-4bit";
+        let a = socket_filename(dir, model, 4242, 1);
+        let b = socket_filename(dir, model, 4242, 2);
+        assert_ne!(a, b);
+    }
+
+    /// Even when the dir is so long the model text budget is zero, the name
+    /// is still a valid, hash-distinguished engine socket.
+    #[test]
+    fn socket_filename_pure_hash_when_no_room() {
+        let long = format!("/{}/sockets", "x".repeat(SOCKET_PATH_CEILING));
+        let dir = Path::new(&long);
+        let name = socket_filename(dir, "mlx-community/some-model-4bit", 7, 9);
+        assert!(name.starts_with("engine-") && name.ends_with(".sock"));
+        // No model text survived, but the hash + pid + nonce keep it unique.
+        assert!(!name.is_empty());
+    }
+
+    /// A normal short path keeps a readable model prefix.
+    #[test]
+    fn socket_filename_keeps_model_prefix_when_short() {
+        let dir = Path::new("/Users/u/.cocore/sockets");
+        let name = socket_filename(dir, "mlx-community/Qwen2.5-7B-Instruct-4bit", 1, 2);
+        assert!(name.contains("mlx-community_Qwen"));
     }
 }

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -146,6 +146,19 @@ enum AgentCmd {
     /// menu-bar app polls this to reconcile the agent process to the
     /// owner's choice no matter which side (site or tray) changed it.
     Active,
+    /// Report this machine's attestation status: its trust level, whether the
+    /// Mac is MDM-enrolled, whether an attestation record is published (and
+    /// when it expires), and any attestation fault. Explains the common
+    /// "enrolled but still self-attested" state. The "list via command" the
+    /// settings UI mirrors.
+    Attestation {
+        /// Clear the MDA request cooldown so the next attestation refresh
+        /// re-requests a hardware attestation immediately, instead of waiting
+        /// out the remaining (up to 6h) cooldown. Use on an MDM-enrolled Mac
+        /// that's still self-attested and you don't want to wait.
+        #[arg(long)]
+        retry: bool,
+    },
     /// Write a content-safe diagnostic bundle (a `.tar.gz`) for a bug
     /// report and print its path. Contains crash + health telemetry only
     /// — logs (no prompt/token content by design), the last panic +
@@ -208,6 +221,7 @@ async fn main() -> Result<()> {
         Cmd::Agent(AgentCmd::Pause) => cmd_set_active(false).await,
         Cmd::Agent(AgentCmd::Resume) => cmd_set_active(true).await,
         Cmd::Agent(AgentCmd::Active) => cmd_print_active().await,
+        Cmd::Agent(AgentCmd::Attestation { retry }) => cmd_attestation(retry).await,
         Cmd::Agent(AgentCmd::Diag { out }) => cmd_diag(out),
     }
 }
@@ -430,6 +444,130 @@ async fn cmd_print_active() -> Result<()> {
     };
     println!("{}", if active { "serving" } else { "paused" });
     Ok(())
+}
+
+/// `cocore agent attestation [--retry]`: report this machine's attestation
+/// posture. Reads the provider record (trustLevel + any attestationFault) and
+/// the latest published attestation record (URI + expiry + whether it carries a
+/// hardware MDA chain), plus the local MDM-enrollment state, and explains the
+/// common "enrolled but still self-attested" case. `--retry` first clears the
+/// MDA request cooldown so the next refresh re-requests a hardware attestation.
+async fn cmd_attestation(retry: bool) -> Result<()> {
+    if retry {
+        match cocore_provider::mda_loader::clear_auto_request_cooldown() {
+            Ok(true) => println!(
+                "Cleared the MDA request cooldown — the next attestation refresh will re-request a hardware attestation."
+            ),
+            Ok(false) => println!("No MDA request cooldown was set (nothing to clear)."),
+            Err(e) => println!("Could not clear the MDA request cooldown: {e}"),
+        }
+    }
+
+    let (pds, pubkey) = open_pds()?;
+
+    // Provider record: the ACHIEVED trustLevel + any attestation fault.
+    let (trust_level, attestation_fault_msg) = match find_my_provider_record(&pds, &pubkey).await {
+        Ok((_, value, _)) => {
+            let tl = value
+                .get("trustLevel")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown")
+                .to_string();
+            let fault = value
+                .get("attestationFault")
+                .and_then(|f| f.get("message"))
+                .and_then(|m| m.as_str())
+                .map(str::to_string);
+            (tl, fault)
+        }
+        Err(_) => (
+            "unknown (this machine has not served yet)".to_string(),
+            None,
+        ),
+    };
+    println!("trustLevel:    {trust_level}");
+
+    // Local MDM enrollment (macOS system state; non-macOS reports `no`).
+    let enrolled = cocore_provider::mda_loader::mdm_enrolled();
+    println!("mdmEnrolled:   {}", if enrolled { "yes" } else { "no" });
+
+    // Latest published attestation record on this machine's PDS.
+    match latest_attestation_record(&pds).await {
+        Ok(Some(att)) => {
+            println!(
+                "attestation:   {} (expires {})",
+                att.uri,
+                att.expires_at.as_deref().unwrap_or("?")
+            );
+            println!(
+                "hardwareBound: {}",
+                if att.mda_chain_present {
+                    "yes"
+                } else {
+                    "no (self-attested)"
+                }
+            );
+        }
+        Ok(None) => {
+            println!("attestation:   NONE published");
+            if let Some(msg) = &attestation_fault_msg {
+                println!("fault:         {msg}");
+            }
+        }
+        Err(e) => println!("attestation:   (could not read from PDS: {e})"),
+    }
+
+    // The common point of confusion: enrolled, but still self-attested.
+    if enrolled && trust_level != "hardware-attested" {
+        println!();
+        println!(
+            "This Mac is MDM-enrolled but not yet hardware-attested. A key-bound \
+             attestation chain was requested and lands on the next attestation \
+             refresh (≤23h). To re-request sooner, run \
+             `cocore agent attestation --retry`."
+        );
+    }
+    Ok(())
+}
+
+/// A flattened view of this machine's most recent attestation record, for the
+/// `attestation` status command.
+struct AttestationView {
+    uri: String,
+    expires_at: Option<String>,
+    mda_chain_present: bool,
+}
+
+/// Read this machine's latest `dev.cocore.compute.attestation` record from its
+/// PDS, picking the one with the freshest `attestedAt`. `Ok(None)` when none is
+/// published (the machine never attested, or publish failed).
+async fn latest_attestation_record(pds: &PdsClient) -> Result<Option<AttestationView>> {
+    let records = pds
+        .list_my_records("dev.cocore.compute.attestation")
+        .await?;
+    let latest = records.into_iter().max_by(|a, b| {
+        let key = |r: &cocore_provider::pds::ListedRecord| {
+            r.value
+                .get("attestedAt")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string()
+        };
+        key(a).cmp(&key(b))
+    });
+    Ok(latest.map(|r| AttestationView {
+        uri: r.uri,
+        expires_at: r
+            .value
+            .get("expiresAt")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        mda_chain_present: r
+            .value
+            .get("mdaCertChain")
+            .and_then(|v| v.as_array())
+            .is_some_and(|a| !a.is_empty()),
+    }))
 }
 
 fn init_tracing(level: &str) {

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -2976,7 +2976,13 @@ mod vision_fault_tests {
             "ValueError: could not map weights: language_model.layers.0.self_attn.q_proj"
         )));
         assert!(is_multimodal_weight_map_failure(Some(
-            "Missing key in checkpoint"
+            "Missing key in checkpoint: language_model.embed_tokens.weight"
+        )));
+        // A text model with a corrupted/version-mismatched checkpoint produces
+        // a bare `Missing key … model.…` (no `language_model.`): this must NOT
+        // be classified as multimodal, or the user gets the wrong remediation.
+        assert!(!is_multimodal_weight_map_failure(Some(
+            "Missing key in checkpoint: model.layers.0.self_attn.q_proj.weight"
         )));
         assert!(!is_multimodal_weight_map_failure(Some(
             "OSError: out of memory loading weights"

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -3,12 +3,17 @@ use clap::{Parser, Subcommand};
 use cocore_provider::{
     advisor::AdvisorClient,
     attestation, oauth,
-    pds::{EngineFault, ModelPrice, PdsClient, ProBonoPolicy, ProviderRecord, TrustLevel},
+    pds::{
+        AttestationFault, EngineFault, ModelPrice, PdsClient, ProBonoPolicy, ProviderRecord,
+        TrustLevel,
+    },
     pricing,
     protocol::Register,
     receipt::StrongRef,
     secure_enclave, security, system_profile,
 };
+use std::sync::Arc;
+use tokio::sync::RwLock;
 
 mod doctor;
 mod models_cli;
@@ -980,7 +985,10 @@ async fn cmd_serve(
     // against that key, so leaving it empty (as the M1 walking
     // skeleton did) makes the very first AttestationChallenge round
     // close the connection with `attestation-bad-signature`.
-    let signer = secure_enclave::load_or_create_identity()?;
+    // Held as an `Arc` so the background re-attestation task can share the same
+    // signing identity as the serve loop (the trait is `Send + Sync`).
+    let signer: Arc<dyn secure_enclave::SigningIdentity> =
+        secure_enclave::load_or_create_identity()?.into();
 
     // X25519 encryption keypair for sealed prompts. M2 will persist
     // this alongside the session; for now we generate fresh on every
@@ -1057,6 +1065,7 @@ async fn cmd_serve(
             // real record below flips this to true once engines are up.
             serving: Some(false),
             engineFault: None,
+            attestationFault: None,
             // Coarse location is resolved (best-effort, network) and stamped
             // only on the real record below — never worth delaying the
             // "machine is visible" provisioning publish on an IP lookup.
@@ -1276,62 +1285,24 @@ async fn cmd_serve(
     // bound to this machine's signing key; `tier` is the attestation's own
     // evidence-gated computation, which stays best-effort until the measured
     // native engine serves under a hardened-attested posture.
-    let mut attestation_inputs =
-        attestation::build_stub_inputs(&session.did, &enc.public_key_b64());
-    // MDA option-B (the live macOS hardware-attested path). Two ways in:
-    //   * EXPLICIT: an operator pinned COCORE_MDA_* env (chain path/url, request
-    //     url + serial + udid) — honored verbatim.
-    //   * AUTO (production default): no explicit env — the agent derives its own
-    //     serial + Hardware UUID + the coordinator URLs from the session console
-    //     base, and only when this Mac is MDM-enrolled loads the captured chain,
-    //     requesting a fresh key-bound DeviceInformation attestation
-    //     (DeviceAttestationNonce = sha256(pubkey)) if none exists yet. The chain
-    //     binds to the signing key via the leaf freshness OID; `build` re-verifies
-    //     + only embeds it if it binds. All fail-soft; Apple-rate-limited so we
-    //     only request when we don't already hold a bound chain.
-    let pubkey_b64 = signer.public_key_b64();
-    cocore_provider::mda_loader::request_attestation(&pubkey_b64);
-    let mut mda_cert_chain = cocore_provider::mda_loader::try_load();
-    if mda_cert_chain.is_empty() && !cocore_provider::mda_loader::any_explicit_mda_env() {
-        mda_cert_chain = cocore_provider::mda_loader::acquire_auto(
-            &session.api_base,
-            &session.api_key,
-            &pubkey_b64,
-        );
-    }
-    attestation_inputs.mda_cert_chain = mda_cert_chain;
-    // App Attest evidence — bound to this signing key; `build` re-verifies + only
-    // embeds it if it binds. NB: App Attest is iOS-only (non-functional on macOS,
-    // DCAppAttestService.isSupported=false); this stays a no-op on the Mac and is
-    // retained for a future iOS companion. macOS binds via the MDA chain above.
-    attestation_inputs.app_attest =
-        cocore_provider::mda_loader::load_appattest(&signer.public_key_b64());
-    attestation_inputs.in_process_backend = engines.entries().iter().any(|(_, e)| e.in_process());
-    attestation_inputs.metallib_hash = engines
-        .entries()
-        .iter()
-        .find_map(|(_, e)| e.metallib_hash());
-    attestation_inputs.engine_lib_hash = engines
-        .entries()
-        .iter()
-        .find_map(|(_, e)| e.engine_lib_hash());
-    let built_attestation = attestation::build(attestation_inputs, &*signer);
-    let (achieved_trust_level, achieved_tier) = match &built_attestation {
-        Ok(rec) => (
-            // Derive from what the attestation ACTUALLY embedded, not from what
-            // was loaded: `build` drops any MDA chain / App Attest object that
-            // doesn't verify Apple-rooted AND bind to our signing key. Either a
-            // bound MDA chain or bound App Attest earns hardware-attested.
-            if !rec.mdaCertChain.is_empty() || rec.appAttest.is_some() {
-                TrustLevel::HardwareAttested
-            } else {
-                TrustLevel::SelfAttested
-            },
-            Some(rec.tier.clone()),
-        ),
-        // Build failed → fall back to the honest floor; the publish below logs it.
-        Err(_) => (TrustLevel::SelfAttested, None),
-    };
+    // Snapshot the engine-derived attestation inputs once: the loaded engine
+    // set is fixed for this serve, so the refresh task can carry this instead
+    // of borrowing the (later-moved) engine registry.
+    let engine_facts = EngineAttestationFacts::from_registry(&engines);
+    // Build + publish the attestation now. This is the SAME path the refresh
+    // task below re-runs every ~23h (attestations expire after 24h); doing it
+    // here gives the provider record its ACHIEVED trustLevel/tier and the
+    // Register frame its attestation URI / cdHash / tier.
+    let boot_attestation = build_and_publish_attestation(
+        &session,
+        &*signer,
+        &enc.public_key_b64(),
+        &engine_facts,
+        &pds,
+    )
+    .await;
+    let achieved_trust_level = boot_attestation.trust_level;
+    let achieved_tier = boot_attestation.tier.clone();
 
     // Coarse, opt-in location (refresh-on-serve). Only when the owner opted in
     // via the console's `shareLocation` switch (read off our record above) do we
@@ -1415,6 +1386,10 @@ async fn cmd_serve(
         // clears any stale fault from a prior failed serve; `Some(..)`
         // tells the console this machine is up but only serving `stub`.
         engineFault: engine_fault,
+        // Surface an attestation build/publish failure so the console shows the
+        // machine can't produce receipts (and why) instead of a healthy-looking
+        // idle machine. `None` clears any stale fault on a clean (re-)attestation.
+        attestationFault: boot_attestation.fault.clone(),
         // Coarse, opt-in location resolved above (refresh-on-serve). Absent
         // when sharing is off or the lookup failed. Agent-authored, so it is
         // deliberately NOT in `preserve_console_fields`.
@@ -1455,38 +1430,21 @@ async fn cmd_serve(
         }
     };
 
-    // Publish the attestation we built above (its evidence already set the
-    // provider record's trustLevel/tier). On PDS publish failure (network,
-    // auth, schema) continue with no attestation: the InferenceRequest stub
-    // still answers; receipts just won't be published. Echo the measured
-    // identity + tier on the Register frame so the advisor can compute
-    // confidential eligibility (accelerator only — the PDS attestation stays
-    // authoritative for client verification).
-    let mut register_cd_hash: Option<String> = None;
-    let mut register_tier: Option<String> = None;
-    let attestation_ref: Option<StrongRef> = match built_attestation {
-        Ok(record) => {
-            register_cd_hash = record.cdHash.clone();
-            register_tier = Some(record.tier.clone());
-            match pds.publish_attestation(&record).await {
-                Ok(published) => {
-                    tracing::info!(uri = %published.uri, "published attestation");
-                    Some(StrongRef {
-                        uri: published.uri,
-                        cid: published.cid,
-                    })
-                }
-                Err(e) => {
-                    tracing::warn!(error = %e, "failed to publish attestation; receipts disabled");
-                    None
-                }
-            }
-        }
-        Err(e) => {
-            tracing::warn!(error = %e, "failed to build attestation; receipts disabled");
-            None
-        }
-    };
+    // The attestation was built + published by `build_and_publish_attestation`
+    // above (its evidence already set the provider record's trustLevel/tier).
+    // On build/publish failure the strong-ref is `None`: the InferenceRequest
+    // stub still answers, receipts just aren't published, and the
+    // `attestationFault` on the record above tells the console why. Echo the
+    // measured identity + tier on the Register frame so the advisor can compute
+    // confidential eligibility (the PDS attestation stays authoritative for
+    // client verification).
+    let register_cd_hash = boot_attestation.cd_hash.clone();
+    let register_tier = boot_attestation.register_tier.clone();
+    // The live, refreshable attestation cell. The refresh task swaps a fresh
+    // strong-ref in here ~1h before the current one expires; the receipt path
+    // reads it per job, so receipts always reference the current attestation.
+    let attestation: Arc<RwLock<Option<StrongRef>>> =
+        Arc::new(RwLock::new(boot_attestation.strong_ref.clone()));
 
     // The Register frame echoes the same telemetry the PDS record
     // carries so the advisor's /providers list matches what's on
@@ -1504,7 +1462,8 @@ async fn cmd_serve(
         supported_models: provider_record.supportedModels.clone(),
         encryption_pub_key: enc.public_key_b64(),
         attestation_pub_key: signer.public_key_b64(),
-        attestation_uri: attestation_ref
+        attestation_uri: boot_attestation
+            .strong_ref
             .as_ref()
             .map(|r| r.uri.clone())
             .unwrap_or_default(),
@@ -1527,7 +1486,62 @@ async fn cmd_serve(
         #[cfg(not(all(target_os = "macos", feature = "apns")))]
         apns_device_token: None,
     };
-    let attestation = attestation_ref.as_ref();
+
+    // Periodic re-attestation. Attestations expire after 24h; without this the
+    // attestation built at boot lapses, every receipt that strong-refs it
+    // becomes invalid, and the machine silently drops out of its attested
+    // posture (the "confidential mode flips on/off / can't re-attest" failure).
+    // The task rebuilds + republishes on a fixed cadence (default ~23h, env
+    // override for testing), re-running the MDA auto-acquire so a key-bound
+    // chain that landed after boot is picked up, and swaps the fresh strong-ref
+    // into the shared cell the receipt path reads. On failure it keeps the
+    // previous ref until the next cycle and records an `attestationFault` on the
+    // provider record so the console surfaces the degraded state.
+    let refresh_handle = {
+        let attestation = attestation.clone();
+        let pds = pds.clone();
+        let session = session.clone();
+        let signer = signer.clone();
+        let enc_pub = enc.public_key_b64();
+        let engine_facts = engine_facts.clone();
+        let attestation_pub_key = attestation_pub_key.clone();
+        let base_record = provider_record.clone();
+        tokio::spawn(async move {
+            let interval = attestation_refresh_interval();
+            loop {
+                tokio::time::sleep(interval).await;
+                let outcome = build_and_publish_attestation(
+                    &session,
+                    &*signer,
+                    &enc_pub,
+                    &engine_facts,
+                    &pds,
+                )
+                .await;
+                match &outcome.strong_ref {
+                    Some(r) => {
+                        *attestation.write().await = Some(r.clone());
+                        tracing::info!(uri = %r.uri, "attestation refreshed");
+                    }
+                    None => {
+                        tracing::warn!(
+                            "attestation refresh failed; keeping previous ref until next cycle"
+                        );
+                    }
+                }
+                // Reflect the refresh outcome on the provider record so the
+                // console clears or surfaces the fault. Best-effort: a failed
+                // re-publish here doesn't affect the live attestation cell.
+                republish_attestation_fault(
+                    &pds,
+                    &attestation_pub_key,
+                    &base_record,
+                    outcome.fault.clone(),
+                )
+                .await;
+            }
+        })
+    };
 
     // The serve future below loops forever. Race it against a graceful
     // shutdown signal (SIGTERM from launchd / the macOS app supervisor on
@@ -1568,7 +1582,7 @@ async fn cmd_serve(
                             &*signer,
                             &enc,
                             &pds,
-                            attestation,
+                            attestation.clone(),
                             &engines,
                             provider_rkey.as_deref(),
                             &desired_at_start,
@@ -1636,7 +1650,7 @@ async fn cmd_serve(
                         );
                         let client = AdvisorClient::new(advisor_url);
                         tokio::select! {
-                            res = client.run(register.clone(), &*signer, &enc, &pds, attestation, &eng, provider_rkey.as_deref(), &desired_at_start, desired_tier_at_start.as_deref(), &model_schedules, &configured_models, push_rx.as_mut(), &pro_bono_at_start) => {
+                            res = client.run(register.clone(), &*signer, &enc, &pds, attestation.clone(), &eng, provider_rkey.as_deref(), &desired_at_start, desired_tier_at_start.as_deref(), &model_schedules, &configured_models, push_rx.as_mut(), &pro_bono_at_start) => {
                                 if let Err(e) = res {
                                     tracing::warn!(error = %e, "advisor run ended; reconnecting within window in 5s");
                                 }
@@ -1715,7 +1729,225 @@ async fn cmd_serve(
             }
         }
     }
+    // Stop the background re-attestation task on the way out (shutdown only —
+    // `serve` itself never returns).
+    refresh_handle.abort();
     Ok(())
+}
+
+/// Engine-derived attestation inputs, snapshotted once at serve start. The
+/// loaded engine set is fixed for a serve lifetime, so the re-attestation task
+/// carries this owned snapshot instead of borrowing the engine registry (which
+/// the serve loop may move into its schedule branch).
+#[derive(Clone, Default)]
+struct EngineAttestationFacts {
+    in_process_backend: bool,
+    metallib_hash: Option<String>,
+    engine_lib_hash: Option<String>,
+}
+
+impl EngineAttestationFacts {
+    fn from_registry(engines: &cocore_provider::engines::EngineRegistry) -> Self {
+        Self {
+            in_process_backend: engines.entries().iter().any(|(_, e)| e.in_process()),
+            metallib_hash: engines
+                .entries()
+                .iter()
+                .find_map(|(_, e)| e.metallib_hash()),
+            engine_lib_hash: engines
+                .entries()
+                .iter()
+                .find_map(|(_, e)| e.engine_lib_hash()),
+        }
+    }
+}
+
+/// The result of building + publishing one attestation.
+struct AttestationOutcome {
+    /// Strong-ref to the published attestation record; `None` when build or
+    /// publish failed (receipts skip publishing in that mode).
+    strong_ref: Option<StrongRef>,
+    /// ACHIEVED trust level, derived from what the attestation actually
+    /// embedded — a bound MDA chain or App Attest object earns
+    /// hardware-attested; otherwise self-attested.
+    trust_level: TrustLevel,
+    /// The attestation's evidence-gated tier, when built.
+    tier: Option<String>,
+    /// Measured cdHash to echo on the Register frame.
+    cd_hash: Option<String>,
+    /// Tier to echo on the Register frame.
+    register_tier: Option<String>,
+    /// Set when build or publish failed, for the provider record + console.
+    fault: Option<AttestationFault>,
+}
+
+/// Assemble the attestation inputs from the current machine + key state, build
+/// the signed record, and publish it to the provider's PDS. Used both at serve
+/// start and by the periodic refresh task (attestations expire after 24h; see
+/// `attestation.rs`). Re-runs the MDA auto-acquire so a key-bound chain that was
+/// requested on an earlier cycle but landed later is picked up on refresh.
+/// Fail-soft: any build/publish error returns `strong_ref: None` plus a
+/// content-safe `fault`, never panics.
+async fn build_and_publish_attestation(
+    session: &oauth::Session,
+    signer: &dyn secure_enclave::SigningIdentity,
+    encryption_pub_key_b64: &str,
+    engine_facts: &EngineAttestationFacts,
+    pds: &PdsClient,
+) -> AttestationOutcome {
+    let mut attestation_inputs =
+        attestation::build_stub_inputs(&session.did, encryption_pub_key_b64);
+    // MDA option-B (the live macOS hardware-attested path). EXPLICIT env wins;
+    // otherwise AUTO derives serial + Hardware UUID + coordinator URLs from the
+    // session console base and, only when this Mac is MDM-enrolled, loads the
+    // captured chain — requesting a fresh key-bound attestation if none is held
+    // yet (it lands on a later refresh, which is exactly what this task drives).
+    let pubkey_b64 = signer.public_key_b64();
+    cocore_provider::mda_loader::request_attestation(&pubkey_b64);
+    let mut mda_cert_chain = cocore_provider::mda_loader::try_load();
+    if mda_cert_chain.is_empty() && !cocore_provider::mda_loader::any_explicit_mda_env() {
+        mda_cert_chain = cocore_provider::mda_loader::acquire_auto(
+            &session.api_base,
+            &session.api_key,
+            &pubkey_b64,
+        );
+    }
+    attestation_inputs.mda_cert_chain = mda_cert_chain;
+    // App Attest evidence — bound to this signing key; `build` re-verifies + only
+    // embeds it if it binds. A no-op on macOS (iOS-only), retained for a future
+    // iOS companion.
+    attestation_inputs.app_attest =
+        cocore_provider::mda_loader::load_appattest(&signer.public_key_b64());
+    attestation_inputs.in_process_backend = engine_facts.in_process_backend;
+    attestation_inputs.metallib_hash = engine_facts.metallib_hash.clone();
+    attestation_inputs.engine_lib_hash = engine_facts.engine_lib_hash.clone();
+
+    let built = attestation::build(attestation_inputs, signer);
+    // Derive trust/tier from what the attestation ACTUALLY embedded, not from
+    // what was loaded: `build` drops any MDA chain / App Attest that doesn't
+    // verify Apple-rooted AND bind to our signing key.
+    let (trust_level, tier) = match &built {
+        Ok(rec) => (
+            if !rec.mdaCertChain.is_empty() || rec.appAttest.is_some() {
+                TrustLevel::HardwareAttested
+            } else {
+                TrustLevel::SelfAttested
+            },
+            Some(rec.tier.clone()),
+        ),
+        Err(_) => (TrustLevel::SelfAttested, None),
+    };
+
+    match built {
+        Ok(record) => {
+            let cd_hash = record.cdHash.clone();
+            let register_tier = Some(record.tier.clone());
+            match pds.publish_attestation(&record).await {
+                Ok(published) => {
+                    tracing::info!(uri = %published.uri, "published attestation");
+                    AttestationOutcome {
+                        strong_ref: Some(StrongRef {
+                            uri: published.uri,
+                            cid: published.cid,
+                        }),
+                        trust_level,
+                        tier,
+                        cd_hash,
+                        register_tier,
+                        fault: None,
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to publish attestation; receipts disabled");
+                    AttestationOutcome {
+                        strong_ref: None,
+                        trust_level,
+                        tier,
+                        cd_hash,
+                        register_tier,
+                        fault: Some(AttestationFault {
+                            code: "attestation-publish-failed".to_string(),
+                            message: "This machine could not publish its attestation record \
+                                to its PDS, so it cannot produce verifiable receipts and will \
+                                complete no billable jobs. The machine is otherwise online. \
+                                Fix: check this machine's network connection to its PDS and \
+                                that the session is still valid (re-pair with \
+                                `cocore agent pair` if needed); it retries automatically on \
+                                the next attestation refresh."
+                                .to_string(),
+                            at: chrono::Utc::now(),
+                        }),
+                    }
+                }
+            }
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to build attestation; receipts disabled");
+            AttestationOutcome {
+                strong_ref: None,
+                trust_level,
+                tier,
+                cd_hash: None,
+                register_tier: None,
+                fault: Some(AttestationFault {
+                    code: "attestation-build-failed".to_string(),
+                    message: "This machine could not assemble its signed attestation, so it \
+                        cannot produce verifiable receipts and will complete no billable jobs. \
+                        This usually means the signing identity or a measured-binary input is \
+                        unavailable. Fix: update to the latest co/core build and restart \
+                        serving; if it persists, re-pair with `cocore agent pair`."
+                        .to_string(),
+                    at: chrono::Utc::now(),
+                }),
+            }
+        }
+    }
+}
+
+/// How long the re-attestation task waits between refreshes. Default ~23h (one
+/// hour before the 24h expiry); `COCORE_ATTESTATION_REFRESH_SECS` overrides it
+/// for testing (a positive integer number of seconds).
+fn attestation_refresh_interval() -> std::time::Duration {
+    std::env::var("COCORE_ATTESTATION_REFRESH_SECS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|s| *s > 0)
+        .map(std::time::Duration::from_secs)
+        .unwrap_or_else(|| std::time::Duration::from_secs(23 * 3600))
+}
+
+/// Re-publish this machine's provider record to reflect the latest attestation
+/// outcome (clear the fault on success, set it on failure) after a refresh
+/// cycle. Mirrors the shutdown offline-marker path: read the live record, clone
+/// our agent-built base, preserve the console-authored switches, and CAS on the
+/// CID we just read so we don't clobber a concurrent console write. Best-effort
+/// — a failure here never affects the live attestation cell.
+async fn republish_attestation_fault(
+    pds: &PdsClient,
+    attestation_pub_key: &str,
+    base_record: &ProviderRecord,
+    fault: Option<AttestationFault>,
+) {
+    let publish = async {
+        let (rk, value, cid) = find_my_provider_record(pds, attestation_pub_key).await?;
+        let mut rec = base_record.clone();
+        rec.attestationFault = fault.clone();
+        // Mid-serve: the machine is up and past provisioning.
+        rec.serving = Some(true);
+        rec.provisioning = Some(false);
+        rec.createdAt = chrono::Utc::now();
+        preserve_console_fields(&mut rec, &value);
+        pds.put_provider(&rk, &rec, Some(&cid)).await
+    };
+    match tokio::time::timeout(std::time::Duration::from_secs(10), publish).await {
+        Ok(Ok(_)) => {}
+        Ok(Err(e)) => {
+            tracing::warn!(error = %e, "failed to re-publish provider record after attestation refresh")
+        }
+        Err(_) => {
+            tracing::warn!("provider record re-publish after attestation refresh timed out")
+        }
+    }
 }
 
 /// Resolves when the process receives a graceful shutdown signal: SIGTERM
@@ -2663,6 +2895,7 @@ mod offline_marker_tests {
             provisioning: Some(false),
             serving: Some(true),
             engineFault: None,
+            attestationFault: None,
             region: None,
             regionSource: None,
             regionObservedAt: None,

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -2210,6 +2210,34 @@ fn build_engines(
             models: all_unserved,
             at: chrono::Utc::now(),
         }
+    } else if !failed.is_empty() && is_socket_path_too_long(last_err.as_deref()) {
+        // The engine couldn't open its local Unix-domain socket because the
+        // assembled path overflowed the OS `sun_path` limit (a long $HOME +
+        // a long model id). The generic "not in MLX format" message below
+        // would be actively wrong — the weights are fine; the socket path is
+        // the problem. Current builds budget the path under the limit
+        // (engines/subprocess.rs `socket_filename`), so this only bites
+        // stragglers on an older binary.
+        tracing::warn!(
+            models = ?failed,
+            last_error = %last_err.as_deref().unwrap_or("(none captured)"),
+            "engine socket path exceeded the OS limit; serving stub only"
+        );
+        EngineFault {
+            code: "engine-socket-path".to_string(),
+            message: format!(
+                "The inference engine for [{}] couldn't open its local socket: the \
+                 socket path under your home directory is too long for the operating \
+                 system (the `sun_path` limit). The weights are fine — this is a path \
+                 length problem, not a model problem. The machine is online but only \
+                 serving the no-op `stub` engine. Fix: update to the latest co/core \
+                 build (which shortens the socket path) — \
+                 `curl -fsSL https://cocore.dev/agent | sh` — then start serving again.",
+                failed.join(", "),
+            ),
+            models: all_unserved,
+            at: chrono::Utc::now(),
+        }
     } else if !failed.is_empty() && is_vision_config_failure(last_err.as_deref()) {
         // A vision/multimodal model whose config the multimodal runtime
         // (mlx_vlm) couldn't parse — the "not in MLX format" message below would
@@ -2233,6 +2261,35 @@ fn build_engines(
                  no-op `stub` engine. Fix: pick a standard MLX vision model — e.g. \
                  `mlx-community/Qwen2.5-VL-7B-Instruct-4bit` or \
                  `mlx-community/Qwen2.5-VL-3B-Instruct-4bit` — then start serving again.",
+                failed.join(", "),
+            ),
+            models: all_unserved,
+            at: chrono::Utc::now(),
+        }
+    } else if !failed.is_empty() && is_multimodal_weight_map_failure(last_err.as_deref()) {
+        // A merged / multimodal checkpoint whose weights are nested under
+        // `language_model.*` (e.g. some Gemma multimodal exports) that the
+        // runtime can't key-map onto its module tree. Distinct from the
+        // vision_config failure above: there the image config was rejected;
+        // here the weight NAMES don't line up. Either way "not in MLX format"
+        // would be wrong — the weights ARE MLX, just laid out for a
+        // multimodal model the text runtime can't load.
+        tracing::warn!(
+            models = ?failed,
+            last_error = %last_err.as_deref().unwrap_or("(none captured)"),
+            "multimodal checkpoint weights could not be mapped; serving stub only"
+        );
+        EngineFault {
+            code: "model-multimodal-incompatible".to_string(),
+            message: format!(
+                "The model(s) [{}] couldn't load: this looks like a merged or \
+                 multimodal checkpoint whose weights are nested (e.g. under \
+                 `language_model.*`), which the runtime can't map onto a text model. \
+                 The weights are MLX, but they're laid out for a multimodal model that \
+                 can't be served as plain text. The machine is online but only serving \
+                 the no-op `stub` engine. Fix: pick a standard MLX text model — e.g. \
+                 `mlx-community/Qwen2.5-7B-Instruct-4bit` — or a standard MLX vision \
+                 model, then start serving again.",
                 failed.join(", "),
             ),
             models: all_unserved,
@@ -2325,6 +2382,32 @@ fn is_vision_config_failure(last_err: Option<&str>) -> bool {
     // the config key it failed to build. Either is a strong, content-safe
     // signal (the ring buffer carries only library tracebacks at startup).
     e.contains("VisionConfig") || e.contains("vision_config")
+}
+
+/// Whether an engine-start error is the "the local socket path is too long"
+/// failure — the OS rejecting an AF_UNIX `bind()` whose path exceeds the
+/// `sun_path` limit. Current builds budget the path so this can't happen
+/// (engines/subprocess.rs `socket_filename`), but an older binary on a long
+/// $HOME still hits it; classifying it gives a precise message instead of the
+/// wrong "not in MLX format" one. Content-safe (OS error text only).
+fn is_socket_path_too_long(last_err: Option<&str>) -> bool {
+    let Some(e) = last_err else { return false };
+    e.contains("ENAMETOOLONG")
+        || e.contains("path too long")
+        || (e.contains("AF_UNIX") && e.contains("too long"))
+}
+
+/// Whether an engine-start error is the "multimodal checkpoint weights can't be
+/// mapped" failure — a merged/multimodal export whose tensors are nested under
+/// `language_model.*` (or similar) that the text runtime can't key onto its
+/// module tree. Distinct from [`is_vision_config_failure`]: here the weight
+/// NAMES don't line up rather than the image config being rejected.
+/// Content-safe (library traceback text only).
+fn is_multimodal_weight_map_failure(last_err: Option<&str>) -> bool {
+    let Some(e) = last_err else { return false };
+    e.contains("language_model.")
+        || e.contains("Missing key")
+        || (e.contains("KeyError") && e.contains("model."))
 }
 
 /// Try to start one model's inference subprocess, retrying transient
@@ -2501,6 +2584,44 @@ mod vision_fault_tests {
             "ModuleNotFoundError: vllm_mlx"
         )));
         assert!(!is_vision_config_failure(None));
+    }
+
+    use super::{is_multimodal_weight_map_failure, is_socket_path_too_long};
+
+    #[test]
+    fn detects_socket_path_too_long() {
+        assert!(is_socket_path_too_long(Some(
+            "OSError: AF_UNIX path too long"
+        )));
+        assert!(is_socket_path_too_long(Some(
+            "[stderr] bind: [Errno 63] ENAMETOOLONG"
+        )));
+        assert!(!is_socket_path_too_long(Some("KeyError: 'vision_config'")));
+        assert!(!is_socket_path_too_long(None));
+    }
+
+    #[test]
+    fn detects_multimodal_weight_map_failure() {
+        assert!(is_multimodal_weight_map_failure(Some(
+            "ValueError: could not map weights: language_model.layers.0.self_attn.q_proj"
+        )));
+        assert!(is_multimodal_weight_map_failure(Some(
+            "Missing key in checkpoint"
+        )));
+        assert!(!is_multimodal_weight_map_failure(Some(
+            "OSError: out of memory loading weights"
+        )));
+        assert!(!is_multimodal_weight_map_failure(None));
+    }
+
+    /// A vision_config failure must be classified by the vision branch, not
+    /// the multimodal-weight-map one — the fault chain checks vision first,
+    /// and these stderrs don't overlap.
+    #[test]
+    fn vision_config_not_misread_as_weight_map() {
+        let err = "TypeError: VisionConfig.__init__() missing 6 required positional arguments";
+        assert!(is_vision_config_failure(Some(err)));
+        assert!(!is_multimodal_weight_map_failure(Some(err)));
     }
 }
 

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -2776,8 +2776,8 @@ fn is_socket_path_too_long(last_err: Option<&str>) -> bool {
 fn is_multimodal_weight_map_failure(last_err: Option<&str>) -> bool {
     let Some(e) = last_err else { return false };
     e.contains("language_model.")
-        || e.contains("Missing key")
-        || (e.contains("KeyError") && e.contains("model."))
+        || (e.contains("Missing key") && e.contains("language_model."))
+        || (e.contains("KeyError") && e.contains("language_model."))
 }
 
 /// Try to start one model's inference subprocess, retrying transient

--- a/provider/src/mda_loader.rs
+++ b/provider/src/mda_loader.rs
@@ -576,6 +576,23 @@ fn mark_auto_requested() {
     }
 }
 
+/// Clear the auto-request cooldown marker so the next attestation refresh
+/// re-requests a hardware attestation immediately instead of waiting out the
+/// remaining cooldown. Used by `cocore agent attestation --retry` for an
+/// enrolled Mac that's impatient for its key-bound chain. Returns `Ok(true)`
+/// when a marker existed and was removed, `Ok(false)` when there was nothing to
+/// clear, and `Err` only on an unexpected IO error.
+pub fn clear_auto_request_cooldown() -> std::io::Result<bool> {
+    let Some(path) = auto_request_marker_path() else {
+        return Ok(false);
+    };
+    match std::fs::remove_file(&path) {
+        Ok(()) => Ok(true),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(e) => Err(e),
+    }
+}
+
 /// Minimal query-component percent-encoding (serials/UUIDs are alphanumeric +
 /// `-`, but encode defensively so a stray char can't break the URL).
 fn urlencode(s: &str) -> String {

--- a/provider/src/pds.rs
+++ b/provider/src/pds.rs
@@ -150,6 +150,15 @@ pub struct ProviderRecord {
     /// stale failure. See `build_engines`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub engineFault: Option<EngineFault>,
+    /// Set when `serve` could not build or publish this machine's
+    /// `dev.cocore.compute.attestation` record. Without a published
+    /// attestation the machine cannot produce verifiable receipts (every
+    /// receipt strong-refs one), so it stays effectively self-attested and
+    /// silently completes no billable work. The agent clears this (writes
+    /// `None`) on every successful (re-)attestation, so its presence reflects
+    /// the current state, not a stale failure. See `build_and_publish_attestation`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attestationFault: Option<AttestationFault>,
     /// Coarse, opt-in country of this machine, ISO 3166-1 alpha-2 (e.g.
     /// "US"). AGENT-authored and ADVISORY: a self-asserted claim from a
     /// best-effort IP→country lookup at serve start, NOT a proof of location
@@ -229,6 +238,25 @@ pub struct EngineFault {
     pub at: chrono::DateTime<chrono::Utc>,
 }
 
+/// A content-safe description of why the attestation could not be built or
+/// published. Published on the provider record (mirroring [`EngineFault`]) so
+/// the console can show the operator that receipts are disabled and why,
+/// instead of a machine that looks healthy but completes no billable jobs.
+/// Cleared on every successful (re-)attestation. No prompt/completion bytes
+/// ever reach it (attestation runs before any job).
+#[allow(non_snake_case)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AttestationFault {
+    /// Machine-readable fault class: `attestation-publish-failed` (the record
+    /// could not be written to the PDS) or `attestation-build-failed` (the
+    /// signed record could not be assembled).
+    pub code: String,
+    /// Human-readable summary with remediation guidance.
+    pub message: String,
+    /// When the agent recorded the fault.
+    pub at: chrono::DateTime<chrono::Utc>,
+}
+
 #[allow(non_snake_case)]
 #[derive(Debug, Serialize, Clone)]
 pub struct ModelPrice {
@@ -284,6 +312,7 @@ struct ListRecordsResponse {
 /// HTTP client over the console's `/api/pds/createRecord`
 /// endpoint. One instance per agent lifetime; the API key is
 /// captured at construction and never rotated.
+#[derive(Clone)]
 pub struct PdsClient {
     did: String,
     api_base: String,


### PR DESCRIPTION
## Context

Two provider bug reports (DMs) described a Mac that signs up, claims to be "enrolled," but never settles into a working confidential/secure posture and never completes a job, plus a cluster of model-load failures that all reported the same misleading cause ("not in MLX format"). Root-cause analysis traced every symptom to two real defects and a layer of missing observability. This PR fixes all of them, staged into reviewable commits.

## What was actually wrong

1. **No re-attestation loop.** The attestation was built + published exactly **once at boot**, but attestations expire after 24h. Once one lapsed, every receipt strong-reffing it became invalid and the machine silently dropped out of its attested posture — the *"can't re-attest / confidential mode flips on and off / never completes a job"* report. A freshly MDM-enrolled Mac also never upgraded, because the MDA chain "lands on a later refresh" that never happened.
2. **Every model-load failure misdiagnosed as "not in MLX format."** The fault classifier only special-cased venv/vision/RAM; the AF_UNIX socket-path overflow (long `$HOME` + long model id) and a multimodal checkpoint with weights nested under `language_model.*` both collapsed into the wrong message. The reporter diagnosed both correctly; the agent hid them.
3. **Attestation publish failures were swallowed** (only logged), so the attestation "didn't show up in list/settings" and an enrolled Mac looked "enrolled no matter what" while nothing progressed.

## Changes (by commit)

- **Length-safe engine socket path + accurate model-load faults.** New `socket_filename` budgets the path under the `sun_path` ceiling (hash-suffixed, pid+nonce uniqueness preserved). New `is_socket_path_too_long` / `is_multimodal_weight_map_failure` classifiers; "not in MLX format" is now the final fallback only. Unit tests included.
- **Lexicon:** additive optional `attestationFault` on `dev.cocore.compute.provider` (mirrors `engineFault`; no existing semantics change).
- **Periodic re-attestation + fault surfacing.** Factored `build_and_publish_attestation`; the live attestation is held behind `Arc<RwLock<Option<StrongRef>>>` and read per job; a refresh task rebuilds + republishes every ~23h (`COCORE_ATTESTATION_REFRESH_SECS` overrides for testing), re-running MDA auto-acquire so a key-bound chain that lands after boot is finally picked up. `attestationFault` is set/cleared on the provider record at boot and on each refresh.
- **`cocore agent attestation [--retry]`** status command + console `agent.status` surfaces `attestationFault`. `--retry` clears the MDA request cooldown (`mda_loader::clear_auto_request_cooldown`) so an enrolled-but-self-attested Mac can re-request sooner.

## Invariants

All new record fields are additive/optional; the PDS attestation stays authoritative; no coordinator-shaped component added. The refresh loop **restores** the documented self-verifying-receipt guarantee (attestations were silently expiring) rather than weakening it.

## Verification

- `cargo build -p cocore-provider`, `cargo clippy`, `cargo fmt --check`, and `cargo test -p cocore-provider` all pass (148+ tests, incl. new socket-path-ceiling and fault-classifier tests).
- Manual (suggested): `COCORE_ATTESTATION_REFRESH_SECS=30 cocore agent serve` should publish a fresh `dev.cocore.compute.attestation` every 30s and have the receipt path pick up the new URI; an MDM-enrolled Mac should flip to a non-empty `mdaCertChain` a cycle after boot.
- **Not compile-verified:** the console `agent.status.ts` edit (no `node_modules` in this environment to run `tsc`). It's a minimal, well-typed addition.

## Out of scope (documented, not bugs)
- Qwen3.6-27B "spends full maxTokens reasoning": not tagged a thinking model, so no early stop — expected; tune `max_tokens` / `COCORE_THINKING_PREFILL_MODELS`.
- RAM-floor auto-skip of Qwen3.6-35B-A3B: intended; `COCORE_IGNORE_RAM_FLOOR=1` overrides (and the `model-too-large` message is no longer shadowed by the generic one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqGeafSJvPUzDmHFFFe4rz)_