### PR TITLE
feat(inference): expose & document min_provider_version on the OpenAI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,14 @@ just the model:
   per machine on the website: off, free for *anyone*, or free for an explicit
   list of people (friends-only). Pro-bono jobs are unmetered and take no
   exchange cut, so a balance-less requester can still be served.
+- **By provider version.** Pass `min_provider_version` (e.g. `0.9.32`) to route
+  only to providers running that tray release or newer — useful for pinning a
+  feature that landed in a specific version. Each machine reports its
+  `binaryVersion` when it registers with the matchmaker; only versions at or
+  above your floor are eligible (one reporting no version is excluded). A
+  multimodal request (images/tool messages) already derives this floor on its
+  own; an explicit pin and the automatic floor combine to whichever is higher.
+  Requests fail closed (`no_providers_for_version`) when none qualify.
 - **Verified / friends-only.** `/v1/verified/...` and `/v1/private/...` are the
   existing trust- and friend-constrained paths.
 

--- a/packages/console/public/openapi.yaml
+++ b/packages/console/public/openapi.yaml
@@ -366,6 +366,20 @@ components:
             (`no_providers_for_country`) when the model exists but no provider
             in that country currently serves it.
           example: US
+        min_provider_version:
+          type: string
+          pattern: '^v?\d+(\.\d+){0,3}$'
+          description: >-
+            Optional minimum provider `binaryVersion` (e.g. `0.9.32`; an
+            optional leading `v` is tolerated). When set, the request is routed
+            only to providers whose Register-reported `binaryVersion` is greater
+            than or equal to this floor; a provider reporting no version is
+            excluded. A multimodal request (images/tool messages) also derives
+            an automatic floor — the effective floor is whichever is higher.
+            Returns 503 (`no_providers_for_version`) when the model exists but
+            no connected provider runs a new-enough binary (retryable as the
+            fleet updates).
+          example: 0.9.32
         temperature:
           type: number
           description: Accepted for OpenAI compatibility; honoring is provider-dependent.

--- a/packages/console/src/components/inference-docs/pages/api-reference.tsx
+++ b/packages/console/src/components/inference-docs/pages/api-reference.tsx
@@ -45,19 +45,22 @@ export function InferenceApiReferencePage({ baseUrl }: { baseUrl: string }) {
             <div {...stylex.props(docsStyles.endpointLeft)}>
               <h2 {...stylex.props(docsStyles.h2)}>{section.title}</h2>
               <p {...stylex.props(docsStyles.endpointDesc)}>{section.description}</p>
-              <p {...stylex.props(docsStyles.prose)}>
-                Any <code {...stylex.props(docsStyles.codeInline)}>chat/completions</code> route
-                (open, <code {...stylex.props(docsStyles.codeInline)}>private</code>, and{" "}
-                <code {...stylex.props(docsStyles.codeInline)}>verified</code>) accepts the OpenAI
-                array-of-parts <code {...stylex.props(docsStyles.codeInline)}>content</code> shape.
-                A message is either a plain string (text only) or an ordered list of{" "}
-                <code {...stylex.props(docsStyles.codeInline)}>text</code> and{" "}
-                <code {...stylex.props(docsStyles.codeInline)}>image_url</code> parts. There is no
-                separate upload endpoint — images travel inside the request body.
-              </p>
-              <HighlightedBlock
-                lang="json"
-                code={`{
+              {section.id === "inference-api-image-input" && (
+                <>
+                  <p {...stylex.props(docsStyles.prose)}>
+                    Any <code {...stylex.props(docsStyles.codeInline)}>chat/completions</code> route
+                    (open, <code {...stylex.props(docsStyles.codeInline)}>private</code>, and{" "}
+                    <code {...stylex.props(docsStyles.codeInline)}>verified</code>) accepts the
+                    OpenAI array-of-parts{" "}
+                    <code {...stylex.props(docsStyles.codeInline)}>content</code> shape. A message
+                    is either a plain string (text only) or an ordered list of{" "}
+                    <code {...stylex.props(docsStyles.codeInline)}>text</code> and{" "}
+                    <code {...stylex.props(docsStyles.codeInline)}>image_url</code> parts. There is
+                    no separate upload endpoint — images travel inside the request body.
+                  </p>
+                  <HighlightedBlock
+                    lang="json"
+                    code={`{
   "model": "your-vision-model",
   "messages": [
     {
@@ -74,61 +77,119 @@ export function InferenceApiReferencePage({ baseUrl }: { baseUrl: string }) {
     }
   ]
 }`}
-              />
-              <p {...stylex.props(docsStyles.prose)}>
-                The <code {...stylex.props(docsStyles.codeInline)}>image_url.url</code> field takes
-                one of two forms:
-              </p>
-              <ul {...stylex.props(inferenceDocsSharedStyles.list)}>
-                <li {...stylex.props(inferenceDocsSharedStyles.bullet)}>
-                  <strong>Inline base64 data URI</strong> —{" "}
-                  <code {...stylex.props(docsStyles.codeInline)}>
-                    data:&lt;mime&gt;;base64,&lt;payload&gt;
-                  </code>
-                  . The MIME type must be{" "}
-                  <code {...stylex.props(docsStyles.codeInline)}>image/*</code> (e.g.{" "}
-                  <code {...stylex.props(docsStyles.codeInline)}>image/png</code>,{" "}
-                  <code {...stylex.props(docsStyles.codeInline)}>image/jpeg</code>). The bytes are
-                  sealed directly into the signed job, so the receipt verifies offline with no extra
-                  fetch.
-                </li>
-                <li {...stylex.props(inferenceDocsSharedStyles.bullet)}>
-                  <strong>Remote URL</strong> — an{" "}
-                  <code {...stylex.props(docsStyles.codeInline)}>http(s)://</code> link. co/core
-                  fetches it server-side, verifies the response is{" "}
-                  <code {...stylex.props(docsStyles.codeInline)}>image/*</code>, and inlines it as
-                  base64 before sealing, so the input stays self-contained.
-                </li>
-              </ul>
-              <h3 {...stylex.props(docsStyles.h2)}>Limits</h3>
-              <ul {...stylex.props(inferenceDocsSharedStyles.list)}>
-                <li {...stylex.props(inferenceDocsSharedStyles.bullet)}>
-                  Up to <strong>20 MiB</strong> of decoded image bytes per request, budgeted
-                  separately from the <strong>1 MiB</strong> text limit.
-                </li>
-                <li {...stylex.props(inferenceDocsSharedStyles.bullet)}>
-                  Up to <strong>256</strong> messages per request; images may be spread across them.
-                </li>
-                <li {...stylex.props(inferenceDocsSharedStyles.bullet)}>
-                  <strong>Images only.</strong> Non-image MIME types and arbitrary file attachments
-                  (PDFs, documents, audio) are rejected — there is no general file-upload part
-                  today.
-                </li>
-              </ul>
-              <h3 {...stylex.props(docsStyles.h2)}>Model support</h3>
-              <p {...stylex.props(docsStyles.prose)}>
-                Image input is not gated per model: any{" "}
-                <code {...stylex.props(docsStyles.codeInline)}>model</code> id you can route to will
-                accept an image-bearing request. Whether the image is actually understood depends on
-                the model — send images to a vision/multimodal model (the{" "}
-                <InferenceApiDocLink fragment="inference-api-models">
-                  models directory
-                </InferenceApiDocLink>{" "}
-                flags vision-capable models). A bad or unparseable{" "}
-                <code {...stylex.props(docsStyles.codeInline)}>image_url</code> with no accompanying
-                text returns{" "}
-                <code {...stylex.props(docsStyles.codeInline)}>400 invalid_request_error</code>.
-              </p>
+                  />
+                  <p {...stylex.props(docsStyles.prose)}>
+                    The <code {...stylex.props(docsStyles.codeInline)}>image_url.url</code> field
+                    takes one of two forms:
+                  </p>
+                  <ul {...stylex.props(inferenceDocsSharedStyles.list)}>
+                    <li {...stylex.props(inferenceDocsSharedStyles.bullet)}>
+                      <strong>Inline base64 data URI</strong> —{" "}
+                      <code {...stylex.props(docsStyles.codeInline)}>
+                        data:&lt;mime&gt;;base64,&lt;payload&gt;
+                      </code>
+                      . The MIME type must be{" "}
+                      <code {...stylex.props(docsStyles.codeInline)}>image/*</code> (e.g.{" "}
+                      <code {...stylex.props(docsStyles.codeInline)}>image/png</code>,{" "}
+                      <code {...stylex.props(docsStyles.codeInline)}>image/jpeg</code>). The bytes
+                      are sealed directly into the signed job, so the receipt verifies offline with
+                      no extra fetch.
+                    </li>
+                    <li {...stylex.props(inferenceDocsSharedStyles.bullet)}>
+                      <strong>Remote URL</strong> — an{" "}
+                      <code {...stylex.props(docsStyles.codeInline)}>http(s)://</code> link. co/core
+                      fetches it server-side, verifies the response is{" "}
+                      <code {...stylex.props(docsStyles.codeInline)}>image/*</code>, and inlines it
+                      as base64 before sealing, so the input stays self-contained.
+                    </li>
+                  </ul>
+                  <h3 {...stylex.props(docsStyles.h2)}>Limits</h3>
+                  <ul {...stylex.props(inferenceDocsSharedStyles.list)}>
+                    <li {...stylex.props(inferenceDocsSharedStyles.bullet)}>
+                      Up to <strong>20 MiB</strong> of decoded image bytes per request, budgeted
+                      separately from the <strong>1 MiB</strong> text limit.
+                    </li>
+                    <li {...stylex.props(inferenceDocsSharedStyles.bullet)}>
+                      Up to <strong>256</strong> messages per request; images may be spread across
+                      them.
+                    </li>
+                    <li {...stylex.props(inferenceDocsSharedStyles.bullet)}>
+                      <strong>Images only.</strong> Non-image MIME types and arbitrary file
+                      attachments (PDFs, documents, audio) are rejected — there is no general
+                      file-upload part today.
+                    </li>
+                  </ul>
+                  <h3 {...stylex.props(docsStyles.h2)}>Model support</h3>
+                  <p {...stylex.props(docsStyles.prose)}>
+                    Image input is not gated per model: any{" "}
+                    <code {...stylex.props(docsStyles.codeInline)}>model</code> id you can route to
+                    will accept an image-bearing request. Whether the image is actually understood
+                    depends on the model — send images to a vision/multimodal model (the{" "}
+                    <InferenceApiDocLink fragment="inference-api-models">
+                      models directory
+                    </InferenceApiDocLink>{" "}
+                    flags vision-capable models). A bad or unparseable{" "}
+                    <code {...stylex.props(docsStyles.codeInline)}>image_url</code> with no
+                    accompanying text returns{" "}
+                    <code {...stylex.props(docsStyles.codeInline)}>400 invalid_request_error</code>.
+                  </p>
+                </>
+              )}
+              {section.id === "inference-api-provider-version" && (
+                <>
+                  <p {...stylex.props(docsStyles.prose)}>
+                    Every <code {...stylex.props(docsStyles.codeInline)}>chat/completions</code>{" "}
+                    route (open, <code {...stylex.props(docsStyles.codeInline)}>private</code>,{" "}
+                    <code {...stylex.props(docsStyles.codeInline)}>verified</code>, and{" "}
+                    <code {...stylex.props(docsStyles.codeInline)}>probono</code>) accepts an
+                    optional{" "}
+                    <code {...stylex.props(docsStyles.codeInline)}>min_provider_version</code> body
+                    field. Set it to a dotted-numeric release (e.g.{" "}
+                    <code {...stylex.props(docsStyles.codeInline)}>0.9.32</code>; an optional
+                    leading <code {...stylex.props(docsStyles.codeInline)}>v</code> is tolerated) to
+                    route only to providers running that release or newer. Each tray provider
+                    reports its <code {...stylex.props(docsStyles.codeInline)}>binaryVersion</code>{" "}
+                    when it registers with the matchmaker; only machines reporting a version{" "}
+                    <strong>greater than or equal to</strong> your floor are eligible.
+                  </p>
+                  <HighlightedBlock
+                    lang="json"
+                    code={`{
+  "model": "your-model",
+  "messages": [{ "role": "user", "content": "Hello" }],
+  "min_provider_version": "0.9.32"
+}`}
+                  />
+                  <h3 {...stylex.props(docsStyles.h2)}>Automatic floor for multimodal requests</h3>
+                  <p {...stylex.props(docsStyles.prose)}>
+                    A request that carries images or tool messages (the{" "}
+                    <code {...stylex.props(docsStyles.codeInline)}>messages-v1</code> envelope)
+                    already derives a floor on its own — the first release that both reports its
+                    version and parses that envelope (currently{" "}
+                    <code {...stylex.props(docsStyles.codeInline)}>0.9.32</code>) — so an image
+                    request never reaches a provider that can't read it. When you also pass{" "}
+                    <code {...stylex.props(docsStyles.codeInline)}>min_provider_version</code>, the
+                    effective floor is whichever is <strong>higher</strong>: your explicit pin is
+                    never relaxed below the multimodal floor, and the multimodal floor is never
+                    relaxed below your pin.
+                  </p>
+                  <h3 {...stylex.props(docsStyles.h2)}>When none qualify</h3>
+                  <p {...stylex.props(docsStyles.prose)}>
+                    If the model is served but no connected provider runs a new-enough binary, the
+                    request fails closed with{" "}
+                    <code {...stylex.props(docsStyles.codeInline)}>
+                      503 no_providers_for_version
+                    </code>{" "}
+                    (see{" "}
+                    <InferenceApiDocLink fragment="inference-api-dispatch-errors">
+                      dispatch errors
+                    </InferenceApiDocLink>
+                    ). It is capacity-shaped and retryable — capable machines may come online as the
+                    fleet updates. A provider that reports <em>no</em> version is treated as below
+                    every floor and excluded.
+                  </p>
+                </>
+              )}
             </div>
           </div>
         </section>
@@ -157,6 +218,10 @@ export function InferenceApiReferencePage({ baseUrl }: { baseUrl: string }) {
 
 // 503 — country set, but no provider in that region serves this model
 { "error": { "type": "service_unavailable_error", "code": "no_providers_for_country", "message": "..." } }
+
+// 503 — min_provider_version (or a multimodal floor) set, but no connected
+//        provider runs a new-enough binary. Retryable as the fleet updates.
+{ "error": { "type": "service_unavailable_error", "code": "no_providers_for_version", "message": "..." } }
 
 // 503 — pro-bono route, but no connected provider currently serves you free
 { "error": { "type": "service_unavailable_error", "code": "no_pro_bono_providers", "message": "..." } }

--- a/packages/console/src/lib/inference-docs/catalog.ts
+++ b/packages/console/src/lib/inference-docs/catalog.ts
@@ -40,7 +40,7 @@ export const INFERENCE_API_CATALOG: Array<InferenceApiCatalogEntry> = [
     method: "POST",
     path: "/chat/completions",
     description:
-      "OpenAI-compatible chat completion. Routes to an attested provider serving the requested model. Set country to an ISO 3166-1 alpha-2 code (e.g. US) to route only to providers advertising that region — an advisory provider self-claim — failing closed with no_providers_for_country when none match.",
+      "OpenAI-compatible chat completion. Routes to an attested provider serving the requested model. Set country to an ISO 3166-1 alpha-2 code (e.g. US) to route only to providers advertising that region — an advisory provider self-claim — failing closed with no_providers_for_country when none match. Set min_provider_version (e.g. 0.9.32) to require a minimum provider release, failing closed with no_providers_for_version when none qualify (see Provider version below).",
     auth: "required",
     params: [
       { name: "model", type: "string", required: true },
@@ -48,6 +48,7 @@ export const INFERENCE_API_CATALOG: Array<InferenceApiCatalogEntry> = [
       { name: "stream", type: "boolean" },
       { name: "max_tokens", type: "integer" },
       { name: "country", type: "string" },
+      { name: "min_provider_version", type: "string" },
     ],
     controls: [
       { kind: "text", param: "model", label: "model", placeholder: "stub" },
@@ -59,6 +60,12 @@ export const INFERENCE_API_CATALOG: Array<InferenceApiCatalogEntry> = [
       },
       { kind: "text", param: "max_tokens", label: "max_tokens", placeholder: "256" },
       { kind: "text", param: "country", label: "country", placeholder: "US" },
+      {
+        kind: "text",
+        param: "min_provider_version",
+        label: "min_provider_version",
+        placeholder: "0.9.32",
+      },
     ],
     example: { body: CHAT_BODY, canRun: false },
   },
@@ -99,6 +106,7 @@ export const INFERENCE_API_CATALOG: Array<InferenceApiCatalogEntry> = [
       { name: "stream", type: "boolean" },
       { name: "max_tokens", type: "integer" },
       { name: "country", type: "string" },
+      { name: "min_provider_version", type: "string" },
     ],
     controls: [
       { kind: "text", param: "model", label: "model", placeholder: "stub" },
@@ -110,6 +118,12 @@ export const INFERENCE_API_CATALOG: Array<InferenceApiCatalogEntry> = [
       },
       { kind: "text", param: "max_tokens", label: "max_tokens", placeholder: "256" },
       { kind: "text", param: "country", label: "country", placeholder: "US" },
+      {
+        kind: "text",
+        param: "min_provider_version",
+        label: "min_provider_version",
+        placeholder: "0.9.32",
+      },
     ],
     example: { body: CHAT_BODY, canRun: false },
   },
@@ -128,6 +142,7 @@ export const INFERENCE_API_CATALOG: Array<InferenceApiCatalogEntry> = [
       { name: "stream", type: "boolean" },
       { name: "max_tokens", type: "integer" },
       { name: "country", type: "string" },
+      { name: "min_provider_version", type: "string" },
     ],
     controls: [
       { kind: "text", param: "model", label: "model", placeholder: "stub" },
@@ -145,6 +160,12 @@ export const INFERENCE_API_CATALOG: Array<InferenceApiCatalogEntry> = [
       },
       { kind: "text", param: "max_tokens", label: "max_tokens", placeholder: "256" },
       { kind: "text", param: "country", label: "country", placeholder: "US" },
+      {
+        kind: "text",
+        param: "min_provider_version",
+        label: "min_provider_version",
+        placeholder: "0.9.32",
+      },
     ],
     example: { body: CHAT_BODY, canRun: false },
   },
@@ -162,6 +183,7 @@ export const INFERENCE_API_CATALOG: Array<InferenceApiCatalogEntry> = [
       { name: "stream", type: "boolean" },
       { name: "max_tokens", type: "integer" },
       { name: "country", type: "string" },
+      { name: "min_provider_version", type: "string" },
     ],
     controls: [
       { kind: "text", param: "model", label: "model", placeholder: "stub" },
@@ -173,6 +195,12 @@ export const INFERENCE_API_CATALOG: Array<InferenceApiCatalogEntry> = [
       },
       { kind: "text", param: "max_tokens", label: "max_tokens", placeholder: "256" },
       { kind: "text", param: "country", label: "country", placeholder: "US" },
+      {
+        kind: "text",
+        param: "min_provider_version",
+        label: "min_provider_version",
+        placeholder: "0.9.32",
+      },
     ],
     example: { body: CHAT_BODY, canRun: false },
   },
@@ -185,6 +213,13 @@ export const INFERENCE_API_TOPIC_SECTIONS = [
     title: "Image input",
     description:
       "Vision-capable models accept images alongside text using OpenAI's multimodal content parts. Carried inline as base64 or fetched from a URL; no separate upload step.",
+  },
+  {
+    id: "inference-api-provider-version",
+    navLabel: "provider version",
+    title: "Provider version",
+    description:
+      "Pin a minimum tray-provider release so your request only reaches machines new enough to honor a feature, failing closed when none qualify.",
   },
 ] as const;
 

--- a/packages/console/src/lib/openai-chat-completions.server.ts
+++ b/packages/console/src/lib/openai-chat-completions.server.ts
@@ -71,6 +71,14 @@ export interface OpenAiChatRequest {
   /** Optional tool choice strategy: "auto", "none", "required", or
    *  { type: "function", function: { name } } for a specific tool. */
   tool_choice?: unknown;
+  /** Optional minimum provider binaryVersion to route to, e.g. "0.9.32".
+   *  Only providers whose Register-reported `binaryVersion` is >= this are
+   *  eligible; a provider that reports no version is excluded. Use it to
+   *  pin a feature that landed in a specific release. A multimodal request
+   *  also derives an automatic floor — the effective floor is whichever is
+   *  higher. Fails closed with `no_providers_for_version` (503) when none
+   *  qualify. */
+  min_provider_version?: unknown;
 }
 
 export interface ParsedRequest {
@@ -101,6 +109,10 @@ export interface ParsedRequest {
   toolChoice?: "auto" | "none" | "required";
   /** When toolChoice is "required", optionally force a specific function. */
   toolChoiceFunction?: string;
+  /** Optional caller-requested minimum provider binaryVersion (e.g.
+   *  "0.9.32"). Combined with the automatic multimodal floor at dispatch —
+   *  the higher of the two wins. */
+  minProviderVersion?: string;
 }
 
 const DEFAULT_MAX_TOKENS = 1024;
@@ -275,6 +287,19 @@ export function parseRequest(raw: OpenAiChatRequest): ParsedRequest | string {
     }
     country = raw.country.trim().toUpperCase();
   }
+  // Optional caller-requested provider version floor. Accept a dotted-numeric
+  // version (optional leading `v`); the dispatch comparator tolerates a `v`
+  // prefix and any pre-release/build suffix. `null` is treated as absent.
+  let minProviderVersion: string | undefined;
+  if (raw.min_provider_version !== undefined && raw.min_provider_version !== null) {
+    if (
+      typeof raw.min_provider_version !== "string" ||
+      !/^v?\d+(\.\d+){0,3}$/.test(raw.min_provider_version.trim())
+    ) {
+      return 'min_provider_version must be a dotted-numeric version string (e.g. "0.9.32")';
+    }
+    minProviderVersion = raw.min_provider_version.trim();
+  }
   // Parse OpenAI-compatible response_format for structured output.
   let outputSchema: ParsedRequest["outputSchema"];
   if (raw.response_format !== undefined) {
@@ -367,6 +392,7 @@ export function parseRequest(raw: OpenAiChatRequest): ParsedRequest | string {
     stream,
     maxTokens,
     country,
+    ...(minProviderVersion ? { minProviderVersion } : {}),
     ...(outputSchema ? { outputSchema } : {}),
     ...(tools ? { tools } : {}),
     ...(toolChoice ? { toolChoice } : {}),

--- a/packages/console/src/lib/openai-chat-completions.test.ts
+++ b/packages/console/src/lib/openai-chat-completions.test.ts
@@ -168,6 +168,47 @@ describe("dispatchErrorToHttpResponse", () => {
     assert.equal(out.status, 403);
     assert.equal(out.type, "permission_error");
   });
+
+  test("no-providers-for-version becomes 503 (retryable as the fleet updates)", () => {
+    const out = dispatchErrorToHttpResponse("no-providers-for-version");
+    assert.equal(out.status, 503);
+    assert.equal(out.type, "service_unavailable_error");
+    assert.equal(out.code, "no_providers_for_version");
+  });
+});
+
+describe("parseRequest min_provider_version", () => {
+  const base = { model: "stub", messages: [{ role: "user", content: "hi" }] };
+
+  test("accepts a dotted-numeric version and normalizes nothing", () => {
+    const parsed = parseRequest({ ...base, min_provider_version: "0.9.32" });
+    assert.notEqual(typeof parsed, "string");
+    if (typeof parsed === "string") return;
+    assert.equal(parsed.minProviderVersion, "0.9.32");
+  });
+
+  test("tolerates a leading v and trims whitespace", () => {
+    const parsed = parseRequest({ ...base, min_provider_version: " v1.2.3 " });
+    assert.notEqual(typeof parsed, "string");
+    if (typeof parsed === "string") return;
+    assert.equal(parsed.minProviderVersion, "v1.2.3");
+  });
+
+  test("treats null/absent as no floor", () => {
+    for (const v of [undefined, null]) {
+      const parsed = parseRequest({ ...base, min_provider_version: v });
+      assert.notEqual(typeof parsed, "string");
+      if (typeof parsed === "string") return;
+      assert.equal(parsed.minProviderVersion, undefined);
+    }
+  });
+
+  test("rejects a non-version string with a 400-shaped message", () => {
+    const parsed = parseRequest({ ...base, min_provider_version: "latest" });
+    assert.equal(typeof parsed, "string");
+    if (typeof parsed !== "string") return;
+    assert.match(parsed, /min_provider_version/);
+  });
 });
 
 async function* yieldEvents(events: DispatchEvent[]): AsyncIterable<DispatchEvent> {

--- a/packages/console/src/lib/openai-routes.server.ts
+++ b/packages/console/src/lib/openai-routes.server.ts
@@ -27,6 +27,7 @@ import { isAppviewForwardConfigured } from "@/lib/appview-pds-forward.server.ts"
 import {
   type AdvisorProviderRow,
   type DispatchInputs,
+  meetsMinVersion,
   runDispatch,
 } from "@/lib/inference-dispatch.server.ts";
 import { listMyFriendDids } from "@/lib/friends.server.ts";
@@ -77,6 +78,22 @@ const MESSAGES_V1_MIN_VERSION = process.env["COCORE_MIN_VERSION_MESSAGES_V1"] ??
  *  (`messages-v1`) require a capable provider; plain text has no floor. */
 function minVersionForInput(inputFormat: string | undefined): string | undefined {
   return inputFormat === "messages-v1" ? MESSAGES_V1_MIN_VERSION : undefined;
+}
+
+/** Combine a caller-requested provider floor with the automatic floor an
+ *  input format implies. The effective floor is whichever is HIGHER: a
+ *  caller asking for `0.9.40` on an image request must not be relaxed to the
+ *  `messages-v1` floor, and an image request must not be relaxed below it by
+ *  a lower caller value. Returns undefined when neither floor applies. */
+function effectiveMinVersion(
+  callerMin: string | undefined,
+  inputFormat: string | undefined,
+): string | undefined {
+  const auto = minVersionForInput(inputFormat);
+  if (!callerMin) return auto;
+  if (!auto) return callerMin;
+  // meetsMinVersion(a, b) === a >= b, so keep callerMin when it's the higher.
+  return meetsMinVersion(callerMin, auto) ? callerMin : auto;
 }
 
 // The method NSID a service-auth token must be minted for (its `lxm`
@@ -266,9 +283,10 @@ export async function handleChatCompletions(request: Request): Promise<Response>
     prompt: "",
     payloadBytes: payload.payloadBytes,
     inputFormat: payload.inputFormat,
-    // Image requests must only reach providers running a release that
-    // supports the messages-v1 envelope (fail-closed at the advisor).
-    minProviderVersion: minVersionForInput(payload.inputFormat),
+    // A caller may pin a minimum provider release (min_provider_version);
+    // image requests also derive the messages-v1 floor. The higher of the
+    // two wins, fail-closed at the advisor.
+    minProviderVersion: effectiveMinVersion(parsed.minProviderVersion, payload.inputFormat),
     maxTokensOut: parsed.maxTokens,
     priceCeiling: DEFAULT_PRICE_CEILING,
     country: parsed.country,
@@ -336,9 +354,10 @@ export async function handlePrivateChatCompletions(request: Request): Promise<Re
     prompt: "",
     payloadBytes: payload.payloadBytes,
     inputFormat: payload.inputFormat,
-    // Image requests must only reach providers running a release that
-    // supports the messages-v1 envelope (fail-closed at the advisor).
-    minProviderVersion: minVersionForInput(payload.inputFormat),
+    // A caller may pin a minimum provider release (min_provider_version);
+    // image requests also derive the messages-v1 floor. The higher of the
+    // two wins, fail-closed at the advisor.
+    minProviderVersion: effectiveMinVersion(parsed.minProviderVersion, payload.inputFormat),
     maxTokensOut: parsed.maxTokens,
     priceCeiling: DEFAULT_PRICE_CEILING,
     // `allowedProviderDids` here is what tips runDispatch into
@@ -431,9 +450,10 @@ export async function handleVerifiedChatCompletions(request: Request): Promise<R
     prompt: "",
     payloadBytes: payload.payloadBytes,
     inputFormat: payload.inputFormat,
-    // Image requests must only reach providers running a release that
-    // supports the messages-v1 envelope (fail-closed at the advisor).
-    minProviderVersion: minVersionForInput(payload.inputFormat),
+    // A caller may pin a minimum provider release (min_provider_version);
+    // image requests also derive the messages-v1 floor. The higher of the
+    // two wins, fail-closed at the advisor.
+    minProviderVersion: effectiveMinVersion(parsed.minProviderVersion, payload.inputFormat),
     maxTokensOut: parsed.maxTokens,
     priceCeiling: DEFAULT_PRICE_CEILING,
     // Same mechanism as the friends path, but the set is the proof-backed
@@ -513,9 +533,10 @@ export async function handleProBonoChatCompletions(request: Request): Promise<Re
     prompt: "",
     payloadBytes: payload.payloadBytes,
     inputFormat: payload.inputFormat,
-    // Image requests must only reach providers running a release that
-    // supports the messages-v1 envelope (fail-closed at the advisor).
-    minProviderVersion: minVersionForInput(payload.inputFormat),
+    // A caller may pin a minimum provider release (min_provider_version);
+    // image requests also derive the messages-v1 floor. The higher of the
+    // two wins, fail-closed at the advisor.
+    minProviderVersion: effectiveMinVersion(parsed.minProviderVersion, payload.inputFormat),
     maxTokensOut: parsed.maxTokens,
     priceCeiling: DEFAULT_PRICE_CEILING,
     // Constrain routing to providers that serve this requester free — same


### PR DESCRIPTION
## What

Lets API callers **target a minimum tray-provider version** on the public OpenAI-compatible inference API, and documents the spec so people can implement against it.

The AppView XRPC `dev.cocore.inference.dispatch` endpoint already accepted an explicit `minProviderVersion`, but the public `/v1/chat/completions` surface only *derived* a floor automatically for multimodal requests — there was no caller knob. This adds one.

## API

Optional `min_provider_version` body field on every chat/completions route (`open`, `private`, `verified`, `probono`):

```json
{
  "model": "your-model",
  "messages": [{ "role": "user", "content": "Hello" }],
  "min_provider_version": "0.9.32"
}
```

- Dotted-numeric (optional leading `v`); validated, else `400`.
- Routes only to providers whose Register-reported `binaryVersion` ≥ the floor; a provider reporting **no** version is excluded.
- A multimodal request (images/tool messages) still derives the `messages-v1` floor automatically — the **effective floor is whichever is higher**, so an explicit pin is never relaxed below the multimodal floor and vice-versa.
- Fails closed with `503 no_providers_for_version` (retryable as the fleet updates).

## Code

- `openai-chat-completions.server.ts` — parse + validate `min_provider_version` in `parseRequest`.
- `openai-routes.server.ts` — `effectiveMinVersion()` combines the caller floor with the auto multimodal floor (higher wins); applied at all 4 dispatch sites. Reuses the existing `minProviderVersion` plumbing through `runDispatch`/`filterByMinVersion`.
- Tests: `parseRequest` accept/normalize/reject cases + the `no_providers_for_version` 503 mapping.

## Docs

- Inference **API reference** (`catalog.ts` params + a new "Provider version" topic section + the dispatch-errors block).
- **OpenAPI** spec (`ChatCompletionRequest.min_provider_version`).
- **README** routing section.

typecheck + oxlint + oxfmt clean; touched test suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)