### PR TITLE
feat(release): auto-register the confidential cdHash on Railway

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@
         enclave-build shell-build \
         stack-up stack-down stack-smoke stack-logs \
         mac-installer mac-release mac-install mac-uninstall \
+        register-cdhash \
         build test e2e clean
 
 lex-validate:
@@ -170,6 +171,36 @@ mac-release:
 	@echo "   dist/SHA256SUMS:"; cat dist/SHA256SUMS
 	@echo "==> release artifacts:"
 	@ls -lh dist/cocore.app.zip dist/cocore-mac-arm64.tar.gz dist/SHA256SUMS
+	@# Surface (and optionally register) the confidential cdHash so the
+	@# advisor's known-good set tracks this release. Print-only by default;
+	@# set COCORE_AUTO_REGISTER_CDHASH=1 to push it to Railway automatically.
+	@$(MAKE) register-cdhash
+
+# The Developer-ID-signed confidential worker nested inside cocore.app. Its
+# cdHash is what the confidential tier trusts (COCORE_KNOWN_GOOD_CDHASHES) —
+# extracted from the LOCAL notarized build (CI only ad-hoc signs, so the CI
+# cdHash is not the distributable one).
+WORKER_BIN := provider-shell/build/cocore.app/Contents/CoCoreProvider.app/Contents/MacOS/cocore-provider
+
+# `make register-cdhash` extracts the confidential worker's cdHash from the
+# built app and registers it in the advisor's known-good set. Print-only unless
+# COCORE_AUTO_REGISTER_CDHASH=1 (then it sets the Railway var + redeploys, only
+# ever APPENDING — see scripts/register-known-good.sh). No-op for a build that
+# didn't nest the confidential worker.
+register-cdhash:
+	@if [ ! -f "$(WORKER_BIN)" ]; then \
+	  echo "==> no confidential worker at $(WORKER_BIN) — skipping cdHash registration (non-confidential build)"; \
+	else \
+	  echo "==> extract + register confidential cdHash"; \
+	  mkdir -p dist; \
+	  ./scripts/extract-cdhash.sh "$(WORKER_BIN)" | tee dist/cdhash.json >/dev/null; \
+	  if [ "$$COCORE_AUTO_REGISTER_CDHASH" = "1" ]; then \
+	    ./scripts/register-known-good.sh --apply dist/cdhash.json; \
+	  else \
+	    ./scripts/register-known-good.sh dist/cdhash.json; \
+	    echo "   (COCORE_AUTO_REGISTER_CDHASH=1 make register-cdhash  → apply to Railway automatically)"; \
+	  fi; \
+	fi
 
 e2e:
 	@echo "M2: live pair flow"

--- a/scripts/register-known-good.sh
+++ b/scripts/register-known-good.sh
@@ -9,26 +9,51 @@
 # to best-effort — no error, just a quiet loss of the confidential guarantee.
 # Run this WITH every secure release.
 #
-# This helper is intentionally a DOCUMENTED MANUAL STEP for now: it does not
-# touch Railway on its own (a bad COCORE_KNOWN_GOOD_CDHASHES value would
-# de-bless the whole fleet). It computes the exact new env value and prints the
-# precise commands the operator runs to apply it.
+# By default this is a DRY RUN: it reads the CURRENT advisor value (from
+# Railway if the CLI is linked, else from $COCORE_CURRENT_KNOWN_GOOD), computes
+# the deduped APPENDED value, and prints the exact command — it does NOT mutate
+# Railway. Pass --apply to actually set it (a bad/replacing value would
+# de-bless the whole fleet, so the apply path ONLY ever appends, never shrinks).
 #
 # Usage:
-#   ./scripts/register-known-good.sh <cdhash-hex>
-#   ./scripts/register-known-good.sh path/to/cdhash.json
-#   ./scripts/register-known-good.sh < cdhash.json        # piped JSON
+#   ./scripts/register-known-good.sh <cdhash-hex>            # dry run (print)
+#   ./scripts/register-known-good.sh path/to/cdhash.json     # dry run (print)
+#   ./scripts/register-known-good.sh < cdhash.json           # JSON on stdin
+#   ./scripts/register-known-good.sh --apply cdhash.json     # set it on Railway
+#
+# Flags:
+#   --apply              set COCORE_KNOWN_GOOD_CDHASHES on Railway (redeploys).
+#   --service <name>     advisor service name (default "Advisor"; see note).
 #
 # Optional env:
-#   COCORE_CURRENT_KNOWN_GOOD  the CURRENT value of COCORE_KNOWN_GOOD_CDHASHES
-#                              (so the printed new value is current + the new
-#                              hash, deduped). If unset, the snippet shows how
-#                              to read it from Railway first.
+#   COCORE_CURRENT_KNOWN_GOOD  the CURRENT value, if you'd rather not (or can't)
+#                              read it from Railway. Takes precedence over the
+#                              Railway read.
+#   COCORE_ADVISOR_SERVICE     same as --service.
 
 set -euo pipefail
 
 die() { printf 'register-known-good: error: %s\n' "$*" >&2; exit 1; }
+bold() { printf '\033[1m%s\033[0m\n' "$*"; }
+note() { printf '  %s\n' "$*"; }
 
+# The Railway service that runs the advisor. NOTE: capital "A" — the service is
+# named "Advisor"; lowercase "advisor" 404s on the Railway CLI.
+SERVICE="${COCORE_ADVISOR_SERVICE:-Advisor}"
+apply="no"
+positional=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apply)     apply="yes"; shift ;;
+    --service)   SERVICE="${2:?--service needs a name}"; shift 2 ;;
+    --service=*) SERVICE="${1#*=}"; shift ;;
+    -h|--help)   sed -n '2,33p' "$0"; exit 0 ;;
+    --)          shift; break ;;
+    -*)          die "unknown flag: $1 (see --help)" ;;
+    *)           positional+=("$1"); shift ;;
+  esac
+done
+set -- ${positional[@]+"${positional[@]}"}
 arg="${1:-}"
 
 # --- resolve the cdHash from: a hex arg, a cdhash.json path, or stdin -------
@@ -40,7 +65,7 @@ elif [[ -n "$arg" ]]; then
 elif [[ ! -t 0 ]]; then
   raw="$(cat)"            # JSON piped on stdin
 else
-  die "usage: register-known-good.sh <cdhash-hex | cdhash.json>"
+  die "usage: register-known-good.sh [--apply] <cdhash-hex | cdhash.json>"
 fi
 
 # If it looks like JSON, pull .cdHash out of it (no jq dependency — grep/sed).
@@ -60,13 +85,34 @@ esac
 [[ "${#cd_hash}" -eq 40 ]] \
   || die "cdHash is ${#cd_hash} hex chars; expected 40 (20-byte CodeDirectory hash). Got: $cd_hash"
 
+# --- read the CURRENT advisor value ----------------------------------------
+# Precedence: explicit env override > Railway read. We track read_ok separately
+# from emptiness so an APPLY against a legitimately-empty var (the first secure
+# release) is allowed, while a FAILED read blocks apply (never replace blind).
+read_railway_current() {
+  command -v railway >/dev/null 2>&1 || return 1
+  local out
+  out="$(railway variables --service "$SERVICE" --json 2>/dev/null)" || return 1
+  printf '%s' "$out" \
+    | sed -n 's/.*"COCORE_KNOWN_GOOD_CDHASHES"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+    | head -1
+  return 0
+}
+
+current=""
+have_current="no"
+if [[ -n "${COCORE_CURRENT_KNOWN_GOOD:-}" ]]; then
+  current="$COCORE_CURRENT_KNOWN_GOOD"
+  have_current="yes"
+elif current="$(read_railway_current)"; then
+  have_current="yes"   # read succeeded (current may be empty = var unset)
+fi
+
 # --- compute the new env value (current set + new hash, space-joined, deduped) ---
-current="${COCORE_CURRENT_KNOWN_GOOD:-}"
 new_value="$cd_hash"
 already="no"
-if [[ -n "$current" ]]; then
-  # Split current on whitespace/commas, lowercase, dedupe, append the new one.
-  declare -a seen=()
+declare -a seen=()
+if [[ "$have_current" == "yes" && -n "$current" ]]; then
   add() {
     local h
     h="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
@@ -81,38 +127,69 @@ if [[ -n "$current" ]]; then
   new_value="${seen[*]}"   # space-joined; known-good.ts splits on /[\s,]+/
 fi
 
-bold() { printf '\033[1m%s\033[0m\n' "$*"; }
-note() { printf '  %s\n' "$*"; }
-
 bold "==> known-good registration for secure release"
 note "new cdHash:        $cd_hash"
+note "advisor service:   $SERVICE"
 if [[ "$already" == "yes" ]]; then
-  note "status:            ALREADY present in COCORE_CURRENT_KNOWN_GOOD (no-op)"
+  note "status:            ALREADY present (no-op)"
 fi
 printf '\n'
 
-if [[ -z "$current" ]]; then
+# --- apply path: actually set it on Railway --------------------------------
+if [[ "$apply" == "yes" ]]; then
+  command -v railway >/dev/null 2>&1 || die "railway CLI not found (needed for --apply)"
+  [[ "$have_current" == "yes" ]] \
+    || die "could not read the current COCORE_KNOWN_GOOD_CDHASHES from Railway service '$SERVICE'. Refusing to apply blind — a replace would de-bless the fleet. Link the project (railway link) or pass COCORE_CURRENT_KNOWN_GOOD."
+  if [[ "$already" == "yes" ]]; then
+    note "Nothing to do — already in the set. No Railway change, no redeploy."
+    exit 0
+  fi
+  bold "==> applying to Railway service '$SERVICE' (this triggers a redeploy)"
+  note "value: $new_value"
+  railway variables --service "$SERVICE" --set "COCORE_KNOWN_GOOD_CDHASHES=$new_value" \
+    || die "railway variables --set failed"
+  # Verify the readback contains the new hash (best effort; the redeploy may
+  # still be in flight, but the var write itself is synchronous).
+  got="$(read_railway_current || true)"
+  case " ${got//,/ } " in
+    *" $cd_hash "*) note "verified: advisor known-good set now includes $cd_hash" ;;
+    *)              note "NOTE: post-set readback didn't show $cd_hash yet (redeploy in flight?). Re-check with:";
+                    note "  railway variables --service $SERVICE | grep COCORE_KNOWN_GOOD_CDHASHES" ;;
+  esac
+  printf '\n'
+  note "Reminder: the advisor is an ACCELERATOR, not the authority. A confidential"
+  note "requester re-verifies the provider's signed attestation against its OWN"
+  note "known-good set at seal time — publish this cdHash to requesters too"
+  note "(cdhash.json release asset). See docs/secure-release.md."
+  exit 0
+fi
+
+# --- dry run: print the exact command --------------------------------------
+if [[ "$have_current" != "yes" ]]; then
   bold "1) Read the CURRENT advisor value first (so you APPEND, never replace):"
-  cat <<'EOS'
-   # Via the Railway CLI (project co/core, service advisor):
-   railway variables --service advisor | grep COCORE_KNOWN_GOOD_CDHASHES
-   # then re-run this script with that value so it appends + dedupes:
-   COCORE_CURRENT_KNOWN_GOOD="<that value>" ./scripts/register-known-good.sh <cdhash-or-json>
+  cat <<EOS
+   railway variables --service $SERVICE | grep COCORE_KNOWN_GOOD_CDHASHES
+   # then re-run with that value so it appends + dedupes:
+   COCORE_CURRENT_KNOWN_GOOD="<that value>" ./scripts/register-known-good.sh ${arg:-<cdhash-or-json>}
+   # …or just let this script read + apply it for you:
+   ./scripts/register-known-good.sh --apply ${arg:-<cdhash-or-json>}
 EOS
   printf '\n'
   bold "2) Set the appended value (advisor reads COCORE_KNOWN_GOOD_CDHASHES):"
-  note   "If the var is currently EMPTY, the full value is just the new hash:"
+  note "If the var is currently EMPTY, the full value is just the new hash:"
   printf '\n'
-  printf '   railway variables --service advisor --set "COCORE_KNOWN_GOOD_CDHASHES=%s"\n\n' "$cd_hash"
+  printf '   railway variables --service %s --set "COCORE_KNOWN_GOOD_CDHASHES=%s"\n\n' "$SERVICE" "$cd_hash"
 else
-  bold "1) Set the appended value (current set + this release, space-separated):"
+  bold "1) Apply the appended value (current set + this release, deduped):"
   printf '\n'
-  printf '   railway variables --service advisor --set "COCORE_KNOWN_GOOD_CDHASHES=%s"\n\n' "$new_value"
+  printf '   ./scripts/register-known-good.sh --apply %s\n' "${arg:-<cdhash-or-json>}"
+  note "or set it directly:"
+  printf '   railway variables --service %s --set "COCORE_KNOWN_GOOD_CDHASHES=%s"\n\n' "$SERVICE" "$new_value"
 fi
 
-bold "3) Confirm the advisor picked it up after redeploy:"
-cat <<'EOS'
-   railway variables --service advisor | grep COCORE_KNOWN_GOOD_CDHASHES
+bold "2) Confirm the advisor picked it up after redeploy:"
+cat <<EOS
+   railway variables --service $SERVICE | grep COCORE_KNOWN_GOOD_CDHASHES
    # The advisor logs its known-good set size on boot (KnownGoodSet.fromEnv).
    # size 0 == NOTHING is confidential-eligible (fail-closed).
 EOS

--- a/scripts/register-known-good.sh
+++ b/scripts/register-known-good.sh
@@ -24,12 +24,16 @@
 # Flags:
 #   --apply              set COCORE_KNOWN_GOOD_CDHASHES on Railway (redeploys).
 #   --service <name>     advisor service name (default "Advisor"; see note).
+#   --max <n>            retain at most the n most-recent cdHashes (default 5;
+#                        0 = unbounded). Oldest are evicted first so users still
+#                        on a recent prior release keep being recognized.
 #
 # Optional env:
 #   COCORE_CURRENT_KNOWN_GOOD  the CURRENT value, if you'd rather not (or can't)
 #                              read it from Railway. Takes precedence over the
 #                              Railway read.
 #   COCORE_ADVISOR_SERVICE     same as --service.
+#   COCORE_KNOWN_GOOD_MAX      same as --max.
 
 set -euo pipefail
 
@@ -40,6 +44,11 @@ note() { printf '  %s\n' "$*"; }
 # The Railway service that runs the advisor. NOTE: capital "A" — the service is
 # named "Advisor"; lowercase "advisor" 404s on the Railway CLI.
 SERVICE="${COCORE_ADVISOR_SERVICE:-Advisor}"
+# Retain at most the most-recent N cdHashes so the set stays bounded as we cut
+# releases, while still recognizing recent prior versions so users mid-update
+# aren't dropped (the bug this whole flow exists to prevent). Oldest are evicted
+# first. 0 = unbounded. Override with --max or COCORE_KNOWN_GOOD_MAX.
+MAX="${COCORE_KNOWN_GOOD_MAX:-5}"
 apply="no"
 positional=()
 while [[ $# -gt 0 ]]; do
@@ -47,12 +56,15 @@ while [[ $# -gt 0 ]]; do
     --apply)     apply="yes"; shift ;;
     --service)   SERVICE="${2:?--service needs a name}"; shift 2 ;;
     --service=*) SERVICE="${1#*=}"; shift ;;
-    -h|--help)   sed -n '2,33p' "$0"; exit 0 ;;
+    --max)       MAX="${2:?--max needs a count}"; shift 2 ;;
+    --max=*)     MAX="${1#*=}"; shift ;;
+    -h|--help)   sed -n '2,35p' "$0"; exit 0 ;;
     --)          shift; break ;;
     -*)          die "unknown flag: $1 (see --help)" ;;
     *)           positional+=("$1"); shift ;;
   esac
 done
+case "$MAX" in *[!0-9]*) die "--max must be a non-negative integer, got: $MAX" ;; esac
 set -- ${positional[@]+"${positional[@]}"}
 arg="${1:-}"
 
@@ -108,30 +120,47 @@ elif current="$(read_railway_current)"; then
   have_current="yes"   # read succeeded (current may be empty = var unset)
 fi
 
-# --- compute the new env value (current set + new hash, space-joined, deduped) ---
-new_value="$cd_hash"
+# --- compute the new env value (current set + new hash, deduped, capped) ----
+# Build the ordered set oldest→newest: existing hashes in their current order,
+# then the new one appended at the end. Then cap to the most-recent MAX by
+# evicting from the FRONT (oldest), so a bounded set still recognizes recent
+# prior releases. known-good.ts splits the value on /[\s,]+/.
 already="no"
 declare -a seen=()
+add() {
+  h="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+  [[ -z "$h" ]] && return 0
+  for e in ${seen[@]+"${seen[@]}"}; do [[ "$e" == "$h" ]] && return 0; done
+  seen+=("$h")
+}
 if [[ "$have_current" == "yes" && -n "$current" ]]; then
-  add() {
-    local h
-    h="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
-    [[ -z "$h" ]] && return 0
-    for e in ${seen[@]+"${seen[@]}"}; do [[ "$e" == "$h" ]] && return 0; done
-    seen+=("$h")
-  }
   # shellcheck disable=SC2086
   for tok in $(printf '%s' "$current" | tr ',' ' '); do add "$tok"; done
-  for e in ${seen[@]+"${seen[@]}"}; do [[ "$e" == "$cd_hash" ]] && already="yes"; done
-  add "$cd_hash"
-  new_value="${seen[*]}"   # space-joined; known-good.ts splits on /[\s,]+/
 fi
+for e in ${seen[@]+"${seen[@]}"}; do [[ "$e" == "$cd_hash" ]] && already="yes"; done
+add "$cd_hash"
+
+# Cap to the most-recent MAX (0 = unbounded). Positive-offset array slicing
+# keeps this working on macOS's stock bash 3.2 (no negative-index slicing).
+declare -a dropped=()
+if [[ "$MAX" -gt 0 && "${#seen[@]}" -gt "$MAX" ]]; then
+  drop_n=$(( ${#seen[@]} - MAX ))
+  dropped=( "${seen[@]:0:drop_n}" )
+  seen=( "${seen[@]:drop_n}" )
+fi
+new_value="${seen[*]}"
 
 bold "==> known-good registration for secure release"
 note "new cdHash:        $cd_hash"
 note "advisor service:   $SERVICE"
+note "set size:          ${#seen[@]}$( [[ "$MAX" -gt 0 ]] && printf ' (max %s)' "$MAX" )"
 if [[ "$already" == "yes" ]]; then
   note "status:            ALREADY present (no-op)"
+fi
+if [[ "${#dropped[@]}" -gt 0 ]]; then
+  # Never silently truncate — name what aged out so an operator can tell
+  # "intended eviction" from "I lost a version still in the field".
+  note "evicted (oldest):  ${dropped[*]}"
 fi
 printf '\n'
 
@@ -140,8 +169,11 @@ if [[ "$apply" == "yes" ]]; then
   command -v railway >/dev/null 2>&1 || die "railway CLI not found (needed for --apply)"
   [[ "$have_current" == "yes" ]] \
     || die "could not read the current COCORE_KNOWN_GOOD_CDHASHES from Railway service '$SERVICE'. Refusing to apply blind — a replace would de-bless the fleet. Link the project (railway link) or pass COCORE_CURRENT_KNOWN_GOOD."
-  if [[ "$already" == "yes" ]]; then
-    note "Nothing to do — already in the set. No Railway change, no redeploy."
+  # No-op only when the hash is already present AND nothing aged out — i.e. the
+  # computed set is identical to what's live. A trim (dropped non-empty) still
+  # needs to be written even if the new hash was already there.
+  if [[ "$already" == "yes" && "${#dropped[@]}" -eq 0 ]]; then
+    note "Nothing to do — already in the set, nothing evicted. No Railway change, no redeploy."
     exit 0
   fi
   bold "==> applying to Railway service '$SERVICE' (this triggers a redeploy)"


### PR DESCRIPTION
## Why

The confidential tier trusts a build by the code-signing **cdHash** of its notarized worker, registered in the advisor's `COCORE_KNOWN_GOOD_CDHASHES`. That hash changes on **every release** and was a manual copy-paste. Miss it (or fat-finger it) and every confidential request silently downgrades to best-effort — no error. Worse, replacing the set rather than appending **drops prior-version users**: a user still on the previous release gets "build isn't recognized" the moment a new release's hash overwrites theirs.

This makes registration a one-liner (or fully automatic) as part of cutting a release, **appends** instead of replacing, and **bounds** the set so it stays clean while still covering recent prior releases.

## Changes

**`scripts/register-known-good.sh`**
- New opt-in `--apply`: reads the **current** advisor value live from the Railway CLI, dedup-appends the new hash, sets the var, verifies the readback. Refuses to apply if it can't read the current value (never replaces blind). No-op (no redeploy) when nothing changes. Default stays a **dry run** that prints the exact command.
- New `--max <n>` / `COCORE_KNOWN_GOOD_MAX` (**default 5**): retain only the most-recent N cdHashes, evicting oldest first, so a user mid-update on the previous release keeps being recognized. Evictions are **logged, never silent**. Positive-offset array slicing keeps it working on macOS's stock bash 3.2.
- Fixes the service-name footgun (`Advisor`, not `advisor`, which 404s); configurable via `--service` / `COCORE_ADVISOR_SERVICE`.

**`Makefile`** — `make register-cdhash`: extracts the cdHash from the freshly-built notarized worker and registers it. `mac-release` calls it **print-only**, so every release surfaces the ready command + writes `dist/cdhash.json`. Set `COCORE_AUTO_REGISTER_CDHASH=1` to apply to Railway automatically as part of the release.

## Verified

- `bash -n` clean on both stock bash 3.2 and the env bash.
- Dry-run, `--apply` no-op, and `--max` eviction paths exercised against the live `Advisor` service (correctly appends, detects already-present, and evicts oldest when over the cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)