### PR TITLE
feat(advisor): persist rolling latency windows to disk across restarts

### DIFF
--- a/docs/deploy-railway.md
+++ b/docs/deploy-railway.md
@@ -137,8 +137,22 @@ railway variables --service advisor \
 
 The advisor reuses [infra/Dockerfile.node](../infra/Dockerfile.node) —
 the `WORKSPACE` env var is picked up as a Docker build ARG and
-selects the workspace to run. No volume needed (state is in-memory;
-providers reconnect after restart).
+selects the workspace to run. Registry/session state stays in-memory
+(providers reconnect after restart) — but the rolling **latency
+windows** (`/ack`, `/ttft`) are otherwise lost on restart too, which
+leaves the public "time to ack" headline blank ("—") until jobs flow
+again.
+
+To keep that headline populated across redeploys, attach a Railway
+volume to the advisor (same GraphQL pattern as the `services` volume
+above, with the advisor's `serviceId`). The advisor auto-detects it
+via `$RAILWAY_VOLUME_MOUNT_PATH` and persists the windows under an
+`advisor/` subdir — on the next boot it hydrates them and serves the
+last known figures (flagged `cached`) until live traffic refills the
+window. Override the location with `COCORE_ADVISOR_DATA_DIR=/some/path`
+and the flush cadence with `COCORE_ADVISOR_LATENCY_PERSIST_INTERVAL_MS`
+(default 30000). Without a volume the advisor runs exactly as before
+(in-memory, blank headline after a restart).
 
 ## Deploy
 
@@ -290,6 +304,10 @@ route it through the public edge (slower + subject to edge connection churn).
   - rate-limiting / per-requester quotas
   - retry / failover when a chosen provider drops mid-stream
 - **Advisor in-memory** — like the console's pair store, advisor
-  state is in-memory. Providers automatically reconnect on advisor
-  restart; the only side effect is a brief gap where
-  `/providers` shows zero connected DIDs.
+  registry/session state is in-memory. Providers automatically
+  reconnect on advisor restart; the only side effect is a brief gap
+  where `/providers` shows zero connected DIDs. The one exception is
+  the rolling latency windows (`/ack`, `/ttft`): when a volume is
+  attached they're persisted to disk and hydrated on boot so the
+  public latency headline doesn't blank out across a redeploy (see
+  "Configure the advisor service" above).

--- a/infra/advisor/src/latency-store.test.ts
+++ b/infra/advisor/src/latency-store.test.ts
@@ -48,6 +48,21 @@ describe("latency-store", () => {
     expect(w.stats().sampleCount).toBe(0);
   });
 
+  it("returns the net resident count, not the offered count (negatives + capacity)", async () => {
+    const path = join(dir, "overcount.json");
+    // A negative (dropped by the window) plus more valid samples than capacity.
+    await writeFile(
+      path,
+      JSON.stringify({ samples: [-5, 10, 20, 30, 40], updatedAt: "z" }),
+      "utf8",
+    );
+    const w = new LatencyWindow(3);
+    // -5 dropped; only the last 3 of [10,20,30,40] fit → resident count is 3,
+    // not the 5 offered nor the 4 finite — the log must not overcount.
+    expect(await hydrateLatencyWindow(w, path)).toBe(3);
+    expect(w.snapshot()).toEqual([20, 30, 40]);
+  });
+
   it("filters non-numeric samples on read", async () => {
     const path = join(dir, "dirty.json");
     await writeFile(

--- a/infra/advisor/src/latency-store.test.ts
+++ b/infra/advisor/src/latency-store.test.ts
@@ -1,0 +1,75 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { hydrateLatencyWindow, persistLatencyWindow } from "./latency-store.ts";
+import { LatencyWindow } from "./latency-window.ts";
+
+describe("latency-store", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "cocore-latency-"));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("persists then re-hydrates a window across a simulated restart", async () => {
+    const path = join(dir, "nested", "ack-latency.json");
+    const a = new LatencyWindow(100);
+    for (const ms of [100, 200, 300, 400]) a.record(ms);
+
+    // mkdir -p the missing parent and write atomically.
+    expect(await persistLatencyWindow(a, path, "2026-06-27T00:00:00.000Z")).toBe(true);
+
+    const b = new LatencyWindow(100);
+    const n = await hydrateLatencyWindow(b, path);
+    expect(n).toBe(4);
+    expect(b.snapshot()).toEqual([100, 200, 300, 400]);
+    // Restored from disk → served as cached until live traffic arrives.
+    expect(b.stats().cached).toBe(true);
+    expect(b.stats().p50Ms).toBe(a.stats().p50Ms);
+  });
+
+  it("returns 0 (no throw) when the snapshot file is absent", async () => {
+    const w = new LatencyWindow(100);
+    expect(await hydrateLatencyWindow(w, join(dir, "missing.json"))).toBe(0);
+    expect(w.stats().sampleCount).toBe(0);
+  });
+
+  it("ignores a corrupt snapshot rather than crashing", async () => {
+    const path = join(dir, "corrupt.json");
+    await writeFile(path, "{ not json", "utf8");
+    const w = new LatencyWindow(100);
+    expect(await hydrateLatencyWindow(w, path)).toBe(0);
+    expect(w.stats().sampleCount).toBe(0);
+  });
+
+  it("filters non-numeric samples on read", async () => {
+    const path = join(dir, "dirty.json");
+    await writeFile(
+      path,
+      JSON.stringify({ samples: [100, "x", null, 200, Number.NaN], updatedAt: "z" }),
+      "utf8",
+    );
+    const w = new LatencyWindow(100);
+    expect(await hydrateLatencyWindow(w, path)).toBe(2);
+    expect(w.snapshot()).toEqual([100, 200]);
+  });
+
+  it("writes the documented on-disk shape", async () => {
+    const path = join(dir, "shape.json");
+    const w = new LatencyWindow(100);
+    w.record(42);
+    await persistLatencyWindow(w, path, "2026-06-27T12:00:00.000Z");
+    const body = JSON.parse(await readFile(path, "utf8")) as {
+      samples: number[];
+      updatedAt: string;
+    };
+    expect(body.samples).toEqual([42]);
+    expect(body.updatedAt).toBe("2026-06-27T12:00:00.000Z");
+  });
+});

--- a/infra/advisor/src/latency-store.ts
+++ b/infra/advisor/src/latency-store.ts
@@ -27,8 +27,12 @@ interface PersistedLatency {
 }
 
 /** Seed `window` from the snapshot at `path`. Returns the number of samples
- *  hydrated (0 when the file is absent, empty, or unreadable). Never throws —
- *  a cold/corrupt cache simply yields an empty window. */
+ *  actually resident afterwards (0 when the file is absent, empty, or
+ *  unreadable). Never throws — a cold/corrupt cache simply yields an empty
+ *  window. Logs the count and the snapshot's age so an operator can spot a
+ *  headline being seeded from a long-dormant volume; we intentionally serve
+ *  even an old snapshot (that's the point — don't blank the headline on
+ *  restart), and the `cached` flag on `stats()` marks it to API consumers. */
 export async function hydrateLatencyWindow(window: LatencyWindow, path: string): Promise<number> {
   let raw: string;
   try {
@@ -39,16 +43,48 @@ export async function hydrateLatencyWindow(window: LatencyWindow, path: string):
   }
   try {
     const parsed = JSON.parse(raw) as Partial<PersistedLatency>;
+    // Match `hydrate()`'s own validation exactly (finite AND non-negative) so
+    // the resident count below can't be thrown off by samples it would drop.
     const samples = Array.isArray(parsed?.samples)
-      ? parsed.samples.filter((s): s is number => typeof s === "number" && Number.isFinite(s))
+      ? parsed.samples.filter(
+          (s): s is number => typeof s === "number" && Number.isFinite(s) && s >= 0,
+        )
       : [];
     if (samples.length === 0) return 0;
+    // Net samples resident after validation + capacity bounding — never an
+    // overcount even if the snapshot exceeds the window's capacity.
+    const before = window.snapshot().length;
     window.hydrate(samples);
-    return samples.length;
+    const hydrated = window.snapshot().length - before;
+    if (hydrated > 0) {
+      const age = snapshotAge(parsed.updatedAt);
+      console.error(
+        `[latency-store] hydrated ${hydrated} sample(s) from ${path}${age ? ` (snapshot ${age})` : ""}`,
+      );
+    }
+    return hydrated;
   } catch {
     // Corrupt JSON — ignore and start cold rather than crash.
     return 0;
   }
+}
+
+/** Human-readable age of a persisted snapshot from its RFC3339 `updatedAt`,
+ *  or null when missing/unparseable/future-dated. Coarse on purpose — it's a
+ *  log breadcrumb for spotting stale hydrations, not a precise duration. */
+function snapshotAge(updatedAt: unknown): string | null {
+  if (typeof updatedAt !== "string") return null;
+  const t = Date.parse(updatedAt);
+  if (!Number.isFinite(t)) return null;
+  const ms = Date.now() - t;
+  if (ms < 0) return null;
+  const s = Math.round(ms / 1000);
+  if (s < 90) return `age ${s}s`;
+  const m = Math.round(s / 60);
+  if (m < 90) return `age ${m}m`;
+  const h = Math.round(m / 60);
+  if (h < 48) return `age ${h}h`;
+  return `age ${Math.round(h / 24)}d`;
 }
 
 /** Atomically write `window`'s current samples to `path`. Creates the parent

--- a/infra/advisor/src/latency-store.ts
+++ b/infra/advisor/src/latency-store.ts
@@ -1,0 +1,73 @@
+// Disk-backed persistence for the advisor's rolling latency windows.
+//
+// The ack/ttft LatencyWindows live in memory and are otherwise lost on
+// restart, which leaves the public latency headline blank ("—") until jobs
+// flow again. In production the advisor mounts a volume; this module writes
+// the last samples there and reloads them on the next boot so the headline
+// shows the last known figures instead of nothing — flagged `cached` until
+// live traffic refills the window.
+//
+// Best-effort by design: a missing/unreadable/corrupt file just leaves the
+// window empty (the readout falls back to its usual "no samples" state), and
+// a failed write is logged but never crashes the advisor. Writes are atomic
+// (temp file + rename) so a crash mid-write can't leave a truncated cache.
+
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+import type { LatencyWindow } from "./latency-window.ts";
+
+/** On-disk shape. Additive: unknown fields are ignored on read, so the
+ *  format can grow without breaking older/newer advisors sharing a volume. */
+interface PersistedLatency {
+  /** Latency samples in ms, oldest-first. */
+  samples: number[];
+  /** When this snapshot was written (RFC3339, UTC). Informational. */
+  updatedAt: string;
+}
+
+/** Seed `window` from the snapshot at `path`. Returns the number of samples
+ *  hydrated (0 when the file is absent, empty, or unreadable). Never throws —
+ *  a cold/corrupt cache simply yields an empty window. */
+export async function hydrateLatencyWindow(window: LatencyWindow, path: string): Promise<number> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch {
+    // No snapshot yet (first boot / fresh volume) — nothing to hydrate.
+    return 0;
+  }
+  try {
+    const parsed = JSON.parse(raw) as Partial<PersistedLatency>;
+    const samples = Array.isArray(parsed?.samples)
+      ? parsed.samples.filter((s): s is number => typeof s === "number" && Number.isFinite(s))
+      : [];
+    if (samples.length === 0) return 0;
+    window.hydrate(samples);
+    return samples.length;
+  } catch {
+    // Corrupt JSON — ignore and start cold rather than crash.
+    return 0;
+  }
+}
+
+/** Atomically write `window`'s current samples to `path`. Creates the parent
+ *  directory if needed. Resolves false (without throwing) on any I/O error so
+ *  a periodic flush can't take the advisor down. */
+export async function persistLatencyWindow(
+  window: LatencyWindow,
+  path: string,
+  nowIso: string,
+): Promise<boolean> {
+  const body: PersistedLatency = { samples: window.snapshot(), updatedAt: nowIso };
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    const tmp = `${path}.tmp`;
+    await writeFile(tmp, JSON.stringify(body), "utf8");
+    await rename(tmp, path);
+    return true;
+  } catch (e) {
+    console.error(`[latency-store] failed to persist ${path}:`, e);
+    return false;
+  }
+}

--- a/infra/advisor/src/latency-window.test.ts
+++ b/infra/advisor/src/latency-window.test.ts
@@ -12,6 +12,7 @@ describe("LatencyWindow", () => {
       p95Ms: null,
       avgMs: null,
       lastMs: null,
+      cached: false,
     });
   });
 
@@ -49,6 +50,40 @@ describe("LatencyWindow", () => {
     const s = w.stats();
     expect(s.sampleCount).toBe(2);
     expect(s.avgMs).toBe(100);
+  });
+
+  it("flags hydrated samples as cached until a live sample lands", () => {
+    const w = new LatencyWindow(100);
+    w.hydrate([100, 200, 300]);
+    // Served straight from the disk snapshot: real percentiles, marked cached.
+    const before = w.stats();
+    expect(before.sampleCount).toBe(3);
+    expect(before.p50Ms).toBe(200);
+    expect(before.cached).toBe(true);
+    // One fresh sample flips it to live (even while old samples remain).
+    w.record(400);
+    const after = w.stats();
+    expect(after.sampleCount).toBe(4);
+    expect(after.cached).toBe(false);
+  });
+
+  it("hydrate honors capacity and validation, and snapshot round-trips", () => {
+    const w = new LatencyWindow(3);
+    // Five offered, only the last 3 kept; the negative is dropped first.
+    w.hydrate([-1, 10, 20, 30, 40]);
+    expect(w.snapshot()).toEqual([20, 30, 40]);
+    expect(w.stats().sampleCount).toBe(3);
+  });
+
+  it("snapshot reflects live records and can re-seed a fresh window", () => {
+    const a = new LatencyWindow(100);
+    for (const ms of [100, 200, 300]) a.record(ms);
+    const snap = a.snapshot();
+    const b = new LatencyWindow(100);
+    b.hydrate(snap);
+    // Same numbers survive the round-trip, but the re-seeded window is cached.
+    expect(b.stats().p50Ms).toBe(a.stats().p50Ms);
+    expect(b.stats().cached).toBe(true);
   });
 });
 

--- a/infra/advisor/src/latency-window.ts
+++ b/infra/advisor/src/latency-window.ts
@@ -13,9 +13,14 @@
 //     the worker's model-load + prefill + first-token generation.
 //
 // In-memory, rolling: we keep the last `capacity` samples and report
-// percentiles over them. Lost on restart (the advisor's whole registry is),
-// which is fine — these are "typical RECENT latency" headlines, not an SLA
-// ledger, and they repopulate within a handful of jobs.
+// percentiles over them. The window can be HYDRATED from a disk snapshot at
+// startup (see latency-store.ts) so the headline isn't blank after a restart
+// — the advisor's registry repopulates within seconds, but the latency
+// numbers only refill once jobs flow, and a mounted volume lets us serve the
+// last known figures in the meantime. Until a live sample arrives, hydrated
+// readouts are flagged `cached` so callers can tell stale-from-disk apart
+// from fresh traffic. These remain "typical RECENT latency" headlines, not an
+// SLA ledger.
 
 export interface LatencyStats {
   /** Samples currently in the window (≤ capacity). */
@@ -28,11 +33,20 @@ export interface LatencyStats {
   avgMs: number | null;
   /** The most recent sample's latency in ms, or null. */
   lastMs: number | null;
+  /** True when every sample in the window came from a persisted snapshot and
+   *  no live sample has landed since this process started — i.e. the readout
+   *  is being served from the disk cache after a restart. False when there
+   *  are no samples, or once any fresh sample is recorded. */
+  cached: boolean;
 }
 
 export class LatencyWindow {
   private readonly samples: number[] = [];
   private readonly capacity: number;
+  /** Has a live `record()` landed since construction? Starts false and flips
+   *  true on the first real sample, so a window hydrated from disk reports
+   *  `cached: true` only until fresh traffic arrives. */
+  private hasFreshSample = false;
 
   constructor(capacity = 100) {
     this.capacity = Math.max(1, capacity);
@@ -43,13 +57,33 @@ export class LatencyWindow {
    *  median. Oldest sample falls off once the window is full. */
   record(ms: number): void {
     if (!Number.isFinite(ms) || ms < 0) return;
+    this.hasFreshSample = true;
     this.samples.push(ms);
     if (this.samples.length > this.capacity) this.samples.shift();
   }
 
+  /** Seed the window from a persisted snapshot at startup. Same validation
+   *  and capacity bound as `record()`, but these samples do NOT count as
+   *  fresh — the readout stays `cached` until a live `record()` arrives.
+   *  Intended to be called once, before any live traffic. */
+  hydrate(samples: readonly number[]): void {
+    for (const ms of samples) {
+      if (!Number.isFinite(ms) || ms < 0) continue;
+      this.samples.push(ms);
+      if (this.samples.length > this.capacity) this.samples.shift();
+    }
+  }
+
+  /** A copy of the current samples, oldest-first — for persisting to disk. */
+  snapshot(): number[] {
+    return [...this.samples];
+  }
+
   stats(): LatencyStats {
     const n = this.samples.length;
-    if (n === 0) return { sampleCount: 0, p50Ms: null, p95Ms: null, avgMs: null, lastMs: null };
+    if (n === 0) {
+      return { sampleCount: 0, p50Ms: null, p95Ms: null, avgMs: null, lastMs: null, cached: false };
+    }
     const sorted = [...this.samples].sort((a, b) => a - b);
     const pct = (p: number): number => {
       // Nearest-rank percentile over the sorted window.
@@ -63,6 +97,7 @@ export class LatencyWindow {
       p95Ms: pct(95),
       avgMs: Math.round(sum / n),
       lastMs: this.samples[n - 1]!,
+      cached: !this.hasFreshSample,
     };
   }
 }

--- a/infra/advisor/src/main.ts
+++ b/infra/advisor/src/main.ts
@@ -19,9 +19,10 @@
 
 import { randomUUID } from "node:crypto";
 import { createServer } from "node:http";
+import { join } from "node:path";
 
 import { HttpRouter } from "@effect/platform";
-import { Config, Effect, Metric } from "effect";
+import { Config, Effect, Metric, Option } from "effect";
 import { WebSocketServer } from "ws";
 
 import { makeRuntime, record } from "@cocore/o11y";
@@ -31,6 +32,7 @@ import { loadApnsConfig } from "./apns.ts";
 import { handleConnection } from "./connection.ts";
 import { jobsRoute } from "./jobs.ts";
 import { KnownGoodSet } from "./known-good.ts";
+import { hydrateLatencyWindow, persistLatencyWindow } from "./latency-store.ts";
 import { LatencyWindow } from "./latency-window.ts";
 import { ackMs, onlineProviders, ttftMs } from "./metrics.ts";
 import { ProviderRegistry } from "./registry.ts";
@@ -88,6 +90,14 @@ const CONFIG = Effect.runSync(
       Config.withDefault(1500),
     ),
     ttftWindowSamples: Config.integer("COCORE_ADVISOR_TTFT_SAMPLES").pipe(Config.withDefault(100)),
+    // Disk-backed latency cache. `COCORE_ADVISOR_DATA_DIR` wins; otherwise we
+    // derive a subdir under the mounted Railway volume so prod persists by
+    // default. Neither set (dev/CI) → no persistence, windows stay in-memory.
+    dataDir: Config.string("COCORE_ADVISOR_DATA_DIR").pipe(Config.option),
+    railwayVolumeMountPath: Config.string("RAILWAY_VOLUME_MOUNT_PATH").pipe(Config.option),
+    latencyPersistIntervalMs: Config.integer("COCORE_ADVISOR_LATENCY_PERSIST_INTERVAL_MS").pipe(
+      Config.withDefault(30_000),
+    ),
   }),
 );
 
@@ -162,6 +172,19 @@ const REPROBE_TIMEOUT_MS = CONFIG.reprobeTimeoutMs;
 /** How many recent jobs the time-to-first-token window keeps. Matches the
  *  "last 100 jobs" the console headline advertises. */
 const TTFT_WINDOW_SAMPLES = CONFIG.ttftWindowSamples;
+/** Directory the rolling latency windows are persisted to so the public
+ *  latency headline survives a restart. Explicit `COCORE_ADVISOR_DATA_DIR`
+ *  wins; otherwise an `advisor/` subdir of the mounted Railway volume; else
+ *  undefined → persistence off (dev/CI keep the windows purely in-memory). */
+const RAILWAY_VOLUME_MOUNT_PATH = Option.getOrUndefined(CONFIG.railwayVolumeMountPath);
+const DATA_DIR =
+  Option.getOrUndefined(CONFIG.dataDir) ??
+  (RAILWAY_VOLUME_MOUNT_PATH
+    ? join(RAILWAY_VOLUME_MOUNT_PATH.replace(/\/$/, ""), "advisor")
+    : undefined);
+/** How often to flush the latency windows to disk. A hard crash loses at most
+ *  this much tail — acceptable for a "typical recent latency" headline. */
+const LATENCY_PERSIST_INTERVAL_MS = CONFIG.latencyPersistIntervalMs;
 
 async function main(): Promise<void> {
   // One o11y runtime drives the WebSocket side + the periodic gauge/TTFT
@@ -193,6 +216,24 @@ async function main(): Promise<void> {
   // the chosen worker's socket), surfaced at GET /ack for the console's public
   // latency headline — the brokerage number, excluding worker-side time.
   const ack = new LatencyWindow(TTFT_WINDOW_SAMPLES);
+
+  // Disk-backed latency cache. When a data dir is configured (prod mounts a
+  // volume), seed both windows from the last persisted snapshot so /ack and
+  // /ttft serve the last known figures right after a restart instead of the
+  // blank "—" headline they'd otherwise show until jobs flow again. Hydrated
+  // samples report `cached: true` until live traffic refills the window.
+  const ackLatencyPath = DATA_DIR ? join(DATA_DIR, "ack-latency.json") : null;
+  const ttftLatencyPath = DATA_DIR ? join(DATA_DIR, "ttft-latency.json") : null;
+  if (ackLatencyPath) {
+    const n = await hydrateLatencyWindow(ack, ackLatencyPath);
+    if (n > 0)
+      console.error(`[advisor] hydrated ${n} ack-latency sample(s) from ${ackLatencyPath}`);
+  }
+  if (ttftLatencyPath) {
+    const n = await hydrateLatencyWindow(ttft, ttftLatencyPath);
+    if (n > 0)
+      console.error(`[advisor] hydrated ${n} ttft-latency sample(s) from ${ttftLatencyPath}`);
+  }
   const sessions = new SessionManager({
     idleTimeoutMs: SESSION_IDLE_TIMEOUT_MS,
     firstChunkTimeoutMs: SESSION_FIRST_CHUNK_TIMEOUT_MS,
@@ -444,6 +485,32 @@ async function main(): Promise<void> {
     }
   }, REPROBE_INTERVAL_MS);
   reprober.unref();
+
+  // --- Latency cache: flush the rolling windows to disk --------
+  // Periodic + on graceful shutdown, so the public latency headline survives
+  // a redeploy. Only active when a data dir is configured (prod volume).
+  if (DATA_DIR) {
+    const flushLatency = async (): Promise<void> => {
+      const now = new Date().toISOString();
+      await Promise.allSettled([
+        ackLatencyPath ? persistLatencyWindow(ack, ackLatencyPath, now) : Promise.resolve(),
+        ttftLatencyPath ? persistLatencyWindow(ttft, ttftLatencyPath, now) : Promise.resolve(),
+      ]);
+    };
+    const latencyFlusher = setInterval(() => void flushLatency(), LATENCY_PERSIST_INTERVAL_MS);
+    latencyFlusher.unref();
+    // Railway sends SIGTERM on redeploy; flush the freshest samples first.
+    for (const sig of ["SIGTERM", "SIGINT"] as const) {
+      process.once(sig, () => {
+        void flushLatency().finally(() => process.exit(0));
+      });
+    }
+    console.error(
+      `[advisor] latency cache ON dir=${DATA_DIR} flush-interval=${LATENCY_PERSIST_INTERVAL_MS}ms`,
+    );
+  } else {
+    console.error("[advisor] latency cache OFF (no COCORE_ADVISOR_DATA_DIR / volume) — in-memory");
+  }
 
   await new Promise<void>((r) => http.listen(PORT, r));
   console.error(

--- a/infra/advisor/src/main.ts
+++ b/infra/advisor/src/main.ts
@@ -222,18 +222,12 @@ async function main(): Promise<void> {
   // /ttft serve the last known figures right after a restart instead of the
   // blank "—" headline they'd otherwise show until jobs flow again. Hydrated
   // samples report `cached: true` until live traffic refills the window.
+  // The file names identify which window, and hydrateLatencyWindow logs the
+  // resident count + snapshot age itself, so no extra logging is needed here.
   const ackLatencyPath = DATA_DIR ? join(DATA_DIR, "ack-latency.json") : null;
   const ttftLatencyPath = DATA_DIR ? join(DATA_DIR, "ttft-latency.json") : null;
-  if (ackLatencyPath) {
-    const n = await hydrateLatencyWindow(ack, ackLatencyPath);
-    if (n > 0)
-      console.error(`[advisor] hydrated ${n} ack-latency sample(s) from ${ackLatencyPath}`);
-  }
-  if (ttftLatencyPath) {
-    const n = await hydrateLatencyWindow(ttft, ttftLatencyPath);
-    if (n > 0)
-      console.error(`[advisor] hydrated ${n} ttft-latency sample(s) from ${ttftLatencyPath}`);
-  }
+  if (ackLatencyPath) await hydrateLatencyWindow(ack, ackLatencyPath);
+  if (ttftLatencyPath) await hydrateLatencyWindow(ttft, ttftLatencyPath);
   const sessions = new SessionManager({
     idleTimeoutMs: SESSION_IDLE_TIMEOUT_MS,
     firstChunkTimeoutMs: SESSION_FIRST_CHUNK_TIMEOUT_MS,


### PR DESCRIPTION
## Problem

On reboot, the marketing page's network stats (machines online, models, combined memory, cores) eventually repopulate from the AppView/provider records — but the **"time to ack" latency headline stays blank (`—`) until requests flow through again**.

Root cause: the advisor's rolling `LatencyWindow`s backing `GET /ack` and `GET /ttft` are purely in-memory. On restart they're empty, so `/ack` returns `p50Ms: null` and `marketing-snapshot.server.ts` renders the em-dash fallback until live jobs refill the window. The network's other stats come from indexed records and so recover on their own; latency is the one signal with no durable backing.

## Fix

Add an optional **disk-backed cache** for the latency windows, using the volume already mounted in production:

- When a data dir is configured, the advisor flushes both windows to disk periodically and on graceful shutdown (`SIGTERM`/`SIGINT`), and **hydrates them on boot** so `/ack` and `/ttft` serve the last known figures immediately after a restart.
- Hydrated readouts carry a new `cached: true` flag until a live sample lands, so consumers can distinguish disk-cached from fresh traffic.
- Data dir resolution mirrors the `services` token-ledger pattern: explicit `COCORE_ADVISOR_DATA_DIR` wins, else an `advisor/` subdir under `RAILWAY_VOLUME_MOUNT_PATH`, else **persistence is off** (dev/CI keep the in-memory behavior unchanged).

Writes are atomic (temp file + rename) and best-effort: a missing/corrupt snapshot just starts cold, and a failed write logs but never crashes the advisor.

## Changes

- `latency-window.ts` — `hydrate()` / `snapshot()` and a `cached` flag in `stats()`; hydrated samples don't count as "fresh".
- `latency-store.ts` (new) — atomic, best-effort load/persist helpers with a documented on-disk shape.
- `main.ts` — derive the data dir, hydrate `ack`/`ttft` on startup, periodic flush timer (`COCORE_ADVISOR_LATENCY_PERSIST_INTERVAL_MS`, default 30s) + flush on shutdown.
- `docs/deploy-railway.md` — document the optional advisor volume and the new env vars.

## Tests

- `latency-window.test.ts` — `cached` semantics, hydrate capacity/validation, snapshot round-trip; updated the empty-stats assertion for the new field.
- `latency-store.test.ts` (new) — persist→hydrate round-trip across a simulated restart, absent/corrupt file handling, non-numeric filtering, on-disk shape.

All 99 advisor tests pass; `tsc`, `oxlint`, and `oxfmt` are clean.

## Notes

- No lexicon, provider, or consumer changes required — the console already reads `p50Ms` by name and ignores the additive `cached` field.
- To enable in production, attach a Railway volume to the advisor service; the path is auto-detected via `$RAILWAY_VOLUME_MOUNT_PATH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ve8FkfqKS3ztyJum5pi11H

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ve8FkfqKS3ztyJum5pi11H)_