### PR TITLE
fix(inference): resolve AppView-minted API keys + accept service tokens

### DIFF
--- a/packages/appview/src/api/internal-reset.test.ts
+++ b/packages/appview/src/api/internal-reset.test.ts
@@ -40,6 +40,17 @@ function resetReq(base: string, body: unknown, secret: string | null): Promise<R
   });
 }
 
+function resolveKeyReq(base: string, body: unknown, secret: string | null): Promise<Response> {
+  return fetch(`${base}/internal/account/resolve-key`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...(secret ? { "x-cocore-internal-secret": secret } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
 describe("POST /internal/account/reset-did", () => {
   it("rejects a missing/wrong secret with 403", async () => {
     await withReset(async ({ base }) => {
@@ -73,6 +84,43 @@ describe("POST /internal/account/reset-did", () => {
       // Bob is untouched.
       expect(accountStore.resolveBearerKey(b.secret)?.did).toBe(BOB);
       expect(accountStore.getOAuthSession(BOB)).toBe('{"dpop":"v1"}');
+    });
+  });
+});
+
+// The console's inference path calls this so an AppView-minted key (which
+// lands in account.db, not console.db) still authenticates at
+// cocore.dev/v1/chat/completions.
+describe("POST /internal/account/resolve-key", () => {
+  it("rejects a missing/wrong secret with 403", async () => {
+    await withReset(async ({ base }) => {
+      expect((await resolveKeyReq(base, { key: "x" }, null)).status).toBe(403);
+      expect((await resolveKeyReq(base, { key: "x" }, "wrong")).status).toBe(403);
+    });
+  });
+
+  it("requires a key", async () => {
+    await withReset(async ({ base }) => {
+      expect((await resolveKeyReq(base, {}, SECRET)).status).toBe(400);
+      expect((await resolveKeyReq(base, { key: "" }, SECRET)).status).toBe(400);
+    });
+  });
+
+  it("resolves a live key to its owning DID", async () => {
+    await withReset(async ({ base, accountStore }) => {
+      const a = accountStore.createKey({ did: ALICE, name: "laptop" });
+      const res = await resolveKeyReq(base, { key: a.secret }, SECRET);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({ did: ALICE, name: "laptop" });
+    });
+  });
+
+  it("404s an unknown or revoked key", async () => {
+    await withReset(async ({ base, accountStore }) => {
+      expect((await resolveKeyReq(base, { key: "cocore-nope" }, SECRET)).status).toBe(404);
+      const a = accountStore.createKey({ did: ALICE, name: "laptop" });
+      accountStore.revokeAllKeysForDid(ALICE);
+      expect((await resolveKeyReq(base, { key: a.secret }, SECRET)).status).toBe(404);
     });
   });
 });

--- a/packages/appview/src/api/server.ts
+++ b/packages/appview/src/api/server.ts
@@ -111,6 +111,30 @@ function buildInternalAccountRouter(
         return ok({ key: out.key, secret: out.secret });
       }).pipe(Effect.withSpan("appview.internal.mintKey")),
     ),
+    // Resolve a presented bearer key to its owning DID against THIS store.
+    // The console's inference path calls this so a key minted via the
+    // (documented) AppView `createApiKey` — which lands in account.db, a
+    // different store than the console's console.db — still authenticates at
+    // `cocore.dev/v1/chat/completions`. Returns 404 when the key is unknown,
+    // revoked, or expired (resolveBearerKey collapses all three to null), so
+    // the caller never distinguishes those cases.
+    HttpRouter.post(
+      "/internal/account/resolve-key",
+      Effect.gen(function* () {
+        if (!(yield* authorized)) return err(403, { error: "Forbidden" });
+        const parsed = yield* Effect.either(jsonBody);
+        if (parsed._tag === "Left") {
+          return err(400, { error: "InvalidRequest", message: "body must be JSON" });
+        }
+        const body = parsed.right as { key?: unknown };
+        if (typeof body.key !== "string" || body.key.length === 0) {
+          return err(400, { error: "InvalidRequest", message: "key required" });
+        }
+        const resolved = accountStore.resolveBearerKey(body.key);
+        if (!resolved) return err(404, { error: "NotFound", message: "key not resolvable" });
+        return ok({ id: resolved.id, did: resolved.did, name: resolved.name });
+      }).pipe(Effect.withSpan("appview.internal.resolveKey")),
+    ),
     // AppView half of the console's "reset connection" repair flow:
     // revoke all of a DID's API keys + drop its OAuth session so the user
     // can re-pair from a clean slate. (merged from main #33)

--- a/packages/console/src/components/inference-docs/pages/quickstart.tsx
+++ b/packages/console/src/components/inference-docs/pages/quickstart.tsx
@@ -103,7 +103,18 @@ export function InferenceQuickstartPage({ baseUrl }: { baseUrl: string }) {
       <HighlightedBlock code="Authorization: Bearer cocore-..." lang="bash" />
       <CreateApiKeyOrLoginButton redirectTo="/docs/inference/quickstart" />
       <p {...stylex.props(docsStyles.prose)}>
-        Invalid or missing keys return{" "}
+        Building on top of AT Protocol? Skip key provisioning entirely: mint a service-auth token
+        from the caller&apos;s PDS (
+        <code {...stylex.props(docsStyles.codeInline)}>com.atproto.server.getServiceAuth</code> with{" "}
+        <code {...stylex.props(docsStyles.codeInline)}>aud=did:web:console.cocore.dev</code> and{" "}
+        <code {...stylex.props(docsStyles.codeInline)}>lxm=dev.cocore.inference.dispatch</code>) and
+        pass it as the Bearer token. Inference then runs on behalf of the token&apos;s issuer DID.
+        The DID must have connected co/core once so a session exists to publish the job to its PDS;
+        otherwise the request returns{" "}
+        <code {...stylex.props(docsStyles.codeInline)}>401 onboarding_required</code>.
+      </p>
+      <p {...stylex.props(docsStyles.prose)}>
+        Invalid or missing credentials return{" "}
         <code {...stylex.props(docsStyles.codeInline)}>401 authentication_error</code>. See{" "}
         <InferenceApiDocLink fragment="inference-api-http-errors">HTTP errors</InferenceApiDocLink>{" "}
         for the full envelope.

--- a/packages/console/src/lib/api-keys-appview.server.ts
+++ b/packages/console/src/lib/api-keys-appview.server.ts
@@ -39,12 +39,16 @@ export async function resolveBearerKeyViaAppview(presented: string): Promise<Res
   // Cheap shape gate before a network round-trip: every cocore key is
   // `cocore-…`. A JWT or junk bearer can't be an account key, so skip the call.
   if (!presented.startsWith("cocore-")) return null;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 3_000);
   try {
     const res = await fetch(`${b}/internal/account/resolve-key`, {
       method: "POST",
       headers: { "content-type": "application/json", "x-cocore-internal-secret": s },
       body: JSON.stringify({ key: presented }),
+      signal: controller.signal,
     });
+    clearTimeout(timer);
     if (!res.ok) return null;
     const body = (await res.json()) as { id?: string; did?: string; name?: string };
     if (typeof body.did !== "string" || body.did.length === 0) return null;

--- a/packages/console/src/lib/api-keys-appview.server.ts
+++ b/packages/console/src/lib/api-keys-appview.server.ts
@@ -1,0 +1,55 @@
+// Resolve a bearer API key against the AppView's account store.
+//
+// API keys live in two federated stores: console-minted keys in the
+// console's console.db (resolveBearerKey in api-keys.server.ts), and
+// AppView-minted keys — including every key created via the *documented*
+// `dev.cocore.account.createApiKey` endpoint, which the API docs host on
+// the AppView (`#cocore_appview`) — in the AppView's account.db. Each
+// service natively resolves only the keys it minted.
+//
+// The console's OpenAI-compatible inference endpoint
+// (`cocore.dev/v1/chat/completions`) must accept BOTH, otherwise a key a
+// developer mints by following the docs returns a secret but never
+// authenticates ("makes a key but it doesn't do anything"). So after a
+// local console.db miss, the inference path falls back to this, which asks
+// the AppView to resolve the key over the shared-secret internal channel.
+//
+// Gated on COCORE_APPVIEW_INTERNAL_URL + COCORE_INTERNAL_SECRET (the same
+// channel as appview-backed-session.server.ts). With them unset this
+// returns null and the caller keeps its local-only behavior.
+
+import type { ResolvedKey } from "@/lib/api-keys.server.ts";
+
+function base(): string | null {
+  return process.env["COCORE_APPVIEW_INTERNAL_URL"]?.replace(/\/$/, "") || null;
+}
+function secret(): string | null {
+  return process.env["COCORE_INTERNAL_SECRET"] || null;
+}
+
+/** Resolve `presented` against the AppView account store. Returns the
+ *  owning DID (+ key id/name) on success, or null when the key is unknown,
+ *  revoked, expired, malformed, or the AppView is unreachable / not
+ *  configured. Never throws — a transient AppView blip simply declines the
+ *  key here (the local console.db path has already been tried). */
+export async function resolveBearerKeyViaAppview(presented: string): Promise<ResolvedKey | null> {
+  const b = base();
+  const s = secret();
+  if (!b || !s) return null;
+  // Cheap shape gate before a network round-trip: every cocore key is
+  // `cocore-…`. A JWT or junk bearer can't be an account key, so skip the call.
+  if (!presented.startsWith("cocore-")) return null;
+  try {
+    const res = await fetch(`${b}/internal/account/resolve-key`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-cocore-internal-secret": s },
+      body: JSON.stringify({ key: presented }),
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as { id?: string; did?: string; name?: string };
+    if (typeof body.did !== "string" || body.did.length === 0) return null;
+    return { id: body.id ?? "", did: body.did, name: body.name ?? "" };
+  } catch {
+    return null;
+  }
+}

--- a/packages/console/src/lib/api-keys-appview.test.ts
+++ b/packages/console/src/lib/api-keys-appview.test.ts
@@ -1,0 +1,78 @@
+// Unit coverage for the AppView account-store key fallback. The console's
+// inference path calls this after a local console.db miss so a key minted
+// via the documented AppView createApiKey still authenticates.
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { resolveBearerKeyViaAppview } from "./api-keys-appview.server.ts";
+
+const BASE = "http://appview.internal";
+const SECRET = "shh-internal";
+
+beforeEach(() => {
+  process.env["COCORE_APPVIEW_INTERNAL_URL"] = BASE;
+  process.env["COCORE_INTERNAL_SECRET"] = SECRET;
+});
+
+afterEach(() => {
+  delete process.env["COCORE_APPVIEW_INTERNAL_URL"];
+  delete process.env["COCORE_INTERNAL_SECRET"];
+  vi.unstubAllGlobals();
+});
+
+describe("resolveBearerKeyViaAppview", () => {
+  test("returns null without making a call when the channel is unconfigured", async () => {
+    delete process.env["COCORE_APPVIEW_INTERNAL_URL"];
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    expect(await resolveBearerKeyViaAppview("cocore-abc")).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test("skips the round-trip for a non-cocore bearer (e.g. a JWT)", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    expect(await resolveBearerKeyViaAppview("header.payload.sig")).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test("resolves a key, forwarding the internal secret + key body", async () => {
+    const fetchSpy = vi.fn(async (_url: string, init: RequestInit) => {
+      expect((init.headers as Record<string, string>)["x-cocore-internal-secret"]).toBe(SECRET);
+      expect(JSON.parse(init.body as string)).toEqual({ key: "cocore-good" });
+      return new Response(JSON.stringify({ id: "k1", did: "did:plc:abc", name: "laptop" }), {
+        status: 200,
+      });
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+    expect(await resolveBearerKeyViaAppview("cocore-good")).toEqual({
+      id: "k1",
+      did: "did:plc:abc",
+      name: "laptop",
+    });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${BASE}/internal/account/resolve-key`,
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  test("returns null on a 404 (unknown/revoked/expired key)", async () => {
+    vi.stubGlobal("fetch", async () => new Response("{}", { status: 404 }));
+    expect(await resolveBearerKeyViaAppview("cocore-missing")).toBeNull();
+  });
+
+  test("returns null when the AppView is unreachable", async () => {
+    vi.stubGlobal("fetch", async () => {
+      throw new Error("ECONNREFUSED");
+    });
+    expect(await resolveBearerKeyViaAppview("cocore-blip")).toBeNull();
+  });
+
+  test("returns null when the response omits a did", async () => {
+    vi.stubGlobal(
+      "fetch",
+      async () => new Response(JSON.stringify({ name: "x" }), { status: 200 }),
+    );
+    expect(await resolveBearerKeyViaAppview("cocore-weird")).toBeNull();
+  });
+});

--- a/packages/console/src/lib/openai-routes.server.ts
+++ b/packages/console/src/lib/openai-routes.server.ts
@@ -37,6 +37,8 @@ import {
   streamingResponse,
 } from "@/lib/openai-chat-completions.server.ts";
 import { resolveBearerKey } from "@/lib/api-keys.server.ts";
+import { resolveBearerKeyViaAppview } from "@/lib/api-keys-appview.server.ts";
+import { verifyServiceAuth } from "@/lib/service-auth.server.ts";
 import { buildModelDirectory } from "@/lib/model-directory.server.ts";
 import {
   parseTrustFloor,
@@ -58,9 +60,45 @@ import {
 // well above the DEFAULT_MAX_TOKENS of 1024 and most real requests.
 const DEFAULT_PRICE_CEILING = { amount: 100_000, currency: "CC" };
 
-/** Authenticate the bearer key and restore the underlying ATProto
- *  session. On success returns the resolved DID + live session; on
- *  failure returns a ready-to-send error Response. */
+// The method NSID a service-auth token must be minted for (its `lxm`
+// claim) to authenticate inference. The OpenAI-compatible surface forwards
+// to `dev.cocore.inference.dispatch`, so we bind to that NSID — one token
+// works across both the XRPC dispatch and this endpoint.
+const INFERENCE_LXM = "dev.cocore.inference.dispatch";
+
+/** Distinguish an AT Protocol service-auth JWT (three base64url segments)
+ *  from a `cocore-…` API key. A caller can authenticate inference with
+ *  either; a service token (minted by the caller's PDS via getServiceAuth)
+ *  needs no key provisioning at all. */
+function looksLikeServiceToken(bearer: string): boolean {
+  return !bearer.startsWith("cocore-") && bearer.split(".").length === 3;
+}
+
+/** The DID resolved fine, but it has no authorized cocore session — so
+ *  there's no way to publish the job/payment to its PDS. The remedy differs
+ *  by credential: an API-key holder re-mints after re-auth; a service-token
+ *  caller's account owner must complete cocore onboarding once. */
+function sessionAbsentError(viaServiceToken: boolean): Response {
+  if (viaServiceToken) {
+    return jsonError(
+      401,
+      "This DID has no authorized cocore session, so inference cannot run on its behalf. The account owner must connect cocore once at https://cocore.dev, then retry.",
+      "authentication_error",
+      "onboarding_required",
+    );
+  }
+  return jsonError(
+    401,
+    "API key's underlying ATProto session is no longer valid; mint a new key after re-authenticating",
+    "authentication_error",
+  );
+}
+
+/** Authenticate the request and restore the underlying ATProto session.
+ *  Accepts either a cocore API key (resolved against the console store,
+ *  then — for keys minted via the documented AppView endpoint — the AppView
+ *  store) or an AT Protocol service-auth JWT. On success returns the
+ *  resolved DID + live session; on failure returns a ready-to-send error. */
 async function authenticate(
   request: Request,
 ): Promise<{ did: string; oauthSession: OAuthSession } | Response> {
@@ -68,12 +106,29 @@ async function authenticate(
   if (!bearer) {
     return jsonError(401, "Missing Authorization: Bearer header", "authentication_error");
   }
-  const resolved = resolveBearerKey(bearer);
-  if (!resolved) {
-    return jsonError(401, "Invalid API key", "authentication_error");
+
+  // Resolve the caller to a DID via whichever credential they presented.
+  let did: string;
+  let viaServiceToken = false;
+  if (looksLikeServiceToken(bearer)) {
+    viaServiceToken = true;
+    const auth = await verifyServiceAuth(request, INFERENCE_LXM);
+    if (!auth.ok) return jsonError(auth.status, auth.message, "authentication_error", auth.error);
+    did = auth.did;
+  } else {
+    // Local console.db first (console-minted keys + console-paired agents),
+    // then the AppView store (keys minted via the documented createApiKey,
+    // which lands in account.db). The AppView helper self-gates on the
+    // internal channel being configured and on the `cocore-` prefix.
+    const resolved = resolveBearerKey(bearer) ?? (await resolveBearerKeyViaAppview(bearer));
+    if (!resolved) {
+      return jsonError(401, "Invalid API key", "authentication_error", "invalid_api_key");
+    }
+    did = resolved.did;
   }
-  if (!isDid(resolved.did)) {
-    return jsonError(500, "Stored DID is malformed", "server_error");
+
+  if (!isDid(did)) {
+    return jsonError(500, "Resolved DID is malformed", "server_error");
   }
 
   // Single-owner cutover: when forwarding is configured the AppView owns and
@@ -83,15 +138,11 @@ async function authenticate(
   // is replayed by the AppView). Only a DEFINITIVE "session absent" 401s;
   // a transient AppView blip doesn't (the session likely still exists).
   if (isAppviewForwardConfigured()) {
-    const info = await appviewSessionInfo(resolved.did);
+    const info = await appviewSessionInfo(did);
     if (info.checked && !info.present) {
-      return jsonError(
-        401,
-        "API key's underlying ATProto session is no longer valid; mint a new key after re-authenticating",
-        "authentication_error",
-      );
+      return sessionAbsentError(viaServiceToken);
     }
-    return { did: resolved.did, oauthSession: appviewBackedSession(resolved.did as Did) };
+    return { did, oauthSession: appviewBackedSession(did as Did) };
   }
 
   // Restore the OAuth session for this DID. The session store is
@@ -99,16 +150,12 @@ async function authenticate(
   // hasn't explicitly revoked the chain, this resolves.
   const oauthSession = await runTraced(
     "auth.restoreSession",
-    restoreAtprotoSessionEffect(resolved.did as Did),
+    restoreAtprotoSessionEffect(did as Did),
   );
   if (!oauthSession) {
-    return jsonError(
-      401,
-      "API key's underlying ATProto session is no longer valid; mint a new key after re-authenticating",
-      "authentication_error",
-    );
+    return sessionAbsentError(viaServiceToken);
   }
-  return { did: resolved.did, oauthSession };
+  return { did, oauthSession };
 }
 
 /** POST /v1/chat/completions — open-network OpenAI chat completions. */

--- a/packages/console/src/lib/openai-routes.test.ts
+++ b/packages/console/src/lib/openai-routes.test.ts
@@ -9,27 +9,46 @@
 // the dispatch generator) but keep the REAL `authenticate` /
 // `runTraced` path, since the effect/o11y conversion is what touched it.
 
-import { describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import type { DispatchEvent } from "./inference-dispatch.server.ts";
 
 // Mutable knobs the hoisted mocks read.
 const state = vi.hoisted(() => ({
   events: [] as DispatchEvent[],
+  sessionPresent: true,
+  // Resolved by the AppView-store fallback for a cocore- key the local
+  // store rejects (null = the AppView declines it too).
+  appviewKey: null as { id: string; did: string; name: string } | null,
+  // verifyServiceAuth result for a JWT-shaped bearer.
+  serviceAuth: { ok: true, did: "did:plc:servicetokendidservicetok" } as
+    | { ok: true; did: string }
+    | { ok: false; status: number; error: string; message: string },
 }));
 
 vi.mock("@/lib/api-keys.server.ts", () => ({
+  // The local console store only knows its own keys; treat anything but the
+  // canonical test key as a miss so the AppView fallback gets exercised.
   resolveBearerKey: (presented: string) =>
-    presented.startsWith("cocore-")
+    presented === "cocore-testkey"
       ? { id: "key-1", did: "did:plc:testtesttesttesttesttest", name: "test" }
       : null,
+}));
+
+vi.mock("@/lib/api-keys-appview.server.ts", () => ({
+  resolveBearerKeyViaAppview: async (_presented: string) => state.appviewKey,
+}));
+
+vi.mock("@/lib/service-auth.server.ts", () => ({
+  verifyServiceAuth: async (_request: Request, _lxm: string) => state.serviceAuth,
 }));
 
 vi.mock("@/integrations/auth/atproto.server.ts", async () => {
   const { Effect } = await import("effect");
   return {
     // authenticate() runs this through the real runTraced boundary.
-    restoreAtprotoSessionEffect: () => Effect.succeed({ session: "fake" }),
+    restoreAtprotoSessionEffect: () =>
+      state.sessionPresent ? Effect.succeed({ session: "fake" }) : Effect.succeed(null),
   };
 });
 
@@ -60,6 +79,12 @@ const baseBody = {
 };
 
 describe("handleChatCompletions wire contract", () => {
+  beforeEach(() => {
+    state.sessionPresent = true;
+    state.appviewKey = null;
+    state.serviceAuth = { ok: true, did: "did:plc:servicetokendidservicetok" };
+  });
+
   test("stream:true happy path returns text/event-stream, not JSON", async () => {
     state.events = [
       { kind: "chunk", seq: 0, channel: "content", text: "hello" },
@@ -86,6 +111,69 @@ describe("handleChatCompletions wire contract", () => {
     const req = new Request("https://console.test/v1/chat/completions", {
       method: "POST",
       headers: { authorization: "Bearer not-a-cocore-key", "content-type": "application/json" },
+      body: JSON.stringify(baseBody),
+    });
+    const res = await handleChatCompletions(req);
+    expect(res.status).toBe(401);
+    expect(res.headers.get("content-type") ?? "").toMatch(/application\/json/);
+  });
+
+  test("a cocore- key the local store rejects authenticates via the AppView store", async () => {
+    // The Locale bug: a key minted through the documented AppView
+    // createApiKey lands in account.db, not console.db. The fallback must
+    // resolve it so inference runs instead of 401ing.
+    state.events = [{ kind: "complete", tokensIn: 1, tokensOut: 1, receiptUri: "at://x" }];
+    state.appviewKey = { id: "k2", did: "did:plc:appviewmintedkeydidaaaa", name: "appview" };
+    const req = new Request("https://console.test/v1/chat/completions", {
+      method: "POST",
+      headers: { authorization: "Bearer cocore-appviewminted", "content-type": "application/json" },
+      body: JSON.stringify(baseBody),
+    });
+    const res = await handleChatCompletions(req);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type") ?? "").toMatch(/^text\/event-stream/);
+  });
+
+  test("a valid service-auth token (JWT) authenticates inference — no API key", async () => {
+    // mary's idea: hit inference with an AT Protocol service token.
+    state.events = [{ kind: "complete", tokensIn: 1, tokensOut: 1, receiptUri: "at://x" }];
+    const req = new Request("https://console.test/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer header.payload.signature",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(baseBody),
+    });
+    const res = await handleChatCompletions(req);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type") ?? "").toMatch(/^text\/event-stream/);
+  });
+
+  test("a service token for a DID with no cocore session returns onboarding_required", async () => {
+    state.sessionPresent = false;
+    const req = new Request("https://console.test/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer header.payload.signature",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(baseBody),
+    });
+    const res = await handleChatCompletions(req);
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: { code: string | null } };
+    expect(body.error.code).toBe("onboarding_required");
+  });
+
+  test("an invalid service token is rejected with its verify error", async () => {
+    state.serviceAuth = { ok: false, status: 401, error: "BadJwtSignature", message: "bad sig" };
+    const req = new Request("https://console.test/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer header.payload.signature",
+        "content-type": "application/json",
+      },
       body: JSON.stringify(baseBody),
     });
     const res = await handleChatCompletions(req);

--- a/packages/console/src/lib/service-auth.server.ts
+++ b/packages/console/src/lib/service-auth.server.ts
@@ -115,7 +115,6 @@ export async function verifyServiceAuth(
     return fail(401, "BadJwtIssuer", "iss must be a did:plc or did:web");
   }
   if (aud !== cocoreConfig().consoleDid) {
-    console.log(aud, cocoreConfig().consoleDid);
     return fail(401, "BadJwtAudience", "aud does not match this service");
   }
   if (lxm !== expectedLxm) {


### PR DESCRIPTION
## What & why

Two converging fixes to the **inference auth surface**, in response to user reports:

- **Locale:** "createApiKey says it made a key and returns one but doesn't actually make anything."
- **mary:** "why not skip the whole api key and allow hitting the inference endpoint with an atproto service token?"

## The bug (Locale)

Not a missing INSERT, and not a `:memory:` misconfig — both prod services have durable volumes. API keys live in **two federated stores by design**: the console's `console.db` and the AppView's `account.db`, each resolving only the keys *it* minted. The API docs host `dev.cocore.account.createApiKey` on the **AppView** (`#cocore_appview` → `account.db`), but `cocore.dev/v1/chat/completions` — the only API-key inference surface — validated only against **`console.db`**. So a key minted by following the docs was real and persisted, but **inert**.

### Fix (AppView-canonical)
- New shared-secret `/internal/account/resolve-key` endpoint on the AppView (mirrors the existing `/internal/account/mint-key`).
- Console inference `authenticate()` falls back to it after a local `console.db` miss (new `api-keys-appview.server.ts`). Local-first, so console-minted keys stay fast.

## The feature (mary)

The OpenAI-compatible endpoint now also accepts an **AT Protocol service-auth JWT** (3-segment bearer) → `verifyServiceAuth(request, "dev.cocore.inference.dispatch")` with `aud=did:web:console.cocore.dev`. Inference runs on behalf of the token's issuer DID — **no key provisioning**.

- **Onboarding handling:** a DID with no stored cocore session returns a structured **`401 onboarding_required`** (it has no session to publish the job to its PDS).
- Brings the OpenAI surface to parity with the AppView `inference.dispatch`, which already accepted service tokens.
- Inference quickstart docs updated to document the service-token path.

Also removes a stray debug `console.log` in `service-auth.server.ts`.

## Tests

- `openai-routes.test.ts`: service-token auth, AppView-key fallback, `onboarding_required`, invalid-token rejection.
- `api-keys-appview.test.ts`: env/prefix gating + 200/404/error handling (new).
- `internal-reset.test.ts`: `/internal/account/resolve-key` happy path, 403/400/404 (new).

Typecheck (appview + console), lint, and format are clean. The sqlite-backed AppView tests require node 22 (`mise.toml` pin) — they compile here but run in CI, not on a local node 26.

## Invariants

No lexicon change (service-token auth is a mechanism, not a schema change; `createApiKey`/`inference.dispatch` lexicons already exist). No new authoritative state — `account.db` remains operational credentials, not a receipt ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)