### PR TITLE
fix(appview): stop stale ingests from reverting owner-set machine settings

### DIFF
--- a/packages/appview/src/indexer/replay.test.ts
+++ b/packages/appview/src/indexer/replay.test.ts
@@ -200,6 +200,92 @@ test("replay: same event twice is a no-op (idempotent upsert)", async () => {
   assert.equal(snapBefore, snapAfter);
 });
 
+test("stale provider re-ingest never clobbers a newer one (version guard)", () => {
+  const ix = new Indexer(newStore());
+  const uri = "at://did:plc:p/dev.cocore.compute.provider/1";
+  const base = {
+    uri,
+    cid: "v1",
+    collection: "dev.cocore.compute.provider",
+    repo: "did:plc:p",
+    rkey: "1",
+  };
+
+  // The owner's just-saved version: shareLocation on, pro bono on, newer ts.
+  ix.ingest({
+    ...base,
+    cid: "v2",
+    record: {
+      machineLabel: "MBP",
+      attestationPubKey: "A",
+      shareLocation: true,
+      proBono: { mode: "any" },
+      createdAt: "2026-05-07T12:05:00Z",
+    },
+  });
+
+  // A lagging / replayed firehose delivery of the PRE-EDIT commit (older
+  // createdAt, no owner settings) arrives afterward. It must NOT win.
+  ix.ingest({
+    ...base,
+    cid: "v1",
+    record: {
+      machineLabel: "MBP",
+      attestationPubKey: "A",
+      createdAt: "2026-05-07T12:00:00Z",
+    },
+  });
+
+  const got = ix.store.get(uri);
+  assert.ok(got);
+  const body = got.body as { shareLocation?: boolean; proBono?: unknown };
+  assert.equal(body.shareLocation, true, "owner's shareLocation must survive a stale replay");
+  assert.deepEqual(body.proBono, { mode: "any" }, "owner's proBono must survive a stale replay");
+  assert.equal(got.cid, "v2", "newer version stays current");
+});
+
+test("equal or newer provider version still applies (idempotent + real updates)", () => {
+  const ix = new Indexer(newStore());
+  const uri = "at://did:plc:p/dev.cocore.compute.provider/1";
+  const base = {
+    uri,
+    cid: "c",
+    collection: "dev.cocore.compute.provider",
+    repo: "did:plc:p",
+    rkey: "1",
+  };
+  ix.ingest({ ...base, record: { attestationPubKey: "A", createdAt: "2026-05-07T12:00:00Z" } });
+  // Equal createdAt, newer body — last-writer-wins is preserved.
+  ix.ingest({
+    ...base,
+    cid: "c2",
+    record: { attestationPubKey: "A", machineLabel: "renamed", createdAt: "2026-05-07T12:00:00Z" },
+  });
+  assert.equal((ix.store.get(uri)!.body as { machineLabel?: string }).machineLabel, "renamed");
+  // Strictly newer — applies.
+  ix.ingest({
+    ...base,
+    cid: "c3",
+    record: { attestationPubKey: "A", machineLabel: "newest", createdAt: "2026-05-07T12:10:00Z" },
+  });
+  assert.equal((ix.store.get(uri)!.body as { machineLabel?: string }).machineLabel, "newest");
+});
+
+test("records without createdAt keep last-writer-wins (no guard)", () => {
+  const ix = new Indexer(newStore());
+  const uri = "at://did:plc:p/dev.cocore.compute.receipt/1";
+  const base = {
+    uri,
+    cid: "r1",
+    collection: "dev.cocore.compute.receipt",
+    repo: "did:plc:p",
+    rkey: "1",
+  };
+  ix.ingest({ ...base, record: { model: "a" } });
+  ix.ingest({ ...base, cid: "r2", record: { model: "b" } });
+  assert.equal((ix.store.get(uri)!.body as { model?: string }).model, "b");
+});
+
 test("snapshot golden bytes (sentinel against silent body mutation)", async () => {
   const ix = new Indexer(newStore());
   const fh = new Firehose();

--- a/packages/appview/src/store.ts
+++ b/packages/appview/src/store.ts
@@ -10,6 +10,31 @@
 import Database from "better-sqlite3";
 import type { Database as DB } from "better-sqlite3";
 
+/** Pull a record body's `createdAt` (RFC3339 string) if present. Provider
+ *  and job records carry one; the provider agent stamps a fresh value on
+ *  every (re-)publish, and the console stamps one on every owner edit, so
+ *  for those collections `createdAt` is a monotonic "last-published-at"
+ *  version we can order conflicting writes by. Records without it (e.g.
+ *  receipts, attestations) return null and fall back to last-writer-wins. */
+function bodyCreatedAt(body: unknown): string | null {
+  if (!body || typeof body !== "object") return null;
+  const v = (body as Record<string, unknown>)["createdAt"];
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+/** Whether an incoming record version is STRICTLY older than the one we
+ *  already hold. Compared as parsed instants (not lexicographically) so
+ *  producers that serialize `createdAt` at different sub-second precisions
+ *  still order correctly. Unparseable timestamps compare as "not older" so
+ *  we never silently drop a write we can't reason about. Equal instants are
+ *  NOT older — the later arrival still wins, preserving idempotent replay. */
+function isStaleVersion(incoming: string, existing: string): boolean {
+  const a = Date.parse(incoming);
+  const b = Date.parse(existing);
+  if (Number.isNaN(a) || Number.isNaN(b)) return false;
+  return a < b;
+}
+
 export interface IndexedRecord {
   uri: string;
   cid: string;
@@ -241,6 +266,7 @@ export class Store {
   private deleteStmt;
   private getStmt;
   private getByCollectionStmt;
+  private existingVersionStmt;
 
   constructor(path: string) {
     this.db = new Database(path);
@@ -263,6 +289,9 @@ export class Store {
       `SELECT uri, cid, collection, repo, rkey, body, indexed_at as indexedAt
        FROM records WHERE collection = ?
        ORDER BY indexed_at DESC LIMIT ?`,
+    );
+    this.existingVersionStmt = this.db.prepare(
+      `SELECT json_extract(body, '$.createdAt') AS createdAt FROM records WHERE uri = ?`,
     );
   }
 
@@ -295,6 +324,26 @@ export class Store {
   }
 
   upsert(rec: Omit<IndexedRecord, "indexedAt">): void {
+    // Version guard: never let a stale, out-of-order, or replayed ingest
+    // clobber a newer record body. The AppView is a cache the dashboard
+    // reads, fed by two independent, unordered writers — the console's
+    // best-effort bridge mirror (fired the instant an owner edits a setting)
+    // and the firehose (which lags and can re-deliver older commits on
+    // reconnect/backfill). A blind `INSERT OR REPLACE` here makes the LAST
+    // ARRIVAL win regardless of which write is actually newer, so a lagging
+    // firehose replay of a pre-edit provider commit silently reverts an
+    // owner's just-saved `shareLocation` / `proBono` (and every other
+    // owner-set field) in the dashboard even though their PDS — the real
+    // source of truth — is correct. Drop the write when the incoming body
+    // is strictly older than what we hold; equal/newer still applies, so
+    // idempotent replay and legitimate updates are unaffected. Records with
+    // no comparable `createdAt` keep the prior last-writer-wins behavior.
+    const incoming = bodyCreatedAt(rec.body);
+    if (incoming !== null) {
+      const row = this.existingVersionStmt.get(rec.uri) as { createdAt: string | null } | undefined;
+      const existing = row?.createdAt ?? null;
+      if (existing !== null && isStaleVersion(incoming, existing)) return;
+    }
     this.upsertStmt.run({
       uri: rec.uri,
       cid: rec.cid,

--- a/packages/appview/src/store.ts
+++ b/packages/appview/src/store.ts
@@ -267,6 +267,7 @@ export class Store {
   private getStmt;
   private getByCollectionStmt;
   private existingVersionStmt;
+  private guardedUpsertTxn;
 
   constructor(path: string) {
     this.db = new Database(path);
@@ -292,6 +293,26 @@ export class Store {
     );
     this.existingVersionStmt = this.db.prepare(
       `SELECT json_extract(body, '$.createdAt') AS createdAt FROM records WHERE uri = ?`,
+    );
+    // Version-guarded write as ONE atomic step. We compare timestamps in JS
+    // (see isStaleVersion) rather than in the SQL `ON CONFLICT … WHERE` clause
+    // because the provider agent serializes `createdAt` at sub-millisecond
+    // (µs/ns) RFC3339 precision, which SQLite's date functions can't compare
+    // reliably (julianday/strftime cap at ms and return NULL on extra digits).
+    // Keeping the compare in JS means the read + conditional write straddle two
+    // statements, so wrap them in an IMMEDIATE transaction: it takes the write
+    // lock up front, so a second writer (a future multi-process AppView sharing
+    // this WAL database) can't land between the check and the write and defeat
+    // the guard.
+    this.guardedUpsertTxn = this.db.transaction(
+      (incoming: string, params: Record<string, unknown>) => {
+        const row = this.existingVersionStmt.get(params["uri"]) as
+          | { createdAt: string | null }
+          | undefined;
+        const existing = row?.createdAt ?? null;
+        if (existing !== null && isStaleVersion(incoming, existing)) return;
+        this.upsertStmt.run(params);
+      },
     );
   }
 
@@ -338,20 +359,22 @@ export class Store {
     // is strictly older than what we hold; equal/newer still applies, so
     // idempotent replay and legitimate updates are unaffected. Records with
     // no comparable `createdAt` keep the prior last-writer-wins behavior.
-    const incoming = bodyCreatedAt(rec.body);
-    if (incoming !== null) {
-      const row = this.existingVersionStmt.get(rec.uri) as { createdAt: string | null } | undefined;
-      const existing = row?.createdAt ?? null;
-      if (existing !== null && isStaleVersion(incoming, existing)) return;
-    }
-    this.upsertStmt.run({
+    const params = {
       uri: rec.uri,
       cid: rec.cid,
       collection: rec.collection,
       repo: rec.repo,
       rkey: rec.rkey,
       body: JSON.stringify(rec.body),
-    });
+    };
+    const incoming = bodyCreatedAt(rec.body);
+    if (incoming === null) {
+      // No version to compare — plain last-writer-wins, no read needed.
+      this.upsertStmt.run(params);
+      return;
+    }
+    // Versioned record — guard the write atomically (see guardedUpsertTxn).
+    this.guardedUpsertTxn.immediate(incoming, params);
   }
 
   get(uri: string): IndexedRecord | null {

--- a/packages/console/src/lib/provider-record-pds.server.ts
+++ b/packages/console/src/lib/provider-record-pds.server.ts
@@ -94,6 +94,16 @@ async function putMyProviderRecord(
   record: Record<string, unknown>,
   swapRecord: string,
 ): Promise<void> {
+  // Stamp a fresh `createdAt` so this owner edit is unambiguously the newest
+  // version of the record. Provider records treat `createdAt` as a monotonic
+  // "last-published-at" — the agent bumps it on every re-publish — and both
+  // the AppView's index (see store.upsert's version guard) and the agent's
+  // dedup order conflicting writes by it. A read-modify-write that KEEPS the
+  // agent's last timestamp would leave the edit tied with the agent's prior
+  // commit; a lagging/replayed firehose delivery of that same-timestamp
+  // commit could then clobber the edit back to its pre-edit state in the
+  // dashboard. Bumping it makes the edit strictly win.
+  const next = { ...record, createdAt: new Date().toISOString() };
   const res = await session.handle(`/xrpc/com.atproto.repo.putRecord`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -101,7 +111,7 @@ async function putMyProviderRecord(
       repo: session.did,
       collection: PROVIDER_COLLECTION,
       rkey,
-      record,
+      record: next,
       swapRecord,
     }),
   });
@@ -117,7 +127,7 @@ async function putMyProviderRecord(
   try {
     const body = (await res.json()) as { cid?: string };
     if (body?.cid) {
-      mirrorPutToBridge({ did: session.did, rkey, cid: body.cid, record });
+      mirrorPutToBridge({ did: session.did, rkey, cid: body.cid, record: next });
     }
   } catch {
     // ignore — putRecord succeeded, only the bridge hint is missing


### PR DESCRIPTION
## Summary

The "Share country" (`shareLocation`) and "pro bono" (`proBono`) machine settings — and in fact every owner-set provider switch — kept flipping back **off** in the dashboard even after being explicitly set on the website.

This is a **state-contestation bug in the AppView cache**, not in the source of truth. The PDS record stays correct the whole time: both the console write and the provider agent's republishes preserve these owner fields (the agent reads the real PDS directly and runs them through `preserve_console_fields`). But the dashboard reads the **AppView index**, and that index could regress to a stale body.

## Root cause

The AppView's provider row is fed by two independent, **unordered** writers:

1. The console's best-effort **bridge mirror**, fired the instant an owner edits a setting.
2. The **firehose**, which lags and can re-deliver older commits on reconnect/backfill.

`Store.upsert` did a blind `INSERT … ON CONFLICT(uri) DO UPDATE SET body = excluded.body` — so the **last write to arrive wins**, regardless of which is actually newer. A lagging firehose replay of a *pre-edit* provider commit therefore silently overwrote the owner's just-saved settings in the cache, flipping `shareLocation`/`proBono` (and everything else owner-authored) back off in the UI while the PDS remained correct.

## Fix

- **AppView store (`packages/appview/src/store.ts`)** — add a version guard keyed on the body's `createdAt` (a monotonic "last-published-at" for provider/job records). An incoming body **strictly older** than the one held is dropped; equal/newer still applies. Records without a comparable `createdAt` keep last-writer-wins, so receipts/attestations are untouched. The converged state becomes the max-`createdAt` body per `uri` — order-independent, which *strengthens* the federation guarantee.
- **Console (`packages/console/src/lib/provider-record-pds.server.ts`)** — stamp a fresh `createdAt` on every owner edit so the edit is unambiguously the newest version and can never tie with (and be clobbered by a replay of) the agent's prior same-timestamp commit.

This keeps the invariant that the AppView is a cache, never a ledger — the PDS was always right; we just stop the cache from reverting to a stale view of it.

## Testing

`packages/appview` test suite: **113 passing**, including 3 new cases:
- a stale provider re-ingest no longer clobbers a newer one (owner's `shareLocation`/`proBono` survive a replayed pre-edit commit);
- equal/newer versions still apply (idempotent replay + real updates);
- records without `createdAt` keep last-writer-wins.

`tsc --noEmit` passes for both `packages/appview` and `packages/console`; `oxfmt` + `oxlint` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvE2rUbQCYvPo4qYCk24h4)_