### PR TITLE
fix(secure-mode): don't show a false "enabled" screen when not attested

### DIFF
--- a/provider-shell/Sources/CoCoreShell/SecureModeWizard.swift
+++ b/provider-shell/Sources/CoCoreShell/SecureModeWizard.swift
@@ -348,6 +348,16 @@ struct SecureModeWizardView: View {
     /// backstop if the user navigates there another way.
     private func fastPathIfAlreadyEnrolled() {
         guard step == .intro, EnrollmentProbe.isEnrolled() else { return }
+        // Already hardware-attested (the advisor's VERIFIED standing, not a local
+        // guess) → this Mac genuinely is in Secure Mode; show the real success
+        // screen instead of re-running attestation and re-deriving a positive
+        // state. Without this gate, an enrolled-but-not-yet-attested Mac would
+        // fast-path straight into a success-looking screen on every reopen.
+        if state.trustLevel == .hardwareAttested {
+            NSLog("cocore: Secure Mode wizard opened on an attested Mac — already on")
+            advance(to: .done)
+            return
+        }
         NSLog("cocore: Secure Mode wizard opened on an already-enrolled Mac — re-attesting only")
         MenuBarController.setSecureModeDesired(true)
         state.secureModeDesired = true
@@ -378,8 +388,9 @@ struct SecureModeWizardView: View {
     }
 
     /// Terminal states show a single "Done" and drop the "Skip"/"Not now"
-    /// affordances. `pending` is terminal-but-positive (attestation requested,
-    /// landing in the background), so it reads like `done`, not a stuck step.
+    /// affordances. `pending` is terminal so the wizard isn't a stuck step, but
+    /// it is NOT a success: it states plainly that Secure Mode isn't active yet
+    /// and offers "Check again now". Only `.done` means actually attested.
     private var isTerminal: Bool { step == .done || step == .pending }
 
     private var footer: some View {
@@ -542,15 +553,22 @@ struct SecureModeWizardView: View {
     /// lights up on its own.
     private var pendingStep: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Label("Attestation requested", systemImage: "clock.badge.checkmark")
-                .font(.title2).bold().foregroundStyle(Brand.accentText)
+            // Honest, NOT a success screen: the attestation has only been
+            // REQUESTED. A checkmark / accent title here reads as "Secure Mode
+            // enabled!" when it isn't yet — so use a neutral pending treatment
+            // and state plainly that it's not active.
+            Label("Attestation pending", systemImage: "clock")
+                .font(.title2).bold().foregroundStyle(.primary)
+                .fixedSize(horizontal: false, vertical: true)
+            Text("Secure Mode is not active yet.")
+                .font(.headline).foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
             Text(
                 "We've asked this Mac to hardware-attest its identity, bound to your "
                     + "agent's signing key. Apple runs this in the background and rate-limits "
-                    + "it, so the attestation can take a while to land — sometimes hours. You "
-                    + "don't need to keep this window open: Secure Mode will turn on "
-                    + "automatically once the attestation is captured."
+                    + "it, so the attestation can take a while to land — sometimes hours. It "
+                    + "turns on automatically once the attestation is captured; you can close "
+                    + "this window and the agent keeps trying."
             )
             .fixedSize(horizontal: false, vertical: true)
             HStack(spacing: 10) {


### PR DESCRIPTION
## The bug

When enabling Secure Mode, the wizard could present a success-looking screen even though the Mac was **not** actually attested, and a re-open would land straight back on that screen instead of letting the owner retry or see the real state.

Root cause: the wizard declared success from its **local** view of the MDM/attestation flow rather than the advisor's **verified** standing (`trustLevel`):

1. The `pending` step — attestation *requested* but not yet captured, which is the **expected** first-run outcome (Apple captures it asynchronously and rate-limits it) — was styled as a positive, checkmark "Attestation requested" terminal screen. It reads as *"Secure Mode enabled!"* when Secure Mode is not active.
2. Re-opening the wizard on an already-enrolled Mac fast-paths straight back into that same positive screen, so a pending (or otherwise blocked) attestation is indistinguishable from a finished one — and there's no obvious way to re-drive it.

This is purely a UI/state-honesty bug; it would mislead on **any** attestation that hasn't completed.

## Fix

- **`pending` is now honest** — a neutral "Attestation pending" treatment that says plainly **"Secure Mode is not active yet"**, while staying non-blocking with a "Check again now" affordance.
- **The reopen fast-path consults the authoritative `trustLevel`**: only a genuinely `hardware-attested` Mac jumps to the success screen; otherwise it re-checks attestation and lands on the honest pending state.

## Notes

- `swift build` of `CoCoreShell` is clean.
- Ships in the tray app — needs a rebuilt build to reach users. Best verified on an **enrolled-but-not-yet-attested** Mac (confirm the pending screen no longer reads as success, and reopening doesn't jump to success).
- Related but separate: a build whose code hash isn't in the advisor's known-good set is rejected with "build isn't recognized" — that's the cdHash registration path (handled in #129), not this UI fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)