### PR TITLE
fix(provider): de-throttle + de-blind first-serve of Xet-backed HF models

### DIFF
--- a/provider/src/engines/subprocess.rs
+++ b/provider/src/engines/subprocess.rs
@@ -277,16 +277,22 @@ pub fn apply_hf_download_env(cmd: &mut Command) {
 /// valid "transfer is alive" signal the stall watchdog can fall back on.
 /// Best-effort; 0 on any read error.
 fn xet_activity_mtime() -> u64 {
-    let Ok(home) = std::env::var("HOME") else {
-        return 0;
+    // Mirror huggingface_hub's cache-root resolution:
+    // HF_HOME > XDG_CACHE_HOME/huggingface > ~/.cache/huggingface.
+    let hf_cache_root = if let Ok(hf_home) = std::env::var("HF_HOME").filter(|v| !v.is_empty()) {
+        PathBuf::from(hf_home)
+    } else if let Ok(xdg) = std::env::var("XDG_CACHE_HOME").filter(|v| !v.is_empty()) {
+        Path::new(&xdg).join("huggingface")
+    } else {
+        let Ok(home) = std::env::var("HOME") else {
+            return 0;
+        };
+        if home.is_empty() {
+            return 0;
+        }
+        Path::new(&home).join(".cache").join("huggingface")
     };
-    if home.is_empty() {
-        return 0;
-    }
-    let dir = Path::new(&home)
-        .join(".cache")
-        .join("huggingface")
-        .join("xet");
+    let dir = hf_cache_root.join("xet");
     newest_mtime_secs(&dir)
 }
 

--- a/provider/src/engines/subprocess.rs
+++ b/provider/src/engines/subprocess.rs
@@ -188,6 +188,146 @@ fn human_bytes(bytes: u64) -> String {
     format!("{value:.decimals$} {}", UNITS[i])
 }
 
+/// HuggingFace token env vars we honor, in priority order. The first
+/// non-empty one wins. `COCORE_HF_TOKEN` lets the operator scope a token
+/// to cocore without touching the global `HF_TOKEN` that other tools on
+/// the box read; the rest are the standard hub variables.
+const HF_TOKEN_VARS: [&str; 4] = [
+    "COCORE_HF_TOKEN",
+    "HF_TOKEN",
+    "HF_HUB_TOKEN",
+    "HUGGING_FACE_HUB_TOKEN",
+];
+
+/// Whether `COCORE_DISABLE_XET` is set to an explicit "off" value. Used
+/// to let an operator opt the Xet fast-path back ON (we disable it by
+/// default — see [`apply_hf_download_env`]).
+fn xet_reenabled_by_operator() -> bool {
+    matches!(
+        std::env::var("COCORE_DISABLE_XET")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "0" | "false" | "no" | "off"
+    )
+}
+
+/// Configure a child `Command`'s HuggingFace download environment so the
+/// weight download authenticates and isn't throttled. Applied to every
+/// engine spawn (and the confidential pre-warm) — see issue #117.
+///
+/// Two problems this fixes, both observed when first-serving an uncached
+/// Xet-backed model:
+///
+///  1. **Unauthenticated → 429 throttle collapse.** With no usable token,
+///     HF rate-limits the traffic; the Xet adaptive-concurrency controller
+///     hits a 429 storm, collapses to its concurrency floor (~40 KB/s), and
+///     a multi-GB download can't finish inside the stall window. We resolve
+///     a non-empty token from [`HF_TOKEN_VARS`] and export it under the two
+///     names huggingface_hub reads (`HF_TOKEN` + `HF_HUB_TOKEN`). Crucially
+///     we also **scrub** a set-but-EMPTY token (the launchd default on the
+///     reporting host), which HF treats as unauthenticated — leaving it set
+///     would shadow nothing useful and keep requests anonymous.
+///
+///  2. **Xet progress is invisible to the watchdog.** The Xet/CAS path
+///     writes a 0-byte `.incomplete` until the head term commits, so the
+///     on-disk byte counter the stall watchdog reads stays flat while GBs
+///     cross the network — a healthy download reads as "no progress" and is
+///     killed. Defaulting `HF_HUB_DISABLE_XET=1` forces the plain-LFS HTTPS
+///     path, which both sidesteps the 429-prone Xet protocol AND advances
+///     the on-disk counter incrementally so the watchdog sees real progress.
+///     An operator who wants Xet back sets `COCORE_DISABLE_XET=0`.
+///
+/// Content-safe: never logs the token value.
+pub fn apply_hf_download_env(cmd: &mut Command) {
+    // (1) Token: first non-empty wins; export under both hub names. If none
+    // is non-empty, strip any (possibly empty) token vars from the child so
+    // an empty `HF_TOKEN` can't pin requests to the throttled anonymous tier.
+    let token = HF_TOKEN_VARS
+        .iter()
+        .find_map(|var| std::env::var(var).ok().filter(|v| !v.trim().is_empty()));
+    match token {
+        Some(token) => {
+            cmd.env("HF_TOKEN", &token).env("HF_HUB_TOKEN", &token);
+        }
+        None => {
+            for var in HF_TOKEN_VARS {
+                cmd.env_remove(var);
+            }
+        }
+    }
+
+    // (2) Xet: disabled by default (plain-LFS), opt back in with
+    // COCORE_DISABLE_XET=0.
+    if xet_reenabled_by_operator() {
+        cmd.env_remove("HF_HUB_DISABLE_XET");
+    } else {
+        cmd.env("HF_HUB_DISABLE_XET", "1");
+    }
+}
+
+/// Newest modification time (as seconds since the Unix epoch) of any file
+/// under the HuggingFace Xet cache/log tree, or 0 if absent. The Xet/CAS
+/// reconstruction path leaves the model's on-disk blob at 0 bytes until its
+/// head term commits (see [`apply_hf_download_env`]), so [`hf_cache_size`]
+/// reads flat during an active Xet transfer. This tree — chunk cache and the
+/// per-generation structured logs under `~/.cache/huggingface/xet/` — IS
+/// touched continuously while bytes flow, so an advancing mtime here is a
+/// valid "transfer is alive" signal the stall watchdog can fall back on.
+/// Best-effort; 0 on any read error.
+fn xet_activity_mtime() -> u64 {
+    let Ok(home) = std::env::var("HOME") else {
+        return 0;
+    };
+    if home.is_empty() {
+        return 0;
+    }
+    let dir = Path::new(&home)
+        .join(".cache")
+        .join("huggingface")
+        .join("xet");
+    newest_mtime_secs(&dir)
+}
+
+/// Recursively find the newest file mtime (seconds since epoch) under `dir`.
+/// Uses `symlink_metadata` so symlinks are stat'd as links, not followed.
+/// Best-effort; 0 on any read error or empty tree.
+fn newest_mtime_secs(dir: &Path) -> u64 {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    let mut newest = 0u64;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        match std::fs::symlink_metadata(&path) {
+            Ok(md) if md.is_dir() => newest = newest.max(newest_mtime_secs(&path)),
+            Ok(md) => {
+                if let Ok(mtime) = md.modified() {
+                    if let Ok(since) = mtime.duration_since(std::time::UNIX_EPOCH) {
+                        newest = newest.max(since.as_secs());
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    newest
+}
+
+/// Stall timeout for the readiness wait, honoring a `COCORE_DOWNLOAD_STALL_TIMEOUT`
+/// override (whole seconds). Defaults to [`READY_STALL_TIMEOUT`]. An operator on a
+/// slow link pulling a large Xet model that genuinely needs more than the default
+/// window can raise this; a malformed/zero value falls back to the default.
+fn ready_stall_timeout() -> Duration {
+    std::env::var("COCORE_DOWNLOAD_STALL_TIMEOUT")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|&s| s > 0)
+        .map(Duration::from_secs)
+        .unwrap_or(READY_STALL_TIMEOUT)
+}
+
 /// Embedded Python wrapper. Written to disk once at first spawn so the
 /// agent ships as a single static binary, no separate file to install
 /// alongside it.
@@ -489,6 +629,10 @@ impl SubprocessEngine {
             // mechanic; the failsafe is what bounds its lifetime.
             .stdin(Stdio::null());
 
+        // Authenticate + de-throttle the HF weight download, and force the
+        // plain-LFS path so the stall watchdog can see byte progress (#117).
+        apply_hf_download_env(&mut cmd);
+
         let mut child = cmd.spawn().with_context(|| {
             format!(
                 "spawning {} {} --model {} --uds {}",
@@ -536,6 +680,12 @@ impl SubprocessEngine {
         let started = Instant::now();
         let mut last_progress = started;
         let mut last_bytes = hf_cache_size(&self.model_id);
+        // Xet/CAS transfers leave the on-disk blob at 0 bytes until the head
+        // term commits, so `last_bytes` stays flat while GBs cross the wire.
+        // The Xet cache/log tree IS touched continuously during the transfer,
+        // so an advancing mtime there is our fallback "still alive" signal.
+        let mut last_xet_mtime = xet_activity_mtime();
+        let stall_timeout = ready_stall_timeout();
         let mut last_log = started;
         loop {
             if self.socket_path.exists() && self.probe_ready() {
@@ -558,6 +708,15 @@ impl SubprocessEngine {
                 last_bytes = bytes;
                 last_progress = now;
             }
+            // Xet-aware progress: even when the on-disk byte counter is flat
+            // (the head-term-commit behavior above), a freshly-written file in
+            // the Xet cache/log tree means the transfer is actively moving, so
+            // don't let the stall watchdog kill a healthy Xet download.
+            let xet_mtime = xet_activity_mtime();
+            if xet_mtime > last_xet_mtime {
+                last_xet_mtime = xet_mtime;
+                last_progress = now;
+            }
             // Periodic, content-safe progress line (byte counts only — no
             // prompt/token data). Gives the agent log *some* visibility into
             // an otherwise-silent multi-GB download.
@@ -570,14 +729,14 @@ impl SubprocessEngine {
                 last_log = now;
             }
 
-            if now.duration_since(last_progress) > READY_STALL_TIMEOUT {
+            if now.duration_since(last_progress) > stall_timeout {
                 let _ = child.kill();
                 bail!(
                     "inference subprocess for {} made no progress for {}s ({} downloaded so far) and never became ready. \
                      Common causes: a stalled/failed HF download, vllm-mlx import error, or missing venv.\n\
                      Recent engine output (no request has been served yet — content-safe to share):\n{}\n{}",
                     self.model_id,
-                    READY_STALL_TIMEOUT.as_secs(),
+                    stall_timeout.as_secs(),
                     human_bytes(last_bytes),
                     render_ring("stdout", &stdout_buf),
                     render_ring("stderr", &stderr_buf),
@@ -1127,6 +1286,91 @@ mod tests {
             })
             .unwrap();
         (out, tokens)
+    }
+
+    /// Serializes the env-mutating tests below — `std::env::set_var` is
+    /// process-global, so they'd race each other under cargo's parallel runner.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Collect a Command's explicit env diffs into (key -> Option<value>).
+    fn cmd_env(cmd: &Command) -> std::collections::HashMap<String, Option<String>> {
+        cmd.get_envs()
+            .map(|(k, v)| {
+                (
+                    k.to_string_lossy().into_owned(),
+                    v.map(|v| v.to_string_lossy().into_owned()),
+                )
+            })
+            .collect()
+    }
+
+    /// A non-empty token is exported under both hub names and Xet is disabled
+    /// by default. Env vars are process-global, so this test owns HF_* state.
+    #[test]
+    fn apply_hf_env_passes_token_and_disables_xet() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        for var in HF_TOKEN_VARS {
+            std::env::remove_var(var);
+        }
+        std::env::remove_var("COCORE_DISABLE_XET");
+        std::env::set_var("COCORE_HF_TOKEN", "hf_secret123");
+
+        let mut cmd = Command::new("true");
+        apply_hf_download_env(&mut cmd);
+        let env = cmd_env(&cmd);
+
+        assert_eq!(env.get("HF_TOKEN"), Some(&Some("hf_secret123".to_string())));
+        assert_eq!(
+            env.get("HF_HUB_TOKEN"),
+            Some(&Some("hf_secret123".to_string()))
+        );
+        assert_eq!(
+            env.get("HF_HUB_DISABLE_XET"),
+            Some(&Some("1".to_string()))
+        );
+
+        std::env::remove_var("COCORE_HF_TOKEN");
+    }
+
+    /// A set-but-EMPTY token (the launchd default that triggered #117) is
+    /// scrubbed from the child env, not propagated as an empty value.
+    #[test]
+    fn apply_hf_env_scrubs_empty_token() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        for var in HF_TOKEN_VARS {
+            std::env::remove_var(var);
+        }
+        std::env::remove_var("COCORE_DISABLE_XET");
+        std::env::set_var("HF_TOKEN", ""); // set-but-empty
+
+        let mut cmd = Command::new("true");
+        apply_hf_download_env(&mut cmd);
+        let env = cmd_env(&cmd);
+
+        // env_remove records the key with a None value.
+        assert_eq!(env.get("HF_TOKEN"), Some(&None));
+        assert_eq!(env.get("HF_HUB_TOKEN"), Some(&None));
+
+        std::env::remove_var("HF_TOKEN");
+    }
+
+    /// COCORE_DISABLE_XET=0 re-enables the Xet fast path (no disable var set).
+    #[test]
+    fn apply_hf_env_xet_opt_out_reenables() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        for var in HF_TOKEN_VARS {
+            std::env::remove_var(var);
+        }
+        std::env::set_var("COCORE_DISABLE_XET", "0");
+
+        let mut cmd = Command::new("true");
+        apply_hf_download_env(&mut cmd);
+        let env = cmd_env(&cmd);
+
+        // Removed (operator wants Xet), not set to "1".
+        assert_eq!(env.get("HF_HUB_DISABLE_XET"), Some(&None));
+
+        std::env::remove_var("COCORE_DISABLE_XET");
     }
 
     #[test]

--- a/provider/src/engines/subprocess.rs
+++ b/provider/src/engines/subprocess.rs
@@ -281,21 +281,23 @@ fn xet_activity_mtime() -> u64 {
     // HF_HOME > XDG_CACHE_HOME/huggingface > ~/.cache/huggingface.
     // (`std::env::var` returns a Result, so `.ok().filter(..)` to drop both
     // the unset and the set-but-empty cases before falling through.)
-    let hf_cache_root = if let Some(hf_home) =
-        std::env::var("HF_HOME").ok().filter(|v| !v.is_empty())
-    {
-        PathBuf::from(hf_home)
-    } else if let Some(xdg) = std::env::var("XDG_CACHE_HOME").ok().filter(|v| !v.is_empty()) {
-        Path::new(&xdg).join("huggingface")
-    } else {
-        let Ok(home) = std::env::var("HOME") else {
-            return 0;
+    let hf_cache_root =
+        if let Some(hf_home) = std::env::var("HF_HOME").ok().filter(|v| !v.is_empty()) {
+            PathBuf::from(hf_home)
+        } else if let Some(xdg) = std::env::var("XDG_CACHE_HOME")
+            .ok()
+            .filter(|v| !v.is_empty())
+        {
+            Path::new(&xdg).join("huggingface")
+        } else {
+            let Ok(home) = std::env::var("HOME") else {
+                return 0;
+            };
+            if home.is_empty() {
+                return 0;
+            }
+            Path::new(&home).join(".cache").join("huggingface")
         };
-        if home.is_empty() {
-            return 0;
-        }
-        Path::new(&home).join(".cache").join("huggingface")
-    };
     let dir = hf_cache_root.join("xet");
     newest_mtime_secs(&dir)
 }
@@ -1334,10 +1336,7 @@ mod tests {
             env.get("HF_HUB_TOKEN"),
             Some(&Some("hf_secret123".to_string()))
         );
-        assert_eq!(
-            env.get("HF_HUB_DISABLE_XET"),
-            Some(&Some("1".to_string()))
-        );
+        assert_eq!(env.get("HF_HUB_DISABLE_XET"), Some(&Some("1".to_string())));
 
         std::env::remove_var("COCORE_HF_TOKEN");
     }

--- a/provider/src/engines/subprocess.rs
+++ b/provider/src/engines/subprocess.rs
@@ -279,9 +279,13 @@ pub fn apply_hf_download_env(cmd: &mut Command) {
 fn xet_activity_mtime() -> u64 {
     // Mirror huggingface_hub's cache-root resolution:
     // HF_HOME > XDG_CACHE_HOME/huggingface > ~/.cache/huggingface.
-    let hf_cache_root = if let Ok(hf_home) = std::env::var("HF_HOME").filter(|v| !v.is_empty()) {
+    // (`std::env::var` returns a Result, so `.ok().filter(..)` to drop both
+    // the unset and the set-but-empty cases before falling through.)
+    let hf_cache_root = if let Some(hf_home) =
+        std::env::var("HF_HOME").ok().filter(|v| !v.is_empty())
+    {
         PathBuf::from(hf_home)
-    } else if let Ok(xdg) = std::env::var("XDG_CACHE_HOME").filter(|v| !v.is_empty()) {
+    } else if let Some(xdg) = std::env::var("XDG_CACHE_HOME").ok().filter(|v| !v.is_empty()) {
         Path::new(&xdg).join("huggingface")
     } else {
         let Ok(home) = std::env::var("HOME") else {

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -1019,15 +1019,17 @@ fn download_hf_snapshot(venv_python: &std::path::Path, model: &str) -> Option<St
     // plain string literal (which rustfmt never reflows).
     let code =
         "import sys; from huggingface_hub import snapshot_download; print(snapshot_download(sys.argv[1]))";
-    let out = std::process::Command::new(venv_python)
-        .arg("-c")
+    let mut cmd = std::process::Command::new(venv_python);
+    cmd.arg("-c")
         .arg(code)
         .arg(model)
         // Accelerated parallel download (hf_transfer is installed by
         // scripts/bootstrap-python-venv.sh alongside vllm-mlx).
-        .env("HF_HUB_ENABLE_HF_TRANSFER", "1")
-        .output()
-        .ok()?;
+        .env("HF_HUB_ENABLE_HF_TRANSFER", "1");
+    // Same auth + plain-LFS download env the engine subprocess uses, so the
+    // confidential pre-warm doesn't hit the unauthenticated 429 throttle (#117).
+    cocore_provider::engines::subprocess::apply_hf_download_env(&mut cmd);
+    let out = cmd.output().ok()?;
     if !out.status.success() {
         tracing::warn!(
             model = %model,
@@ -2668,6 +2670,36 @@ fn build_engines(
             models: all_unserved,
             at: chrono::Utc::now(),
         }
+    } else if !failed.is_empty() && is_weight_download_incomplete(last_err.as_deref()) {
+        // The weights never finished downloading — the readiness watchdog
+        // killed a stalled/throttled download, or the engine logged HF
+        // throttling (unauthenticated 429s). The generic "not MLX format"
+        // message below would be actively wrong (the model id is fine; the
+        // bytes just never landed) and sends the operator down the wrong path
+        // verifying model packaging instead of the download. See issue #117.
+        tracing::warn!(
+            models = ?failed,
+            last_error = %last_err.as_deref().unwrap_or("(none captured)"),
+            "weight download did not complete (stalled/throttled/killed); serving stub only"
+        );
+        EngineFault {
+            code: "model-download-incomplete".to_string(),
+            message: format!(
+                "The weight download for [{}] was throttled or killed before it \
+                 finished, so the engine never came online — the model id and format \
+                 are fine; the bytes never landed. The machine is online but only \
+                 serving the no-op `stub` engine, so it won't be matched to real \
+                 inference jobs. Most common cause: HuggingFace rate-limited an \
+                 unauthenticated download. Fix: set a HuggingFace token before serving \
+                 (export `HF_TOKEN=hf_...`, or `COCORE_HF_TOKEN`), ensure the machine \
+                 can reach huggingface.co, then start serving again. The download \
+                 resumes from where it left off, so retrying after authenticating \
+                 usually succeeds.",
+                failed.join(", "),
+            ),
+            models: all_unserved,
+            at: chrono::Utc::now(),
+        }
     } else if !failed.is_empty() {
         tracing::warn!(
             models = ?failed,
@@ -2781,6 +2813,24 @@ fn is_multimodal_weight_map_failure(last_err: Option<&str>) -> bool {
     e.contains("language_model.")
         || (e.contains("Missing key") && e.contains("language_model."))
         || (e.contains("KeyError") && e.contains("language_model."))
+}
+
+/// Whether an engine-start error is the "the weight download never finished"
+/// failure — the readiness watchdog SIGKILLing a stalled/throttled download, or
+/// the engine logging HuggingFace throttling (unauthenticated 429s) before being
+/// killed. Detected from the watchdog's own bail text ("made no progress …",
+/// "never became ready") and the throttle signals the child writes to stderr.
+/// Drives a precise "download was throttled/killed" message instead of the
+/// generic "not MLX format" one, which is wrong here — the weights ARE the right
+/// format; the bytes just never landed. Content-safe (watchdog + library
+/// traceback text only). See issue #117.
+fn is_weight_download_incomplete(last_err: Option<&str>) -> bool {
+    let Some(e) = last_err else { return false };
+    e.contains("made no progress for")
+        || e.contains("never became ready")
+        || e.contains("unauthenticated requests to the HF Hub")
+        || e.contains("Too Many Requests")
+        || e.contains("429")
 }
 
 /// Try to start one model's inference subprocess, retrying transient
@@ -3001,6 +3051,39 @@ mod vision_fault_tests {
         let err = "TypeError: VisionConfig.__init__() missing 6 required positional arguments";
         assert!(is_vision_config_failure(Some(err)));
         assert!(!is_multimodal_weight_map_failure(Some(err)));
+    }
+
+    use super::is_weight_download_incomplete;
+
+    #[test]
+    fn detects_watchdog_no_progress_kill() {
+        // The exact bail text the readiness watchdog emits when it SIGKILLs a
+        // stalled/throttled download (subprocess.rs).
+        let err = "inference subprocess for mlx-community/Qwen3.5-4B-MLX-4bit made no progress for 300s (26 MB downloaded so far) and never became ready.";
+        assert!(is_weight_download_incomplete(Some(err)));
+    }
+
+    #[test]
+    fn detects_hf_throttle_signals() {
+        assert!(is_weight_download_incomplete(Some(
+            "Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN"
+        )));
+        assert!(is_weight_download_incomplete(Some(
+            "[stderr] HTTP Error 429: Too Many Requests"
+        )));
+    }
+
+    #[test]
+    fn download_incomplete_ignores_unrelated_and_none() {
+        // A real not-MLX / OOM / import failure must NOT be misclassified as a
+        // download problem, or the operator gets the wrong remediation.
+        assert!(!is_weight_download_incomplete(Some(
+            "OSError: out of memory loading weights"
+        )));
+        assert!(!is_weight_download_incomplete(Some(
+            "TypeError: VisionConfig.__init__() missing 6 required positional arguments"
+        )));
+        assert!(!is_weight_download_incomplete(None));
     }
 }
 

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -2830,7 +2830,6 @@ fn is_weight_download_incomplete(last_err: Option<&str>) -> bool {
         || e.contains("never became ready")
         || e.contains("unauthenticated requests to the HF Hub")
         || e.contains("Too Many Requests")
-        || e.contains("429")
 }
 
 /// Try to start one model's inference subprocess, retrying transient


### PR DESCRIPTION
Fixes #117 — a first serve of an uncached Xet-backed HF model
(`mlx-community/Qwen3.5-4B-MLX-4bit`, 3 GB) never installs. Three independent
defects share one repro. Provider-agent only; **no lexicon change**.

## Issue 3 — engine sends unauthenticated HF requests → 429 throttle collapse (root cause)
The engine subprocess inherited the agent env wholesale and set **no** HF
download env. On the reporting host `HF_TOKEN` is *set-but-empty* in launchd, so
requests went out **unauthenticated** → HF rate-limited → the Xet
adaptive-concurrency controller hit a 429 storm, collapsed 57→1 (~40 KB/s), and
3 GB couldn't land inside the 300 s stall window.

New `apply_hf_download_env(&mut Command)` (`provider/src/engines/subprocess.rs`),
applied to the engine spawn **and** the confidential pre-warm
`download_hf_snapshot` in `main.rs`:
- Resolves the first non-empty token from
  `COCORE_HF_TOKEN` / `HF_TOKEN` / `HF_HUB_TOKEN` / `HUGGING_FACE_HUB_TOKEN`,
  exports it under both hub names.
- **Scrubs** a set-but-empty token from the child env (the launchd default that
  caused this).
- Defaults `HF_HUB_DISABLE_XET=1` → plain-LFS HTTPS, which sidesteps the
  429-prone Xet path **and** makes the on-disk byte counter advance again (this
  also rescues Issue 1). Opt back into Xet with `COCORE_DISABLE_XET=0`.

## Issue 1 — stall watchdog is blind to Xet progress (latent)
The watchdog measured progress solely from on-disk HF cache size, which stays
flat for Xet (0-byte `.incomplete` until the head term commits) while GBs cross
the wire — so a **healthy** transfer reads as no-progress and gets SIGKILLed.
- Added `xet_activity_mtime()` (newest mtime under `~/.cache/huggingface/xet/`)
  as a fallback "transfer is alive" signal.
- Added `COCORE_DOWNLOAD_STALL_TIMEOUT` override of the 300 s default.

(Largely mooted by defaulting Xet off, but kept as hardening for `COCORE_DISABLE_XET=0`.)

## Issue 2 — misleading "not MLX format" fault (independent)
A throttled/killed download surfaced the generic `model-load-failed` message
leading with *"the model isn't in MLX format"* — wrong for an `mlx-community/…`
model. Added `is_weight_download_incomplete()` classifier (matches the watchdog
bail + HF throttle signals) and a dedicated `model-download-incomplete`
`EngineFault` ahead of the generic one — same pattern as the existing
`is_vision_config_failure` / `is_socket_path_too_long` classifiers.

## Behavior-change callout
Defaulting Xet **off** trades Xet's CAS dedup/speed for first-serve reliability:
plain-LFS always works and is watchdog-visible. Power users on fat pipes can
re-enable with `COCORE_DISABLE_XET=0`. This is a fleet-wide default change.

## Tests
- New: token pass-through, empty-token scrub, Xet opt-out, and all three
  `is_weight_download_incomplete` classifier cases.
- `cargo test` green; `cargo clippy --all-targets --features apns` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)