### PR TITLE
feat(latency): report time-to-ack on the landing page, not TTFT

### DIFF
--- a/infra/advisor/src/jobs.test.ts
+++ b/infra/advisor/src/jobs.test.ts
@@ -22,7 +22,9 @@ interface Harness {
   sessions: SessionManager;
 }
 
-async function startHarness(opts: { attestationMaxAgeMs?: number } = {}): Promise<Harness> {
+async function startHarness(
+  opts: { attestationMaxAgeMs?: number; onDispatched?: (ms: number) => void } = {},
+): Promise<Harness> {
   const registry = new ProviderRegistry();
   const sessions = new SessionManager({ idleTimeoutMs: 2_000 });
   const server = createServer((req, res) => {
@@ -33,6 +35,7 @@ async function startHarness(opts: { attestationMaxAgeMs?: number } = {}): Promis
         sessions,
         generateId: () => "test-session",
         attestationMaxAgeMs: opts.attestationMaxAgeMs,
+        onDispatched: opts.onDispatched,
       });
       return;
     }
@@ -271,6 +274,33 @@ describe("POST /jobs", () => {
     expect(lines[1]).toContain('"seq":0');
     expect(lines[2]).toContain("event: complete");
     expect(lines[2]).toContain('"receiptUri":"at://receipt"');
+  });
+
+  it("fires onDispatched (time-to-ack) once the inference_request is handed off", async () => {
+    await new Promise<void>((r) => h.server.close(() => r()));
+    const acks: number[] = [];
+    h = await startHarness({ onDispatched: (ms) => acks.push(ms) });
+    const fp = fakeProvider(h.registry, "did:plc:ack", "pub-ack");
+
+    const linesP = readSseLines(`${h.url}/jobs`, {
+      jobUri: "at://job",
+      requesterDid: "did:plc:requester",
+      requesterPubKey: "req-pub",
+      model: "stub",
+      maxTokensOut: 32,
+      ciphertext: [1, 2, 3],
+    });
+
+    // The ack fires the instant the frame lands in the provider's queue —
+    // before any chunk is relayed, proving it measures handoff, not TTFT.
+    await vi.waitFor(() => expect(fp.sent.length).toBeGreaterThan(0), { timeout: 1_000 });
+    expect(acks.length).toBe(1);
+    expect(acks[0]).toBeGreaterThanOrEqual(0);
+    expect(acks[0]).toBeLessThan(2_000);
+
+    // Drain the stream so the request completes cleanly.
+    h.sessions.complete("test-session", { tokensIn: 1, tokensOut: 0, receiptUri: "at://receipt" });
+    await linesP;
   });
 
   it("preflights and fails over from an unresponsive provider to a live one", async () => {

--- a/infra/advisor/src/jobs.ts
+++ b/infra/advisor/src/jobs.ts
@@ -251,6 +251,11 @@ export interface JobsContext {
    *  candidate. Small by design — a healthy serve loop answers in a few
    *  ms; this only needs to clear network RTT. Defaults to 1500ms. */
   preflightTimeoutMs?: number;
+  /** Called once per successful dispatch with the time-to-ack in ms
+   *  (`/jobs` received → `inference_request` frame handed to the chosen
+   *  provider's socket). The brokerage-latency headline; main.ts feeds it
+   *  into the rolling window the `/ack` route serves + an OTLP histogram. */
+  onDispatched?: (ms: number) => void;
 }
 
 /** Outcome of selecting + preflighting a provider for a parsed job. */
@@ -452,6 +457,12 @@ function dispatch(
 
   try {
     provider.send(inferenceFrame);
+    // Time-to-ack: the frame is now on the chosen provider's socket. This is
+    // the brokerage latency — received → handed off to a live worker (the
+    // preflight ping already proved it answers) — and explicitly NOT the
+    // worker's model-load/prefill/first-token time. Recorded only on a
+    // successful send so a dead-socket throw doesn't log a bogus 0.
+    ctx.onDispatched?.(Date.now() - receivedAt);
     // Account the dispatch for silent-failure detection. `recordDispatch`
     // returns true on the heartbeat-free edge where this dispatch is the one
     // that tips the provider over the threshold with still-zero completions

--- a/infra/advisor/src/latency-window.test.ts
+++ b/infra/advisor/src/latency-window.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
 
+import { LatencyWindow } from "./latency-window.ts";
 import { SessionManager } from "./sessions.ts";
-import { TtftWindow } from "./ttft.ts";
 
-describe("TtftWindow", () => {
+describe("LatencyWindow", () => {
   it("reports null stats when empty", () => {
-    const w = new TtftWindow(100);
+    const w = new LatencyWindow(100);
     expect(w.stats()).toEqual({
       sampleCount: 0,
       p50Ms: null,
@@ -16,7 +16,7 @@ describe("TtftWindow", () => {
   });
 
   it("computes p50/p95/avg/last over the window", () => {
-    const w = new TtftWindow(100);
+    const w = new LatencyWindow(100);
     for (const ms of [100, 200, 300, 400, 500]) w.record(ms);
     const s = w.stats();
     expect(s.sampleCount).toBe(5);
@@ -27,7 +27,7 @@ describe("TtftWindow", () => {
   });
 
   it("rolls off the oldest sample past capacity", () => {
-    const w = new TtftWindow(3);
+    const w = new LatencyWindow(3);
     w.record(1000);
     w.record(10);
     w.record(20);
@@ -40,7 +40,7 @@ describe("TtftWindow", () => {
   });
 
   it("drops non-finite / negative samples (clock skew must not poison the median)", () => {
-    const w = new TtftWindow(100);
+    const w = new LatencyWindow(100);
     w.record(50);
     w.record(-5);
     w.record(Number.NaN);

--- a/infra/advisor/src/latency-window.ts
+++ b/infra/advisor/src/latency-window.ts
@@ -1,32 +1,36 @@
-// Time-to-first-token (TTFT) tracker.
+// Rolling latency window.
 //
-// The advisor is the one place that sees both ends of the user-facing
-// latency: it receives a `/jobs` request and relays the provider's first
-// `inference_chunk` back to the requester. TTFT = (first chunk relayed) −
-// (job received). That's the "how fast does it START responding" number —
-// what people actually mean by latency — as opposed to a receipt's
-// `completedAt − startedAt`, which is total generation time and scales with
-// output length, not responsiveness.
+// A tiny in-memory ring of the last `capacity` millisecond samples, with
+// percentile/avg/last readouts. The advisor uses it for the two user-facing
+// latency headlines it can measure first-hand:
+//
+//   * time-to-ack  — (job received → `inference_request` frame handed to the
+//     chosen provider's socket). The brokerage number: how fast cocore picks a
+//     live worker and gets the job to it, including the preflight liveness
+//     round-trip. Excludes everything the worker then does.
+//   * TTFT         — (job received → first `inference_chunk` relayed back).
+//     The end-to-end "how fast does it START responding" number, which folds in
+//     the worker's model-load + prefill + first-token generation.
 //
 // In-memory, rolling: we keep the last `capacity` samples and report
 // percentiles over them. Lost on restart (the advisor's whole registry is),
-// which is fine — it's a "typical RECENT latency" headline, not an SLA
-// ledger, and it repopulates within a handful of jobs.
+// which is fine — these are "typical RECENT latency" headlines, not an SLA
+// ledger, and they repopulate within a handful of jobs.
 
-export interface TtftStats {
+export interface LatencyStats {
   /** Samples currently in the window (≤ capacity). */
   sampleCount: number;
-  /** Median TTFT in ms, or null when there are no samples. */
+  /** Median latency in ms, or null when there are no samples. */
   p50Ms: number | null;
-  /** 95th-percentile TTFT in ms, or null when there are no samples. */
+  /** 95th-percentile latency in ms, or null when there are no samples. */
   p95Ms: number | null;
-  /** Mean TTFT in ms, or null when there are no samples. */
+  /** Mean latency in ms, or null when there are no samples. */
   avgMs: number | null;
-  /** The most recent sample's TTFT in ms, or null. */
+  /** The most recent sample's latency in ms, or null. */
   lastMs: number | null;
 }
 
-export class TtftWindow {
+export class LatencyWindow {
   private readonly samples: number[] = [];
   private readonly capacity: number;
 
@@ -34,7 +38,7 @@ export class TtftWindow {
     this.capacity = Math.max(1, capacity);
   }
 
-  /** Record one TTFT sample (ms). Non-finite or negative values are
+  /** Record one latency sample (ms). Non-finite or negative values are
    *  dropped — a clock skew or a malformed timing shouldn't poison the
    *  median. Oldest sample falls off once the window is full. */
   record(ms: number): void {
@@ -43,7 +47,7 @@ export class TtftWindow {
     if (this.samples.length > this.capacity) this.samples.shift();
   }
 
-  stats(): TtftStats {
+  stats(): LatencyStats {
     const n = this.samples.length;
     if (n === 0) return { sampleCount: 0, p50Ms: null, p95Ms: null, avgMs: null, lastMs: null };
     const sorted = [...this.samples].sort((a, b) => a - b);

--- a/infra/advisor/src/main.ts
+++ b/infra/advisor/src/main.ts
@@ -31,10 +31,10 @@ import { loadApnsConfig } from "./apns.ts";
 import { handleConnection } from "./connection.ts";
 import { jobsRoute } from "./jobs.ts";
 import { KnownGoodSet } from "./known-good.ts";
-import { onlineProviders, ttftMs } from "./metrics.ts";
+import { LatencyWindow } from "./latency-window.ts";
+import { ackMs, onlineProviders, ttftMs } from "./metrics.ts";
 import { ProviderRegistry } from "./registry.ts";
 import { SessionManager } from "./sessions.ts";
-import { TtftWindow } from "./ttft.ts";
 
 const SERVICE = { serviceName: "cocore-advisor" };
 
@@ -187,8 +187,12 @@ async function main(): Promise<void> {
   // build set is configured). Confidential eligibility is computed per-machine.
   const registry = new ProviderRegistry(KnownGoodSet.fromEnv());
   // Rolling time-to-first-token window (received → first chunk relayed),
-  // surfaced at GET /ttft for the console's public latency stat.
-  const ttft = new TtftWindow(TTFT_WINDOW_SAMPLES);
+  // surfaced at GET /ttft. Folds in the worker's model-load/prefill/gen.
+  const ttft = new LatencyWindow(TTFT_WINDOW_SAMPLES);
+  // Rolling time-to-ack window (received → inference_request frame handed to
+  // the chosen worker's socket), surfaced at GET /ack for the console's public
+  // latency headline — the brokerage number, excluding worker-side time.
+  const ack = new LatencyWindow(TTFT_WINDOW_SAMPLES);
   const sessions = new SessionManager({
     idleTimeoutMs: SESSION_IDLE_TIMEOUT_MS,
     firstChunkTimeoutMs: SESSION_FIRST_CHUNK_TIMEOUT_MS,
@@ -241,9 +245,17 @@ async function main(): Promise<void> {
     HttpRouter.get(
       "/ttft",
       // Time-to-first-token over the last ~100 jobs (received → first chunk
-      // relayed). The honest "latency" headline — distinct from a receipt's
-      // completedAt − startedAt (total generation time).
+      // relayed). Distinct from a receipt's completedAt − startedAt (total
+      // generation time); folds in the worker's model-load/prefill/gen.
       Effect.sync(() => ok(ttft.stats())).pipe(Effect.withSpan("advisor.ttft")),
+    ),
+    HttpRouter.get(
+      "/ack",
+      // Time-to-ack over the last ~100 jobs (received → inference_request frame
+      // handed to the chosen worker's socket). The brokerage-latency headline:
+      // how fast cocore routes a job to a live worker, excluding worker-side
+      // model-load/prefill/generation (that's /ttft).
+      Effect.sync(() => ok(ack.stats())).pipe(Effect.withSpan("advisor.ack")),
     ),
     HttpRouter.get(
       "/providers",
@@ -341,6 +353,12 @@ async function main(): Promise<void> {
         generateId: () => randomUUID(),
         attestationMaxAgeMs: ATTESTATION_MAX_AGE_MS,
         preflightTimeoutMs: PREFLIGHT_TIMEOUT_MS,
+        onDispatched: (ms) => {
+          ack.record(ms);
+          // Mirror the ack sample into a histogram for OTLP export (the /ack
+          // route keeps serving the rolling in-memory window).
+          record(runtime, Metric.update(ackMs, ms));
+        },
       }),
     ),
   );

--- a/infra/advisor/src/metrics.ts
+++ b/infra/advisor/src/metrics.ts
@@ -25,10 +25,21 @@ export function dispatchOutcome(outcome: "ok" | "no-capacity" | "rejected") {
 }
 
 /** Time-to-first-token in ms (job received → first chunk relayed). Boundaries
- *  cover sub-ms to ~1min, matching the rolling TtftWindow the /ttft route
+ *  cover sub-ms to ~1min, matching the rolling LatencyWindow the /ttft route
  *  serves. */
 export const ttftMs = Metric.histogram(
   "cocore.advisor.ttft_ms",
   MetricBoundaries.exponential({ start: 1, factor: 2, count: 16 }),
   "time-to-first-token in milliseconds",
+);
+
+/** Time-to-ack in ms (job received → `inference_request` frame handed to the
+ *  chosen provider's socket). The brokerage latency — picking a live worker and
+ *  getting the job to it, incl. the preflight liveness round-trip, excluding the
+ *  worker's own model-load/prefill/generation. Same boundaries as ttftMs;
+ *  matches the rolling LatencyWindow the /ack route serves. */
+export const ackMs = Metric.histogram(
+  "cocore.advisor.ack_ms",
+  MetricBoundaries.exponential({ start: 1, factor: 2, count: 16 }),
+  "time-to-ack in milliseconds",
 );

--- a/packages/console/src/lib/marketing-snapshot.server.ts
+++ b/packages/console/src/lib/marketing-snapshot.server.ts
@@ -44,12 +44,14 @@ export type MarketingSnapshot = {
     /** Bare integer from `tokenRate.inputPricePerMTok` (assumed equal to
      *  the output rate today; we render one number). */
     tokenRatePerMtok: number;
-    /** Network median (p50) TIME-TO-FIRST-TOKEN over the last ≤100 jobs,
-     *  in ms — measured at the advisor as (request received → first chunk
-     *  relayed to the requester). This is responsiveness, NOT a receipt's
-     *  completedAt − startedAt (total generation time, which scales with
-     *  output length). null when the advisor has no recent samples. */
-    firstTokenP50Ms: number | null;
+    /** Network median (p50) TIME-TO-ACK over the last ≤100 jobs, in ms —
+     *  measured at the advisor as (request received → `inference_request`
+     *  frame handed to the chosen worker's socket). This is the BROKERAGE
+     *  latency: how fast cocore routes a job to a live worker (incl. the
+     *  preflight liveness round-trip), deliberately excluding worker-side
+     *  model-load/prefill/first-token time (that's our /ttft signal, not
+     *  the public headline). null when the advisor has no recent samples. */
+    ackP50Ms: number | null;
   };
   /** A live, sampled glimpse of the network for the landing page:
    *  some real members, some real machines, and a few real receipts.
@@ -112,7 +114,7 @@ const FALLBACK = {
     totalCpuCores: 0,
     tokenGrant: 1_000_000,
     tokenRatePerMtok: 1_000_000,
-    firstTokenP50Ms: null,
+    ackP50Ms: null,
   },
   live: {
     people: [] as MarketingSnapshot["live"]["people"],
@@ -333,16 +335,18 @@ function sumProviderHardware(rows: AppviewIndexedRecord[]): {
   return { totalRamGB, totalCpuCores };
 }
 
-/** Fetch the advisor's rolling time-to-first-token p50 (ms) for the public
- *  latency headline — (request received → first chunk relayed), the honest
- *  "latency" number. Best-effort: a slow/unreachable advisor must not stall
- *  or fail the marketing page, so we time out fast and return null (the
- *  stat then renders its fallback). `advisorUrl` is the HTTP base (same one
- *  dispatch hits for `/providers` and `/jobs`). */
-async function fetchAdvisorTtftP50Ms(): Promise<number | null> {
+/** Fetch the advisor's rolling time-to-ack p50 (ms) for the public latency
+ *  headline — (request received → `inference_request` frame handed to the
+ *  chosen worker's socket), the brokerage number: how fast we route a job to
+ *  a live worker, excluding the worker's own model-load/prefill/generation.
+ *  Best-effort: a slow/unreachable advisor must not stall or fail the
+ *  marketing page, so we time out fast and return null (the stat then renders
+ *  its fallback). `advisorUrl` is the HTTP base (same one dispatch hits for
+ *  `/providers` and `/jobs`). */
+async function fetchAdvisorAckP50Ms(): Promise<number | null> {
   try {
     const base = cocoreConfig().advisorUrl.replace(/\/$/, "");
-    const r = await fetch(`${base}/ttft`, {
+    const r = await fetch(`${base}/ack`, {
       headers: { accept: "application/json" },
       signal: AbortSignal.timeout(2_000),
     });
@@ -357,7 +361,7 @@ async function fetchAdvisorTtftP50Ms(): Promise<number | null> {
 async function buildMarketingSnapshot(): Promise<MarketingSnapshot> {
   const generatedAt = new Date().toISOString();
 
-  const [[receiptsR, providersR, activityR, accountsR, profilesR], firstTokenP50Ms, policy] =
+  const [[receiptsR, providersR, activityR, accountsR, profilesR], ackP50Ms, policy] =
     await Promise.all([
       // One root span, five concurrent child `appview.request` spans —
       // each appview effect carries its own span (see appview.server.ts).
@@ -374,7 +378,7 @@ async function buildMarketingSnapshot(): Promise<MarketingSnapshot> {
           { concurrency: "unbounded" },
         ),
       ),
-      fetchAdvisorTtftP50Ms(),
+      fetchAdvisorAckP50Ms(),
       fetchPolicySnapshot(),
     ]);
 
@@ -395,7 +399,7 @@ async function buildMarketingSnapshot(): Promise<MarketingSnapshot> {
     totalCpuCores,
     tokenGrant: policy?.tokenGrant ?? FALLBACK.stats.tokenGrant,
     tokenRatePerMtok: policy?.tokenRatePerMtok ?? FALLBACK.stats.tokenRatePerMtok,
-    firstTokenP50Ms,
+    ackP50Ms,
   };
 
   // ── Live glimpse: real members, machines, receipts. ──────────

--- a/packages/console/src/routes/_header-layout.index.tsx
+++ b/packages/console/src/routes/_header-layout.index.tsx
@@ -1489,16 +1489,16 @@ function MarketingPage() {
           </div>
         </div>
         <div {...stylex.props(styles.statItem)}>
-          <div {...stylex.props(styles.statLabel)}>time to first token</div>
+          <div {...stylex.props(styles.statLabel)}>time to ack</div>
           <div {...stylex.props(styles.statValue)}>
-            {marketing.stats.firstTokenP50Ms !== null ? (
+            {marketing.stats.ackP50Ms !== null ? (
               <>
-                {formatLatencyMs(marketing.stats.firstTokenP50Ms)}
+                {formatLatencyMs(marketing.stats.ackP50Ms)}
                 <span {...stylex.props(styles.statUnit)}>p50</span>
               </>
             ) : (
               <>
-                1<span {...stylex.props(styles.statUnit)}>token in/out</span>
+                —<span {...stylex.props(styles.statUnit)}>p50</span>
               </>
             )}
           </div>


### PR DESCRIPTION
## Why

The public latency headline ("time to first token") measured TTFT at the advisor: `/jobs` request received → first `inference_chunk` relayed. That folds in the worker's **model-load, prefill, and first-token generation** — which is why the landing page often showed **4–5s**.

Per Honeycomb (graze prod, 7d), the broker's own work (`advisor.dispatch` span) is **P50 178ms / P95 386ms / P99 478ms**. The multi-second number is entirely worker-side — outside our responsibility zone. Our job is to run a fast brokerage, so the headline should report how fast we get a job to a live worker.

## What

Switch the headline to **time-to-ack**: request received → `inference_request` frame handed to the chosen worker's socket (including the preflight liveness round-trip), excluding all worker-side time.

### Advisor (`infra/advisor/`)
- New **`GET /ack`** — rolling p50/p95/avg/last over the last ~100 jobs (span `advisor.ack`) + `cocore.advisor.ack_ms` OTLP histogram.
- `dispatch()` fires `onDispatched(now − receivedAt)` right after a successful `provider.send` (success-only, so a dead-socket throw can't log a bogus 0).
- Generalized the rolling-window module: `ttft.ts` → `latency-window.ts` (`TtftWindow` → `LatencyWindow`), now backing both windows.
- **TTFT retained** — `/ttft` + `cocore.advisor.ttft_ms` stay as the worker-side diagnostic signal; only the *public headline* moved off it.

### Console (`packages/console/`)
- Marketing snapshot fetches `/ack` (`fetchAdvisorAckP50Ms`); stat field `firstTokenP50Ms` → `ackP50Ms`.
- Landing headline label **"time to first token" → "time to ack"**; null fallback now `—` (was "1 token in/out").

## Tests
- New `jobs.test` asserting the ack fires on handoff **before** any chunk is relayed (proves it measures handoff, not TTFT).
- Advisor 20/20 green; advisor + console typecheck clean; lint 0/0; formatted.

## Rollout notes
- Needs an **advisor + console redeploy**.
- The `/ack` window is in-memory: reads `sampleCount: 0` (page shows `—`) right after each advisor redeploy, repopulates within a handful of jobs.
- Once warm, expect the headline to read **~180ms p50** instead of 4–5s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)