### PR TITLE
chore(release): bump version to 0.9.32

### DIFF
--- a/provider-shell/Sources/CoCoreShell/Resources/Info.plist
+++ b/provider-shell/Sources/CoCoreShell/Resources/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleName</key>
 	<string>co/core</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.31</string>
+	<string>0.9.32</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -22,7 +22,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>931</string>
+	<string>932</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/provider/Cargo.lock
+++ b/provider/Cargo.lock
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "cocore-provider"
-version = "0.9.31"
+version = "0.9.32"
 dependencies = [
  "anyhow",
  "asn1-rs",

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cocore-provider"
-version = "0.9.31"
+version = "0.9.32"
 edition = "2021"
 description = "co/core provider agent: runs hardened compute and publishes signed receipts to AT Protocol."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Release **v0.9.32** of the cocore tray app + provider.

## What's in this release (since v0.9.31)
- **Tool-calling support** across the full stack, gated by a forced-tool startup canary (provider advertises tool models only after vLLM-MLX proves it returns real `tool_calls`); native/confidential engines reject tool + structured-output requests.
- **Provider binary-version targeting** — advisor can route inference to a minimum provider `binaryVersion` (image-capable routing).
- **Xet download hardening** — default `HF_HUB_DISABLE_XET=1` + HF_TOKEN plumb/scrub so first-serve of uncached models isn't 429-throttle-killed.
- **Inference auth** — resolve AppView-minted API keys + accept atproto service tokens.
- **Advisor latency tracking** — time-to-ack landing headline + rolling latency windows persisted across restarts (advisor-side; not in the tray bundle).

Version bumped in `provider/Cargo.toml`, `Cargo.lock`, and the shell `Info.plist` (CFBundleShortVersionString → 0.9.32, CFBundleVersion → 932).

🤖 Generated with [Claude Code](https://claude.com/claude-code)