### PR TITLE
fix(secure-mode): treat "device not yet in NanoMDM" enqueue 500 as pending, not a failure

### DIFF
--- a/packages/console/src/lib/mdm-coordinator.server.test.ts
+++ b/packages/console/src/lib/mdm-coordinator.server.test.ts
@@ -13,6 +13,7 @@ import {
   authenticateNanomdmWebhook,
   buildDeviceInformationAttestationCommand,
   buildEnrollmentProfile,
+  enqueueTargetNotEnrolled,
   isValidSerial,
   isValidUdid,
   parseNanomdmAttestationWebhook,
@@ -183,6 +184,34 @@ describe("pushAttestationCommand — tolerance (no 400 for the shipped wizard)",
     expect(r.queued).toBe(true);
     expect(r.stubbed).toBe(true);
     expect(r.status).toBe("queued");
+  });
+});
+
+describe("enqueueTargetNotEnrolled — transient not-yet-registered race", () => {
+  it("matches the field Postgres enrollment_queue FK violation on a 500", () => {
+    // The exact NanoMDM body the reporting user pasted from the wizard.
+    const body = JSON.stringify({
+      command_error:
+        'pq: insert or update on table "enrollment_queue" violates foreign key constraint "enrollment_queue_id_fkey"',
+      command_uuid: "A9D544A1-294C-4158-A2EC-E48A45A7DE65",
+    });
+    expect(enqueueTargetNotEnrolled(500, body)).toBe(true);
+  });
+
+  it("matches the MySQL foreign-key phrasing referencing enrollment_queue", () => {
+    expect(
+      enqueueTargetNotEnrolled(
+        500,
+        "Error 1452: Cannot add or update a child row: a foreign key constraint fails (`nanomdm`.`enrollment_queue`, ...)",
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores unrelated 500s and non-500 statuses", () => {
+    expect(enqueueTargetNotEnrolled(500, "internal server error")).toBe(false);
+    expect(enqueueTargetNotEnrolled(503, "enrollment_queue foreign key")).toBe(false);
+    expect(enqueueTargetNotEnrolled(400, "bad request")).toBe(false);
+    expect(enqueueTargetNotEnrolled(200, "")).toBe(false);
   });
 });
 

--- a/packages/console/src/lib/mdm-coordinator.server.ts
+++ b/packages/console/src/lib/mdm-coordinator.server.ts
@@ -457,6 +457,30 @@ ${inner}
 `;
 }
 
+/** NanoMDM answers `/v1/enqueue` with a 500 + a database foreign-key violation
+ *  on its `enrollment_queue` table when the enqueue target has no enrollment row
+ *  yet — i.e. the Mac reports MDM-enrolled locally (`profiles status`) but its
+ *  NanoMDM check-in (Authenticate/TokenUpdate, which creates that row) hasn't
+ *  landed. That is a transient race right after profile install, NOT a
+ *  misconfiguration, so callers downgrade it to a soft "pending" instead of a
+ *  hard "error" that would dead-end the wizard with `secure-mode/push-failed`.
+ *
+ *  Matches the Postgres phrasing seen in the field
+ *  (`violates foreign key constraint "enrollment_queue_id_fkey"`) and the MySQL
+ *  one (`a foreign key constraint fails` referencing `enrollment_queue`). */
+export function enqueueTargetNotEnrolled(httpStatus: number, body: string): boolean {
+  if (httpStatus !== 500) return false;
+  const b = body.toLowerCase();
+  return b.includes("enrollment_queue") && (b.includes("foreign key") || b.includes("constraint"));
+}
+
+/** Operator/owner-facing detail for the `enqueueTargetNotEnrolled` race. */
+const NOT_YET_ENROLLED_DETAIL =
+  "device not yet registered with NanoMDM — it reports MDM-enrolled locally but " +
+  "its check-in hasn't created an enrollment row yet, so the attestation can't be " +
+  "queued. This clears on its own once the check-in lands; the agent's background " +
+  "flow re-requests until it does.";
+
 /** Wrap a mobileconfig in NanoMDM's InstallProfile command plist. */
 function buildInstallProfileCommand(commandUuid: string, profile: string): string {
   const payloadB64 = Buffer.from(profile, "utf8").toString("base64");
@@ -533,6 +557,15 @@ export async function pushAttestationCommand(
     });
     if (!enqueueResp.ok) {
       const text = await enqueueResp.text().catch(() => "");
+      if (enqueueTargetNotEnrolled(enqueueResp.status, text)) {
+        return {
+          queued: false,
+          commandUuid,
+          status: "pending",
+          stubbed: false,
+          detail: NOT_YET_ENROLLED_DETAIL,
+        };
+      }
       return {
         queued: false,
         commandUuid,
@@ -779,6 +812,15 @@ export async function requestDeviceInformationAttestation(
     });
     if (!enqueueResp.ok) {
       const text = await enqueueResp.text().catch(() => "");
+      if (enqueueTargetNotEnrolled(enqueueResp.status, text)) {
+        return {
+          queued: false,
+          commandUuid,
+          status: "pending",
+          stubbed: false,
+          detail: NOT_YET_ENROLLED_DETAIL,
+        };
+      }
       return {
         queued: false,
         commandUuid,

--- a/provider-shell/Sources/CoCoreShell/SecureModeWizard.swift
+++ b/provider-shell/Sources/CoCoreShell/SecureModeWizard.swift
@@ -180,6 +180,11 @@ struct AttestationDiagnostic {
     /// least-specific so the first matching cause wins.
     var code: String {
         if !enrolled { return "secure-mode/not-enrolled" }
+        // The coordinator reports `pending` when NanoMDM has no enrollment row
+        // for this device yet (its check-in hasn't landed) — a benign race right
+        // after profile install, NOT a queue failure. Classify it ahead of
+        // `push-failed` so it never surfaces as a red error.
+        if requestStatus == "pending" { return "secure-mode/awaiting-mdm-checkin" }
         if requestStatus == "error" { return "secure-mode/push-failed" }
         if chainStatus == "error" || chainHTTP != nil { return "secure-mode/chain-store-error" }
         return "secure-mode/chain-not-captured"
@@ -192,6 +197,11 @@ struct AttestationDiagnostic {
             return "This Mac doesn't report MDM enrollment, so it can't be asked "
                 + "to hardware-attest. Re-run the enroll step and Allow + Touch ID "
                 + "the management profile."
+        case "secure-mode/awaiting-mdm-checkin":
+            return "This Mac is enrolled, but co/core's device-management server hasn't "
+                + "registered its check-in yet, so the attestation can't be requested just "
+                + "this moment. This clears on its own within a few minutes — Secure Mode "
+                + "turns on automatically once it does, no action needed."
         case "secure-mode/push-failed":
             return "The coordinator couldn't queue the attestation request "
                 + "(\(requestDetail ?? "no detail"))."
@@ -211,6 +221,12 @@ struct AttestationDiagnostic {
         switch code {
         case "secure-mode/not-enrolled":
             return "agent: mdm_enrolled() is false; confirm `profiles status -type enrollment`."
+        case "secure-mode/awaiting-mdm-checkin":
+            return "NanoMDM has no enrollment row for this UDID yet (enqueue FK violation on "
+                + "enrollment_queue). The device reports enrolled locally but its "
+                + "Authenticate/TokenUpdate check-in hasn't landed; the agent's background "
+                + "option-B flow re-requests until it does. Confirm the device reaches the "
+                + "MDM ServerURL so its check-in registers."
         case "secure-mode/push-failed":
             return "check NanoMDM /v1/enqueue + /v1/push and that the device's UDID is a valid NanoMDM target."
         case "secure-mode/chain-store-error":
@@ -238,7 +254,9 @@ struct AttestationDiagnostic {
         // shown on the positive pending screen — say "pending" there, not
         // "failed", so the copyable detail doesn't read as an error. Genuine
         // faults keep the "failed" header.
-        let verb = code == "secure-mode/chain-not-captured" ? "pending" : "failed"
+        let verb =
+            (code == "secure-mode/chain-not-captured" || code == "secure-mode/awaiting-mdm-checkin")
+            ? "pending" : "failed"
         return [
             "co/core Secure Mode attestation \(verb) [\(code)]",
             "serial=\(serial) enrolled=\(enrolled) elapsed=\(elapsedSeconds)s polls=\(polls)",
@@ -748,6 +766,33 @@ struct SecureModeWizardView: View {
             let requestStart = Date()
             do {
                 try await requestAttestation()
+                // The coordinator can report `pending` — this Mac isn't on file with
+                // the device-management server yet (enrolled locally, but its MDM
+                // check-in, which registers it, hasn't landed). The attestation can't
+                // be queued until then, so polling for a chain this session is doomed:
+                // present the benign "pending" state now and let the agent's background
+                // flow finish the bind once the check-in registers.
+                if requestStatus == "pending" {
+                    working = false
+                    let diag = AttestationDiagnostic(
+                        serial: serial,
+                        enrolled: EnrollmentProbe.isEnrolled(),
+                        elapsedSeconds: Int(Date().timeIntervalSince(requestStart)),
+                        polls: 0,
+                        requestStatus: requestStatus,
+                        requestStubbed: requestStubbed,
+                        requestDetail: requestDetail,
+                        chainStatus: nil,
+                        chainDetail: nil,
+                        chainHTTP: nil
+                    )
+                    NSLog("cocore: %@", diag.report)
+                    MenuBarController.setSecureModeDesired(true)
+                    state.secureModeDesired = true
+                    pendingDetail = diag.report
+                    advance(to: .pending)
+                    return
+                }
                 progress = "Building the attestation chain…"
                 pollForAttestationChain()
             } catch {
@@ -922,7 +967,8 @@ struct SecureModeWizardView: View {
                 // agent keeps re-driving it until the chain lands. Genuine
                 // faults (not-enrolled / request-failed / store-error) still
                 // surface as an error the owner must act on.
-                if diag.code == "secure-mode/chain-not-captured" {
+                if diag.code == "secure-mode/chain-not-captured"
+                    || diag.code == "secure-mode/awaiting-mdm-checkin" {
                     MenuBarController.setSecureModeDesired(true)
                     state.secureModeDesired = true
                     pendingDetail = diag.report


### PR DESCRIPTION
## What the user hit

The Secure Mode wizard dead-ended on the **Attesting your hardware** step with a red error:

> The coordinator couldn't queue the attestation request (NanoMDM enqueue failed (500): …
> `pq: insert or update on table "enrollment_queue" violates foreign key constraint "enrollment_queue_id_fkey"` …)

Classified as `secure-mode/push-failed`, `elapsed=0s polls=0`, `enrolled=true`.

## Root cause

That FK violation means **NanoMDM has no enrollment row for the enqueue target yet**. The Mac flips to MDM-enrolled locally (`profiles status -type enrollment`) the instant the profile installs, but the row in NanoMDM's `enrollments` table is only created by the device's NanoMDM **check-in** (Authenticate/TokenUpdate), which lands moments *later*. The wizard advances to attesting on the local signal and fires `request-attestation` immediately (`elapsed=0s`), racing ahead of the check-in. Enqueueing to a target with no enrollment row → Postgres FK violation → NanoMDM 500.

It's a **transient race**, not a misconfiguration — and it's the same class of bug the `push-attestation` path already documented for the `enrollmentId` target. Here it's the `request-attestation` (option-B `DeviceInformation`) path against the device UDID.

The reason it surfaced *now*: the recent "don't show a false enabled screen" / option-B wiring made the wizard actually drive `request-attestation` and surface request-leg failures as hard errors, so this race — previously swallowed — became a visible red dead-end.

## Fix

**`packages/console/src/lib/mdm-coordinator.server.ts`**
- New exported `enqueueTargetNotEnrolled(httpStatus, body)` recognizing the `enrollment_queue` FK-violation 500 (Postgres *and* MySQL phrasings).
- Both `requestDeviceInformationAttestation` and `pushAttestationCommand` downgrade that specific failure from `status: "error"` to a soft `status: "pending"` with a clear detail. The `request-attestation` route already returns 200 for any non-`error` status, so the wizard no longer throws, the durable Secure Mode intent is kept, and the agent's background option-B flow re-requests until the check-in registers. Genuine enqueue failures still return `"error"` → 502 as before.

**`provider-shell/Sources/CoCoreShell/SecureModeWizard.swift`**
- New benign diagnostic code `secure-mode/awaiting-mdm-checkin` (classified ahead of `push-failed`) with a non-alarming, copy-pasteable message.
- `startAttestingStep` short-circuits straight to the **pending** screen on a `pending` request result instead of polling 180s for a chain that can't land this session.

## Why this is the right shape

- Preserves the repo's stated MDM design posture: *"The push is ADVISORY … a NanoMDM enqueue/push failure must NOT dead-end the wizard."*
- No coordinator/state changes; the provider's PDS remains source of truth.
- Honest UX: the pending screen states Secure Mode is **not active yet** — it isn't masked as success — and it lights up automatically once the check-in lands.

## Testing

- `mdm-coordinator.server.test.ts`: added coverage for `enqueueTargetNotEnrolled` (exact field Postgres body from the report, MySQL phrasing, and negative cases). Full suite: **20 passed**.
- `oxlint`: clean on both changed TS files.
- Swift target builds on macOS only (no Linux toolchain here); the edits mirror the existing `catch`-block diagnostic construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMJbkzexipC9zTQaaQxrkY)_