### PR TITLE
release: 0.9.31

### DIFF
--- a/provider-shell/Sources/CoCoreShell/Resources/Info.plist
+++ b/provider-shell/Sources/CoCoreShell/Resources/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleName</key>
 	<string>co/core</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.30</string>
+	<string>0.9.31</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -22,7 +22,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>930</string>
+	<string>931</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/provider/Cargo.lock
+++ b/provider/Cargo.lock
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "cocore-provider"
-version = "0.9.30"
+version = "0.9.31"
 dependencies = [
  "anyhow",
  "asn1-rs",

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cocore-provider"
-version = "0.9.30"
+version = "0.9.31"
 edition = "2021"
 description = "co/core provider agent: runs hardened compute and publishes signed receipts to AT Protocol."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Bumps the version to **0.9.31** across all three sites (`provider/Cargo.toml`, `provider/Cargo.lock`, `provider-shell/.../Info.plist` → Short `0.9.31` / Bundle `931`).

This is the first release since v0.9.30. Both surfaces shipped in the `mac-release` artifact have changed materially since the tag: the Swift tray app (`cocore.app`) and the provider `cocore` binary (bundled in the tarball **and** embedded + Developer-ID-signed inside the app at `Contents/MacOS/cocore`).

## Why cut now

**Tray app (Swift):**
- **#90** — stop duplicate confidential workers burning CPU while paused (singleton `reapWorkers` + 30m auto-bounce cooldown; non-blocking reap; cooldown cleared on user intent).
- Unblock vision models in the model picker.
- Secure Mode wizard report accuracy: last-poll-wins chain status/HTTP, classify attesting-step stalls, accurate push-leg elapsed timing.
- Pro-bono + coarse country settings in Preferences.

**Provider (embedded in the app + bundled in the tarball):**
- Vision/multimodal models end-to-end (best-effort + confidential).
- **#95** — stop leaking inference-engine subprocesses.
- Periodic re-attestation + `attestation-status` command + surfaced attestation faults.
- Length-safe engine socket path + accurate model-load faults.
- Opt-in coarse location (country) via geoip; pro-bono + region routing.

The two resource bugs (#90 CPU burn, #95 leaked subprocesses) alone justify the release; vision-model support is a notable feature add on top.

## After merge (ops, macOS-local)

`make mac-release` (with `COCORE_NOTARY_PROFILE` set) → tag `v0.9.31` → CI tarball → `.publish-NN.sh` clobber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)