### PR TITLE
fix(sync): single CAS transactor for provider-record settings

### DIFF
--- a/packages/console/src/lib/provider-record-pds.server.ts
+++ b/packages/console/src/lib/provider-record-pds.server.ts
@@ -155,7 +155,7 @@ function providerRecordStore(session: OAuthSession): CasRecordStore {
  *  unknown fields — untouched), bump the monotonic `createdAt`, and putRecord
  *  with a swap guard, retrying on `InvalidSwap`. A failed read aborts without
  *  writing. This is what every `setProviderRecord*` runs on. */
-export async function transactProviderRecord(
+async function transactProviderRecord(
   session: OAuthSession,
   rkey: string,
   patch: (current: Record<string, unknown>) => Record<string, unknown>,

--- a/packages/console/src/lib/provider-record-pds.server.ts
+++ b/packages/console/src/lib/provider-record-pds.server.ts
@@ -1,6 +1,11 @@
 import type { OAuthSession } from "@atcute/oauth-node-client";
 
 import { cocoreConfig } from "@/lib/cocore-config.ts";
+import {
+  type CasRecordStore,
+  isRecordNotFound,
+  transactRecord,
+} from "@/lib/record-transactor.server.ts";
 
 const PROVIDER_COLLECTION = "dev.cocore.compute.provider";
 
@@ -88,22 +93,17 @@ export async function getMyProviderRecord(
   return { cid: body.cid, value: body.value as Record<string, unknown> };
 }
 
-async function putMyProviderRecord(
+/** Raw `com.atproto.repo.putRecord` over the OAuth session: write `record` at
+ *  `rkey`, optionally guarded by `swapRecord` (the CID it was read at — the
+ *  compare-and-swap token). Returns the committed CID. Does NOT stamp
+ *  `createdAt` or mirror — those are the transactor's job, so there's exactly
+ *  one place that owns the read-modify-write semantics. */
+async function rawPutProviderRecord(
   session: OAuthSession,
   rkey: string,
   record: Record<string, unknown>,
-  swapRecord: string,
-): Promise<void> {
-  // Stamp a fresh `createdAt` so this owner edit is unambiguously the newest
-  // version of the record. Provider records treat `createdAt` as a monotonic
-  // "last-published-at" — the agent bumps it on every re-publish — and both
-  // the AppView's index (see store.upsert's version guard) and the agent's
-  // dedup order conflicting writes by it. A read-modify-write that KEEPS the
-  // agent's last timestamp would leave the edit tied with the agent's prior
-  // commit; a lagging/replayed firehose delivery of that same-timestamp
-  // commit could then clobber the edit back to its pre-edit state in the
-  // dashboard. Bumping it makes the edit strictly win.
-  const next = { ...record, createdAt: new Date().toISOString() };
+  swapRecord: string | null,
+): Promise<{ cid: string }> {
   const res = await session.handle(`/xrpc/com.atproto.repo.putRecord`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -111,8 +111,8 @@ async function putMyProviderRecord(
       repo: session.did,
       collection: PROVIDER_COLLECTION,
       rkey,
-      record: next,
-      swapRecord,
+      record,
+      ...(swapRecord ? { swapRecord } : {}),
     }),
   });
   if (!res.ok) {
@@ -121,17 +121,46 @@ async function putMyProviderRecord(
       res.status === 401 || res.status === 403 ? `${err} · try signing out and back in` : err,
     );
   }
-  // The PDS returns the new CID; mirror to the bridge so AppView
-  // indexes the updated body. Best-effort; we still consider the
-  // write successful if the bridge hint fails.
-  try {
-    const body = (await res.json()) as { cid?: string };
-    if (body?.cid) {
-      mirrorPutToBridge({ did: session.did, rkey, cid: body.cid, record: next });
-    }
-  } catch {
-    // ignore — putRecord succeeded, only the bridge hint is missing
-  }
+  const body = (await res.json().catch(() => ({}))) as { cid?: string };
+  return { cid: body?.cid ?? "" };
+}
+
+/** The PDS-backed CAS store the transactor drives for provider records. `read`
+ *  maps a genuine 404 to `null` (so `createIfMissing` can create) while
+ *  rethrowing transport/auth blips (so the transaction aborts rather than
+ *  fabricating a record); `write` performs the swap-guarded put and fires the
+ *  best-effort bridge mirror so the AppView index reflects the new body
+ *  immediately. */
+function providerRecordStore(session: OAuthSession): CasRecordStore {
+  return {
+    async read(rkey) {
+      try {
+        return await getMyProviderRecord(session, rkey);
+      } catch (err) {
+        if (isRecordNotFound(err)) return null;
+        throw err;
+      }
+    },
+    async write(rkey, value, swapRecord) {
+      const { cid } = await rawPutProviderRecord(session, rkey, value, swapRecord);
+      if (cid) mirrorPutToBridge({ did: session.did, rkey, cid, record: value });
+      return { cid };
+    },
+  };
+}
+
+/** Mutate this machine's provider record through the single CAS transactor:
+ *  read the latest record, apply `patch` (which sets only the owner-intent
+ *  field(s) it owns and leaves everything else — including agent-authored and
+ *  unknown fields — untouched), bump the monotonic `createdAt`, and putRecord
+ *  with a swap guard, retrying on `InvalidSwap`. A failed read aborts without
+ *  writing. This is what every `setProviderRecord*` runs on. */
+export async function transactProviderRecord(
+  session: OAuthSession,
+  rkey: string,
+  patch: (current: Record<string, unknown>) => Record<string, unknown>,
+): Promise<void> {
+  await transactRecord(providerRecordStore(session), rkey, patch, { stampCreatedAt: true });
 }
 
 export async function setProviderRecordActive(
@@ -139,8 +168,7 @@ export async function setProviderRecordActive(
   rkey: string,
   active: boolean,
 ): Promise<void> {
-  const { cid, value } = await getMyProviderRecord(session, rkey);
-  await putMyProviderRecord(session, rkey, { ...value, active }, cid);
+  await transactProviderRecord(session, rkey, (value) => ({ ...value, active }));
 }
 
 /** Opt a machine into (or out of) the confidential tier by writing
@@ -156,14 +184,15 @@ export async function setProviderRecordDesiredTier(
   rkey: string,
   tier: "attested-confidential" | "best-effort",
 ): Promise<void> {
-  const { cid, value } = await getMyProviderRecord(session, rkey);
-  const next = { ...value };
-  if (tier === "attested-confidential") {
-    next["desiredTier"] = tier;
-  } else {
-    delete next["desiredTier"];
-  }
-  await putMyProviderRecord(session, rkey, next, cid);
+  await transactProviderRecord(session, rkey, (value) => {
+    const next = { ...value };
+    if (tier === "attested-confidential") {
+      next["desiredTier"] = tier;
+    } else {
+      delete next["desiredTier"];
+    }
+    return next;
+  });
 }
 
 /** Pin the set of models a machine serves by writing `desiredModels` onto
@@ -185,14 +214,15 @@ export async function setProviderRecordDesiredModels(
     seen.add(trimmed);
     cleaned.push(trimmed);
   }
-  const { cid, value } = await getMyProviderRecord(session, rkey);
-  const next = { ...value };
-  if (cleaned.length > 0) {
-    next["desiredModels"] = cleaned;
-  } else {
-    delete next["desiredModels"];
-  }
-  await putMyProviderRecord(session, rkey, next, cid);
+  await transactProviderRecord(session, rkey, (value) => {
+    const next = { ...value };
+    if (cleaned.length > 0) {
+      next["desiredModels"] = cleaned;
+    } else {
+      delete next["desiredModels"];
+    }
+    return next;
+  });
 }
 
 /** Opt a machine into (or out of) publishing its coarse country by writing
@@ -208,14 +238,15 @@ export async function setProviderRecordShareLocation(
   rkey: string,
   share: boolean,
 ): Promise<void> {
-  const { cid, value } = await getMyProviderRecord(session, rkey);
-  const next = { ...value };
-  if (share) {
-    next["shareLocation"] = true;
-  } else {
-    delete next["shareLocation"];
-  }
-  await putMyProviderRecord(session, rkey, next, cid);
+  await transactProviderRecord(session, rkey, (value) => {
+    const next = { ...value };
+    if (share) {
+      next["shareLocation"] = true;
+    } else {
+      delete next["shareLocation"];
+    }
+    return next;
+  });
 }
 
 /** The owner's pro-bono election for a machine, mirroring the lexicon
@@ -236,26 +267,27 @@ export async function setProviderRecordProBono(
   rkey: string,
   policy: ProBonoPolicyInput,
 ): Promise<void> {
-  const { cid, value } = await getMyProviderRecord(session, rkey);
-  const next = { ...value };
-  if (policy && (policy.mode === "any" || policy.mode === "direct")) {
-    if (policy.mode === "direct") {
-      const cleaned: string[] = [];
-      const seen = new Set<string>();
-      for (const d of policy.dids ?? []) {
-        const trimmed = d.trim();
-        if (trimmed.length === 0 || seen.has(trimmed)) continue;
-        seen.add(trimmed);
-        cleaned.push(trimmed);
+  await transactProviderRecord(session, rkey, (value) => {
+    const next = { ...value };
+    if (policy && (policy.mode === "any" || policy.mode === "direct")) {
+      if (policy.mode === "direct") {
+        const cleaned: string[] = [];
+        const seen = new Set<string>();
+        for (const d of policy.dids ?? []) {
+          const trimmed = d.trim();
+          if (trimmed.length === 0 || seen.has(trimmed)) continue;
+          seen.add(trimmed);
+          cleaned.push(trimmed);
+        }
+        next["proBono"] = { mode: "direct", ...(cleaned.length > 0 ? { dids: cleaned } : {}) };
+      } else {
+        next["proBono"] = { mode: "any" };
       }
-      next["proBono"] = { mode: "direct", ...(cleaned.length > 0 ? { dids: cleaned } : {}) };
     } else {
-      next["proBono"] = { mode: "any" };
+      delete next["proBono"];
     }
-  } else {
-    delete next["proBono"];
-  }
-  await putMyProviderRecord(session, rkey, next, cid);
+    return next;
+  });
 }
 
 /** Rename a machine by writing `machineLabel` onto its provider record.
@@ -275,8 +307,7 @@ export async function setProviderRecordMachineLabel(
   if (trimmed.length === 0) {
     throw new Error("Machine name cannot be empty");
   }
-  const { cid, value } = await getMyProviderRecord(session, rkey);
-  await putMyProviderRecord(session, rkey, { ...value, machineLabel: trimmed }, cid);
+  await transactProviderRecord(session, rkey, (value) => ({ ...value, machineLabel: trimmed }));
 }
 
 interface ListRecordsResponse {

--- a/packages/console/src/lib/record-transactor.server.test.ts
+++ b/packages/console/src/lib/record-transactor.server.test.ts
@@ -86,12 +86,9 @@ describe("transactRecord", () => {
     const store = new FakeStore({
       value: { active: true, supportedModels: ["a"], unknownFutureField: 42 },
     });
-    const { value } = await transactRecord(
-      store,
-      "rk",
-      (v) => ({ ...v, active: false }),
-      { sleep: noSleep },
-    );
+    const { value } = await transactRecord(store, "rk", (v) => ({ ...v, active: false }), {
+      sleep: noSleep,
+    });
     assert.equal(value.active, false);
     // Agent-authored + entirely-unknown fields ride through untouched — this is
     // what makes a new field immune to the "forgot the allowlist" clobber.
@@ -122,12 +119,9 @@ describe("transactRecord", () => {
     store.interpose = () => {
       store.commitExternal((v) => ({ ...v, shareLocation: true }));
     };
-    const { value } = await transactRecord(
-      store,
-      "rk",
-      (v) => ({ ...v, active: false }),
-      { sleep: noSleep },
-    );
+    const { value } = await transactRecord(store, "rk", (v) => ({ ...v, active: false }), {
+      sleep: noSleep,
+    });
     assert.equal(store.writes, 2, "first write conflicts, second succeeds");
     assert.equal(value.active, false, "our field wins (we committed last)");
     assert.equal(value.shareLocation, true, "competitor's untouched field survives");
@@ -171,7 +165,8 @@ describe("transactRecord", () => {
     const store = new FakeStore({ value: { active: true } });
     // Every write loses the swap (a relentless competitor).
     const original = store.write.bind(store);
-    store.write = async (rkey, value, _swap) => original(rkey, value, "stale-cid-that-never-matches");
+    store.write = async (rkey, value, _swap) =>
+      original(rkey, value, "stale-cid-that-never-matches");
     await assert.rejects(
       () =>
         transactRecord(store, "rk", (v) => ({ ...v, active: false }), {

--- a/packages/console/src/lib/record-transactor.server.test.ts
+++ b/packages/console/src/lib/record-transactor.server.test.ts
@@ -1,0 +1,212 @@
+// Unit tests for the CAS read-modify-write transactor — the single path all
+// console + agent record mutations funnel through. These exercise the contract
+// that makes concurrent writers safe: field-scoped patches, last-writer-wins
+// under swap conflict, fail-closed on read errors, and bounded retry.
+//
+// The transactor is storage-agnostic (it takes a CasRecordStore), so we drive
+// it with an in-memory fake that models real PDS compare-and-swap: a write only
+// commits when its swapRecord matches the current CID, and every commit moves
+// the CID. That lets us inject a competing writer between a read and its write
+// to force the exact `InvalidSwap` race the transactor must survive.
+
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+
+import {
+  type CasRecordStore,
+  isRecordNotFound,
+  isSwapConflict,
+  RecordNotFoundError,
+  transactRecord,
+} from "./record-transactor.server.ts";
+
+const noSleep = async () => {};
+
+/** In-memory PDS-like store with real swap semantics. `interpose` runs once,
+ *  just before the next `write` lands, to simulate a competing commit. */
+class FakeStore implements CasRecordStore {
+  cid: string | null;
+  value: Record<string, unknown> | null;
+  reads = 0;
+  writes = 0;
+  private seq = 0;
+  failReadWith: Error | null = null;
+  failWriteWith: Error | null = null;
+  interpose: (() => void) | null = null;
+
+  constructor(initial?: { value: Record<string, unknown> }) {
+    if (initial) {
+      this.value = { ...initial.value };
+      this.cid = "cid-0";
+    } else {
+      this.value = null;
+      this.cid = null;
+    }
+  }
+
+  async read(): Promise<{ cid: string; value: Record<string, unknown> } | null> {
+    this.reads += 1;
+    if (this.failReadWith) throw this.failReadWith;
+    if (this.value === null || this.cid === null) return null;
+    return { cid: this.cid, value: { ...this.value } };
+  }
+
+  async write(
+    _rkey: string,
+    value: Record<string, unknown>,
+    swapRecord: string | null,
+  ): Promise<{ cid: string }> {
+    // A competitor commits between the transactor's read and this write.
+    if (this.interpose) {
+      const fn = this.interpose;
+      this.interpose = null;
+      fn();
+    }
+    this.writes += 1;
+    if (this.failWriteWith) throw this.failWriteWith;
+    if ((this.cid ?? null) !== (swapRecord ?? null)) {
+      throw new Error("InvalidSwap");
+    }
+    this.seq += 1;
+    this.cid = `cid-${this.seq}`;
+    this.value = { ...value };
+    return { cid: this.cid };
+  }
+
+  /** Commit a competing change directly (as if another writer won the race). */
+  commitExternal(mutate: (v: Record<string, unknown>) => Record<string, unknown>): void {
+    this.seq += 1;
+    this.cid = `ext-${this.seq}`;
+    this.value = mutate(this.value ? { ...this.value } : {});
+  }
+}
+
+describe("transactRecord", () => {
+  test("applies a field-scoped patch and preserves all other fields", async () => {
+    const store = new FakeStore({
+      value: { active: true, supportedModels: ["a"], unknownFutureField: 42 },
+    });
+    const { value } = await transactRecord(
+      store,
+      "rk",
+      (v) => ({ ...v, active: false }),
+      { sleep: noSleep },
+    );
+    assert.equal(value.active, false);
+    // Agent-authored + entirely-unknown fields ride through untouched — this is
+    // what makes a new field immune to the "forgot the allowlist" clobber.
+    assert.deepEqual(value.supportedModels, ["a"]);
+    assert.equal(value.unknownFutureField, 42);
+    assert.equal(store.writes, 1);
+  });
+
+  test("stampCreatedAt bumps createdAt to now; off by default", async () => {
+    const store = new FakeStore({ value: { active: true, createdAt: "2000-01-01T00:00:00.000Z" } });
+    const off = await transactRecord(store, "rk", (v) => ({ ...v }), { sleep: noSleep });
+    assert.equal(off.value.createdAt, "2000-01-01T00:00:00.000Z");
+
+    const before = Date.now();
+    const on = await transactRecord(store, "rk", (v) => ({ ...v }), {
+      sleep: noSleep,
+      stampCreatedAt: true,
+    });
+    const stamped = Date.parse(on.value.createdAt as string);
+    assert.ok(stamped >= before, "createdAt should be bumped to ~now");
+  });
+
+  test("retries on swap conflict and merges the competitor's change (last-writer-wins per field)", async () => {
+    const store = new FakeStore({ value: { active: true, proBono: { mode: "any" } } });
+    // Between our read and our write, a competing writer flips a DIFFERENT
+    // field (shareLocation) and commits, moving the CID. Our first write loses
+    // the swap; the transactor re-reads (now seeing shareLocation) and replays.
+    store.interpose = () => {
+      store.commitExternal((v) => ({ ...v, shareLocation: true }));
+    };
+    const { value } = await transactRecord(
+      store,
+      "rk",
+      (v) => ({ ...v, active: false }),
+      { sleep: noSleep },
+    );
+    assert.equal(store.writes, 2, "first write conflicts, second succeeds");
+    assert.equal(value.active, false, "our field wins (we committed last)");
+    assert.equal(value.shareLocation, true, "competitor's untouched field survives");
+    assert.deepEqual(value.proBono, { mode: "any" }, "pre-existing field survives");
+  });
+
+  test("a READ failure aborts the transaction and never writes", async () => {
+    const store = new FakeStore({ value: { active: true } });
+    store.failReadWith = new Error("503 Application failed to respond");
+    await assert.rejects(
+      () => transactRecord(store, "rk", (v) => ({ ...v, active: false }), { sleep: noSleep }),
+      /503/,
+    );
+    assert.equal(store.writes, 0, "must not write a guessed default on a failed read");
+    assert.equal(store.value?.active, true, "record untouched");
+  });
+
+  test("throws RecordNotFoundError when absent and createIfMissing is false", async () => {
+    const store = new FakeStore();
+    await assert.rejects(
+      () => transactRecord(store, "rk", (v) => ({ ...v, active: false }), { sleep: noSleep }),
+      RecordNotFoundError,
+    );
+    assert.equal(store.writes, 0);
+  });
+
+  test("creates the record (null swap) when createIfMissing is set", async () => {
+    const store = new FakeStore();
+    const { value } = await transactRecord(
+      store,
+      "rk",
+      (v) => ({ ...v, active: true, machineLabel: "new" }),
+      { sleep: noSleep, createIfMissing: true },
+    );
+    assert.equal(value.active, true);
+    assert.equal(value.machineLabel, "new");
+    assert.equal(store.writes, 1);
+  });
+
+  test("gives up after maxAttempts of persistent conflict, surfacing the conflict", async () => {
+    const store = new FakeStore({ value: { active: true } });
+    // Every write loses the swap (a relentless competitor).
+    const original = store.write.bind(store);
+    store.write = async (rkey, value, _swap) => original(rkey, value, "stale-cid-that-never-matches");
+    await assert.rejects(
+      () =>
+        transactRecord(store, "rk", (v) => ({ ...v, active: false }), {
+          sleep: noSleep,
+          maxAttempts: 3,
+        }),
+      isSwapConflict,
+    );
+    assert.equal(store.writes, 3, "tried exactly maxAttempts times");
+  });
+
+  test("a non-conflict write error is not retried", async () => {
+    const store = new FakeStore({ value: { active: true } });
+    store.failWriteWith = new Error("401 Unauthorized");
+    await assert.rejects(
+      () => transactRecord(store, "rk", (v) => ({ ...v, active: false }), { sleep: noSleep }),
+      /401/,
+    );
+    assert.equal(store.writes, 1, "auth errors fail fast, no retry");
+  });
+});
+
+describe("error classifiers", () => {
+  test("isSwapConflict matches InvalidSwap and descriptive forms only", () => {
+    assert.ok(isSwapConflict(new Error("InvalidSwap")));
+    assert.ok(isSwapConflict(new Error("Record was at bafy... but expected bafy...")));
+    assert.ok(isSwapConflict("invalid swap"));
+    assert.ok(!isSwapConflict(new Error("RecordNotFound")));
+    assert.ok(!isSwapConflict(new Error("503 upstream")));
+  });
+
+  test("isRecordNotFound matches 404 forms, not swap conflicts", () => {
+    assert.ok(isRecordNotFound(new Error("RecordNotFound")));
+    assert.ok(isRecordNotFound(new Error("Could not locate record")));
+    assert.ok(!isRecordNotFound(new Error("InvalidSwap")));
+    assert.ok(!isRecordNotFound(new Error("503 upstream")));
+  });
+});

--- a/packages/console/src/lib/record-transactor.server.ts
+++ b/packages/console/src/lib/record-transactor.server.ts
@@ -125,9 +125,7 @@ export async function transactRecord(
       throw new RecordNotFoundError(rkey);
     }
     const patched = patch(existing ? { ...existing.value } : {});
-    const value = stampCreatedAt
-      ? { ...patched, createdAt: new Date().toISOString() }
-      : patched;
+    const value = stampCreatedAt ? { ...patched, createdAt: new Date().toISOString() } : patched;
     try {
       const { cid } = await store.write(rkey, value, existing ? existing.cid : null);
       return { cid, value };
@@ -142,7 +140,5 @@ export async function transactRecord(
       throw err;
     }
   }
-  throw (
-    lastConflict ?? new Error(`transactRecord(${rkey}): exhausted ${maxAttempts} attempts`)
-  );
+  throw lastConflict ?? new Error(`transactRecord(${rkey}): exhausted ${maxAttempts} attempts`);
 }

--- a/packages/console/src/lib/record-transactor.server.ts
+++ b/packages/console/src/lib/record-transactor.server.ts
@@ -1,0 +1,148 @@
+// The single compare-and-swap read-modify-write path for mutating an ATProto
+// record. Every settings write in the console (and every agent write that
+// proxies through it) should go through `transactRecord` so concurrent writers
+// — the console UI, the provider agent, and a manual PDS edit — converge
+// deterministically against one set of rules:
+//
+//   1. PDS is the source of truth. Every attempt reads the LATEST record + CID
+//      and patches THAT, so a writer never commits on top of stale state.
+//   2. Field-scoped patches. A caller mutates only the keys it owns; all other
+//      keys — including fields this code has never heard of — carry through
+//      verbatim because the patch starts from the freshly-read body. Two
+//      writers touching different fields both land; two touching the same field
+//      resolve last-writer-wins. This is what replaces the fragile
+//      "rebuild-the-record-and-preserve-an-allowlist-of-other-people's-fields"
+//      pattern that silently dropped any field someone forgot to add to the
+//      list.
+//   3. CAS retry. A putRecord that loses the swap (`InvalidSwap` — the CID
+//      moved under us) re-reads the now-current record and retries the patch,
+//      bounded. The PDS arbitrates contention; whoever commits last wins.
+//   4. Fail-closed. A READ failure ABORTS the transaction (it throws); it never
+//      invents a default and writes it. Writing on a failed/blind read is
+//      exactly the class of bug that reverted owner settings on a transient
+//      blip.
+//
+// The transactor is intentionally storage-agnostic: it takes a `CasRecordStore`
+// so the logic is unit-testable without standing up an OAuth session, and the
+// PDS-backed store stays a thin adapter (see provider-record-pds.server.ts).
+
+/** A record store the transactor reads from and writes to under CAS. The
+ *  PDS-backed implementation wraps `com.atproto.repo.getRecord` /
+ *  `putRecord` over an OAuth session; tests inject an in-memory fake. */
+export interface CasRecordStore {
+  /** Read the current record body + its CID, or `null` when the record does
+   *  not exist. A transport/auth failure MUST throw (so the transaction
+   *  aborts) — returning `null` here would let a blip look like a missing
+   *  record and, with `createIfMissing`, fabricate one. */
+  read(rkey: string): Promise<{ cid: string; value: Record<string, unknown> } | null>;
+  /** Write `value` guarded by `swapRecord` (the CID the patch was applied to,
+   *  or `null` when creating a brand-new record). MUST throw a swap-conflict
+   *  error (recognised by {@link isSwapConflict}) when the CID has moved. */
+  write(
+    rkey: string,
+    value: Record<string, unknown>,
+    swapRecord: string | null,
+  ): Promise<{ cid: string }>;
+}
+
+/** Thrown when a transaction needs an existing record but none is present and
+ *  `createIfMissing` was not set. */
+export class RecordNotFoundError extends Error {
+  constructor(rkey: string) {
+    super(`no record at rkey ${rkey}`);
+    this.name = "RecordNotFoundError";
+  }
+}
+
+/** Whether an error is the ATProto optimistic-concurrency conflict — the
+ *  `swapRecord` CID no longer matches the record's current CID. The PDS raises
+ *  the named XRPC error `InvalidSwap`; the descriptive forms ("Record was at
+ *  …") are matched defensively. This is the signal to re-read and retry. */
+export function isSwapConflict(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return /invalid\s*swap|record\s+was\s+at|swap.*did\s*not\s*match/i.test(msg);
+}
+
+/** Whether a READ error means "the record genuinely isn't there" (a 404 /
+ *  `RecordNotFound` / "could not locate record"), as opposed to a transport or
+ *  auth failure that must abort the transaction. Adapters use this to decide
+ *  whether `read` returns `null` (absent) or rethrows (blip). */
+export function isRecordNotFound(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return /record\s*not\s*found|could\s*not\s*locate|not\s*found/i.test(msg);
+}
+
+export interface TransactOptions {
+  /** Total read-patch-CAS attempts before giving up. Each lost swap consumes
+   *  one. Default 6 — enough to ride out a burst of concurrent republishes. */
+  maxAttempts?: number;
+  /** Create the record (CAS against a null swap) when it doesn't exist yet,
+   *  instead of throwing {@link RecordNotFoundError}. Default false: most
+   *  console edits target a machine that has already served at least once. */
+  createIfMissing?: boolean;
+  /** Stamp `createdAt` to now on every write. The provider record treats
+   *  `createdAt` as a monotonic "last-published-at" that the AppView index and
+   *  the agent's dedup use to order conflicting writes, so an owner edit must
+   *  bump it to strictly win a lagging firehose replay. Default false — the
+   *  transactor core imposes no field convention; the provider wrapper opts in. */
+  stampCreatedAt?: boolean;
+  /** Backoff between attempts, injectable so tests run instantly. Receives the
+   *  1-based attempt number that just failed. */
+  sleep?: (attempt: number) => Promise<void>;
+}
+
+async function defaultBackoff(attempt: number): Promise<void> {
+  // Small jittered backoff so a thundering herd of republishes desynchronises.
+  const base = 40 * attempt;
+  const jitter = Math.floor(Math.random() * 40);
+  await new Promise((resolve) => setTimeout(resolve, base + jitter));
+}
+
+/**
+ * Apply `patch` to the latest version of record `rkey` under compare-and-swap,
+ * retrying on swap conflicts. Returns the committed CID + the value written.
+ *
+ * `patch` receives a shallow copy of the current record body (or `{}` when
+ * creating) and must return the next body. It should set ONLY the fields the
+ * caller owns and leave everything else as-is — that field-scoping is what
+ * makes concurrent writers safe.
+ */
+export async function transactRecord(
+  store: CasRecordStore,
+  rkey: string,
+  patch: (current: Record<string, unknown>) => Record<string, unknown>,
+  opts: TransactOptions = {},
+): Promise<{ cid: string; value: Record<string, unknown> }> {
+  const maxAttempts = Math.max(1, opts.maxAttempts ?? 6);
+  const stampCreatedAt = opts.stampCreatedAt ?? false;
+  const sleep = opts.sleep ?? defaultBackoff;
+  let lastConflict: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    // Read failures propagate here and abort the whole transaction — we never
+    // patch-and-write a guessed default on top of an unreadable record.
+    const existing = await store.read(rkey);
+    if (!existing && !opts.createIfMissing) {
+      throw new RecordNotFoundError(rkey);
+    }
+    const patched = patch(existing ? { ...existing.value } : {});
+    const value = stampCreatedAt
+      ? { ...patched, createdAt: new Date().toISOString() }
+      : patched;
+    try {
+      const { cid } = await store.write(rkey, value, existing ? existing.cid : null);
+      return { cid, value };
+    } catch (err) {
+      if (isSwapConflict(err) && attempt < maxAttempts) {
+        // Someone else committed between our read and write — re-read the now
+        // current record and replay the patch onto it.
+        lastConflict = err;
+        await sleep(attempt);
+        continue;
+      }
+      throw err;
+    }
+  }
+  throw (
+    lastConflict ?? new Error(`transactRecord(${rkey}): exhausted ${maxAttempts} attempts`)
+  );
+}

--- a/provider/src/advisor.rs
+++ b/provider/src/advisor.rs
@@ -355,7 +355,19 @@ impl AdvisorClient {
                 }
                 // A control re-read finished. Honour two owner changes: a
                 // stop (disconnect) and a model-set edit (restart to reload).
-                Some((next_active, desired, desired_tier)) = active_reads.next(), if !active_reads.is_empty() => {
+                Some(maybe_control) = active_reads.next(), if !active_reads.is_empty() => {
+                    // A `None` here means the control read couldn't be resolved
+                    // this cycle (the console proxy fronting the PDS read 502'd,
+                    // or the record momentarily didn't list) — owner intent is
+                    // UNKNOWN, so skip reconciliation entirely. Acting on the old
+                    // read-error defaults (best-effort tier + empty models) is
+                    // what made a transient blip look like the owner opting out
+                    // of confidential / clearing their models and trip a spurious
+                    // restart loop. Wait for the next poll / nudge instead.
+                    let Some((next_active, desired, desired_tier)) = maybe_control else {
+                        tracing::debug!("provider-control read unresolved this cycle; skipping reconciliation");
+                        continue;
+                    };
                     if !next_active {
                         // Owner stopped us — disconnect and let the outer loop
                         // hold us out of the registry until they start us again.
@@ -649,8 +661,13 @@ impl AdvisorClient {
 /// Read the owner's controls (start/stop switch + desired model set) off our
 /// PDS. A free fn (rather than two inline `async` blocks) so both
 /// `active_reads.push` sites produce the SAME future type — `FuturesUnordered`
-/// holds one anonymous type.
-async fn read_provider_control(pds: &PdsClient, rkey: &str) -> (bool, Vec<String>, Option<String>) {
+/// holds one anonymous type. `None` means the read couldn't be resolved (a
+/// transient blip); the caller skips reconciliation rather than acting on
+/// read-error defaults.
+async fn read_provider_control(
+    pds: &PdsClient,
+    rkey: &str,
+) -> Option<(bool, Vec<String>, Option<String>)> {
     pds.get_provider_control(rkey).await
 }
 

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -424,8 +424,16 @@ async fn cmd_set_desired_models(models: Vec<String>) -> Result<bool> {
         let current: Option<Vec<String>> = value
             .get("desiredModels")
             .and_then(|v| v.as_array())
-            .map(|a| a.iter().filter_map(|m| m.as_str().map(str::to_string)).collect());
-        let next: Option<Vec<String>> = if models.is_empty() { None } else { Some(models.clone()) };
+            .map(|a| {
+                a.iter()
+                    .filter_map(|m| m.as_str().map(str::to_string))
+                    .collect()
+            });
+        let next: Option<Vec<String>> = if models.is_empty() {
+            None
+        } else {
+            Some(models.clone())
+        };
         if current == next {
             return Ok(false); // already in the desired state — no write.
         }
@@ -442,11 +450,17 @@ async fn cmd_set_desired_models(models: Vec<String>) -> Result<bool> {
             .await
         {
             Ok(_) => {
-                tracing::info!(count = models.len(), "wrote desiredModels to PDS (owner model pick)");
+                tracing::info!(
+                    count = models.len(),
+                    "wrote desiredModels to PDS (owner model pick)"
+                );
                 return Ok(true);
             }
             Err(e) if is_swap_conflict(&e) && attempt < MAX_ATTEMPTS => {
-                tracing::warn!(attempt, "desiredModels swap lost a race; re-reading and retrying");
+                tracing::warn!(
+                    attempt,
+                    "desiredModels swap lost a race; re-reading and retrying"
+                );
                 tokio::time::sleep(std::time::Duration::from_millis(50 * attempt as u64)).await;
                 continue;
             }
@@ -791,7 +805,10 @@ async fn dedup_and_publish_provider(
 
         // Delete duplicate losers (best-effort; only need to run once).
         for (loser_rkey, loser_cid, _, _) in matching.iter().skip(1) {
-            match pds.delete_record(collection, loser_rkey, Some(loser_cid)).await {
+            match pds
+                .delete_record(collection, loser_rkey, Some(loser_cid))
+                .await
+            {
                 Ok(()) => {
                     deleted += 1;
                     tracing::info!(rkey = %loser_rkey, "deleted duplicate provider record");
@@ -809,7 +826,10 @@ async fn dedup_and_publish_provider(
             Err(e) if is_swap_conflict(&e) && attempt < MAX_ATTEMPTS => {
                 // Someone (a console edit, a sibling write) committed between our
                 // read and put. Re-read the now-current record and replay.
-                tracing::warn!(attempt, "provider record swap conflict; re-reading and retrying");
+                tracing::warn!(
+                    attempt,
+                    "provider record swap conflict; re-reading and retrying"
+                );
                 last_conflict = Some(e);
                 tokio::time::sleep(std::time::Duration::from_millis(50 * attempt as u64)).await;
                 continue;
@@ -894,7 +914,10 @@ async fn wait_until_active(pds: &cocore_provider::pds::PdsClient, rkey: Option<&
         // resolved (a transient PDS / console-proxy blip), distinct from a
         // confirmed `Some(active)`. Acting on that blip as if it were a real
         // value is the conflation that let a paused machine un-pause itself.
-        let read = pds.get_provider_control(rk).await.map(|(active, _, _)| active);
+        let read = pds
+            .get_provider_control(rk)
+            .await
+            .map(|(active, _, _)| active);
         if active_gate_decision(read, &mut confirmed_paused) == ActiveGate::Serve {
             clear_serving_paused();
             return;
@@ -3308,9 +3331,15 @@ mod active_gate_tests {
     #[test]
     fn confirmed_active_serves_and_confirmed_pause_waits() {
         let mut paused = false;
-        assert_eq!(active_gate_decision(Some(true), &mut paused), ActiveGate::Serve);
+        assert_eq!(
+            active_gate_decision(Some(true), &mut paused),
+            ActiveGate::Serve
+        );
         assert!(!paused);
-        assert_eq!(active_gate_decision(Some(false), &mut paused), ActiveGate::Wait);
+        assert_eq!(
+            active_gate_decision(Some(false), &mut paused),
+            ActiveGate::Wait
+        );
         assert!(paused, "a confirmed pause latches");
     }
 
@@ -3319,14 +3348,20 @@ mod active_gate_tests {
         // The regression: owner pauses (Some(false)); then the next read blips
         // (None). The machine must STAY paused — a blip can't un-pause it.
         let mut paused = false;
-        assert_eq!(active_gate_decision(Some(false), &mut paused), ActiveGate::Wait);
+        assert_eq!(
+            active_gate_decision(Some(false), &mut paused),
+            ActiveGate::Wait
+        );
         assert_eq!(
             active_gate_decision(None, &mut paused),
             ActiveGate::Wait,
             "an unresolved read must never un-pause a confirmed-paused machine"
         );
         // …and once the owner resumes (Some(true)), it serves.
-        assert_eq!(active_gate_decision(Some(true), &mut paused), ActiveGate::Serve);
+        assert_eq!(
+            active_gate_decision(Some(true), &mut paused),
+            ActiveGate::Serve
+        );
     }
 
     #[test]
@@ -3400,8 +3435,16 @@ mod offline_marker_tests {
 
         let merged = merge_agent_provider_fields(&live, &offline);
 
-        assert_eq!(merged.get("active"), Some(&serde_json::json!(false)), "pause preserved");
-        assert_eq!(merged.get("serving"), Some(&serde_json::json!(false)), "agent serving=false applied");
+        assert_eq!(
+            merged.get("active"),
+            Some(&serde_json::json!(false)),
+            "pause preserved"
+        );
+        assert_eq!(
+            merged.get("serving"),
+            Some(&serde_json::json!(false)),
+            "agent serving=false applied"
+        );
     }
 
     /// The reverse must also hold: quitting a SERVING machine must not
@@ -3438,9 +3481,15 @@ mod offline_marker_tests {
         assert_eq!(merged.get("payoutsEnabled"), Some(&serde_json::json!(true)));
         assert_eq!(
             merged.get("desiredModels"),
-            Some(&serde_json::json!(["mlx-community/Qwen2.5-3B-Instruct-4bit", "stub"]))
+            Some(&serde_json::json!([
+                "mlx-community/Qwen2.5-3B-Instruct-4bit",
+                "stub"
+            ]))
         );
-        assert_eq!(merged.get("desiredTier"), Some(&serde_json::json!("attested-confidential")));
+        assert_eq!(
+            merged.get("desiredTier"),
+            Some(&serde_json::json!("attested-confidential"))
+        );
         assert_eq!(
             merged.get("proBono"),
             Some(&serde_json::json!({ "mode": "direct", "dids": ["did:plc:friend"] }))
@@ -3473,7 +3522,8 @@ mod offline_marker_tests {
     #[test]
     fn merge_overwrites_agent_fields_and_clears_absent_ones() {
         let mut rebuilt = agent_built_record();
-        rebuilt.supportedModels = vec!["mlx-community/gemma-3-4b-it-qat-4bit".into(), "stub".into()];
+        rebuilt.supportedModels =
+            vec!["mlx-community/gemma-3-4b-it-qat-4bit".into(), "stub".into()];
         // Healthy this serve: no fault, not confidential, not sharing location.
         rebuilt.engineFault = None;
         rebuilt.tier = None;
@@ -3491,7 +3541,10 @@ mod offline_marker_tests {
         // Always-present agent field overwritten.
         assert_eq!(
             merged.get("supportedModels"),
-            Some(&serde_json::json!(["mlx-community/gemma-3-4b-it-qat-4bit", "stub"]))
+            Some(&serde_json::json!([
+                "mlx-community/gemma-3-4b-it-qat-4bit",
+                "stub"
+            ]))
         );
         // Stale agent-authored optional fields cleared.
         assert_eq!(merged.get("engineFault"), None, "cleared fault");
@@ -3512,7 +3565,11 @@ mod offline_marker_tests {
 
         let merged = merge_agent_provider_fields(&live, &rebuilt);
 
-        assert_eq!(merged.get("active"), Some(&serde_json::json!(false)), "owner value wins");
+        assert_eq!(
+            merged.get("active"),
+            Some(&serde_json::json!(false)),
+            "owner value wins"
+        );
         assert_eq!(
             merged.get("desiredModels"),
             Some(&serde_json::json!(["owner-choice"])),
@@ -3528,7 +3585,10 @@ mod offline_marker_tests {
         let merged = merge_agent_provider_fields(&serde_json::json!({}), &rebuilt);
 
         assert_eq!(merged.get("chip"), Some(&serde_json::json!("Apple M1")));
-        assert_eq!(merged.get("supportedModels"), Some(&serde_json::json!(["stub"])));
+        assert_eq!(
+            merged.get("supportedModels"),
+            Some(&serde_json::json!(["stub"]))
+        );
         assert_eq!(merged.get("active"), None);
         assert_eq!(merged.get("desiredModels"), None);
     }

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -217,7 +217,7 @@ async fn main() -> Result<()> {
         Cmd::Agent(AgentCmd::Confidential { off }) => cmd_set_confidential(!off).await,
         Cmd::Agent(AgentCmd::Doctor { console, fix }) => doctor::run(&console, fix).await,
         Cmd::Agent(AgentCmd::Update { console, check }) => update::run(&console, check).await,
-        Cmd::Agent(AgentCmd::Models(cmd)) => models_cli::run(cmd),
+        Cmd::Agent(AgentCmd::Models(cmd)) => models_cli::run(cmd).await,
         Cmd::Agent(AgentCmd::Pause) => cmd_set_active(false).await,
         Cmd::Agent(AgentCmd::Resume) => cmd_set_active(true).await,
         Cmd::Agent(AgentCmd::Active) => cmd_print_active().await,
@@ -386,6 +386,68 @@ async fn cmd_set_confidential(on: bool) -> Result<()> {
                     attempt,
                     "desiredTier swap lost a race; re-reading and retrying"
                 );
+                continue;
+            }
+            Err(e) => return Err(e.into()),
+        }
+    }
+    unreachable!("loop returns on success, on the final attempt, or on a non-swap error")
+}
+
+/// `cocore agent models set/add/remove` percolation: write the owner's model
+/// pick to `desiredModels` on this machine's provider record — the SAME field
+/// the console's model picker writes. This is what makes a tray model change
+/// percolate to the PDS source of truth (and from there to the AppView, the
+/// confidential native engine, and any serving sibling that reconciles), rather
+/// than only living in the local LaunchAgent plist. An empty list REMOVES the
+/// field (revert to the machine's local default). Field-scoped CAS on the CID
+/// with a bounded retry, exactly like `cmd_set_active`: it patches only
+/// `desiredModels` and leaves every other (agent + owner) field untouched.
+///
+/// A missing record (the machine hasn't served yet, so nothing to patch onto)
+/// is a no-op — the caller's local plist write still applies and first serve
+/// publishes the full record. Returns whether a write actually happened.
+async fn cmd_set_desired_models(models: Vec<String>) -> Result<bool> {
+    let (pds, pubkey) = open_pds()?;
+    const MAX_ATTEMPTS: u32 = 5;
+    for attempt in 1..=MAX_ATTEMPTS {
+        let find = find_my_provider_record(&pds, &pubkey).await;
+        if find.is_err() {
+            // No provider record yet — nothing to patch `desiredModels` onto.
+            // The local plist still carries the set; first serve publishes it.
+            tracing::info!(
+                "no provider record yet; skipped desiredModels PDS write (local config carries the set until first serve)"
+            );
+            return Ok(false);
+        }
+        let (rkey, mut value, cid) = find?;
+        let current: Option<Vec<String>> = value
+            .get("desiredModels")
+            .and_then(|v| v.as_array())
+            .map(|a| a.iter().filter_map(|m| m.as_str().map(str::to_string)).collect());
+        let next: Option<Vec<String>> = if models.is_empty() { None } else { Some(models.clone()) };
+        if current == next {
+            return Ok(false); // already in the desired state — no write.
+        }
+        // Patch ONLY desiredModels; everything else rides through untouched.
+        if let Some(obj) = value.as_object_mut() {
+            if models.is_empty() {
+                obj.remove("desiredModels");
+            } else {
+                obj.insert("desiredModels".to_string(), serde_json::json!(models));
+            }
+        }
+        match pds
+            .put_record("dev.cocore.compute.provider", &rkey, &value, Some(&cid))
+            .await
+        {
+            Ok(_) => {
+                tracing::info!(count = models.len(), "wrote desiredModels to PDS (owner model pick)");
+                return Ok(true);
+            }
+            Err(e) if is_swap_conflict(&e) && attempt < MAX_ATTEMPTS => {
+                tracing::warn!(attempt, "desiredModels swap lost a race; re-reading and retrying");
+                tokio::time::sleep(std::time::Duration::from_millis(50 * attempt as u64)).await;
                 continue;
             }
             Err(e) => return Err(e.into()),
@@ -651,48 +713,12 @@ fn kickstart_launchagent_if_installed() {
     // either picks it up at next start or needs a manual restart.
 }
 
-/// Overlay the owner/console-authored fields (`active`, `payoutsEnabled`,
-/// `desiredModels`, `desiredTier`) from an existing PDS record onto a record the
-/// agent is about to (re-)publish.
-///
-/// The agent NEVER authors these — the console writes them (the start/stop
-/// switch, Stripe-Connect payouts eligibility, the model picker). They are
-/// all `#[serde(skip_serializing_if = "Option::is_none")]`, and the agent
-/// builds its in-memory record with them as `None`, so any write that doesn't
-/// carry them forward OMITS them from the record. That's silently destructive:
-/// an absent `active` reads back as the default `true`, so a write that drops
-/// it UN-PAUSES a machine the owner just paused. Both the startup dedup
-/// re-publish and the graceful-shutdown offline marker funnel through here so
-/// neither can clobber the switches.
-fn preserve_console_fields(record: &mut ProviderRecord, existing: &serde_json::Value) {
-    record.active = existing.get("active").and_then(|v| v.as_bool());
-    record.payoutsEnabled = existing.get("payoutsEnabled").and_then(|v| v.as_bool());
-    record.desiredModels = existing
-        .get("desiredModels")
-        .and_then(|v| v.as_array())
-        .map(|a| {
-            a.iter()
-                .filter_map(|m| m.as_str().map(str::to_string))
-                .collect::<Vec<_>>()
-        });
-    // The owner's confidential opt-in (console/tray "Upgrade security"). Like
-    // the others it's console-written and the agent must carry it through, or a
-    // serve restart would silently drop the owner's choice to go confidential.
-    record.desiredTier = existing
-        .get("desiredTier")
-        .and_then(|v| v.as_str())
-        .map(str::to_string);
-    // The owner's pro-bono election (console / tray "serve pro bono"). Like
-    // the others it's console-written; carry it through or a serve restart
-    // would silently drop the owner's choice to give work away free.
-    record.proBono = ProBonoPolicy::from_record_value(existing);
-    // The owner's location-sharing opt-in (console "Share country" switch).
-    // Console-written like the others — carry it through, or a serve restart
-    // would silently drop the owner's choice. The agent reads this to decide
-    // whether to stamp `region` (see `cmd_serve`); preserving it keeps the
-    // switch sticky across re-publishes.
-    record.shareLocation = existing.get("shareLocation").and_then(|v| v.as_bool());
-}
+// Owner-intent field preservation is no longer a hand-rolled allowlist
+// (`preserve_console_fields`). Every agent re-publish now goes through
+// `dedup_and_publish_provider`, which merges the agent's authored fields onto
+// the LATEST record via `cocore_provider::pds::merge_agent_provider_fields` —
+// owner-intent fields AND any unknown/future field are preserved by default, so
+// a new owner setting can't be silently clobbered by an agent write.
 
 /// Find this machine's existing provider record (if any) on the
 /// user's PDS by matching `attestationPubKey`, delete any other
@@ -711,100 +737,89 @@ async fn dedup_and_publish_provider(
     attestation_pub_key: &str,
     record: &ProviderRecord,
 ) -> anyhow::Result<(cocore_provider::pds::PublishedRecord, bool, usize)> {
+    // The single agent write path for this machine's provider record: a
+    // compare-and-swap read-modify-write that reads the LATEST record, merges
+    // the agent's authored fields onto it (owner-intent + unknown fields
+    // preserved — see `merge_agent_provider_fields`), and putRecords under a
+    // swap guard, retrying on `InvalidSwap` by re-reading. A read failure
+    // aborts — we never publish a fabricated body on a blind read. It also
+    // dedups: a DID that holds several records with our attestationPubKey
+    // (stale reinstall dupes) keeps the newest and deletes the rest.
+    const MAX_ATTEMPTS: u32 = 6;
     let collection = "dev.cocore.compute.provider";
-    let listed = pds.list_my_records(collection).await?;
-    // Group by attestationPubKey; keep records that match ours.
-    // Each matching tuple carries the existing record's body so we
-    // can preserve fields the agent doesn't manage (notably
-    // `payoutsEnabled`, set by the console's Stripe-Connect reconcile)
-    // when we re-publish on startup.
-    let mut matching: Vec<(String, String, String, serde_json::Value)> = Vec::new();
-    let mut other_pubkey_count = 0usize;
-    for r in &listed {
-        let rkey = r.uri.rsplit('/').next().unwrap_or("").to_string();
-        let key = r.value.get("attestationPubKey").and_then(|v| v.as_str());
-        let created_at = r
-            .value
-            .get("createdAt")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
-        match key {
-            Some(k) if k == attestation_pub_key => {
-                matching.push((rkey, r.cid.clone(), created_at, r.value.clone()));
-            }
-            Some(_) => {
-                other_pubkey_count += 1;
-            }
-            None => {
-                // No attestationPubKey — pre-2026-05 record from before
-                // the field was required; leave alone.
+    let mut deleted = 0usize;
+    let mut last_conflict: Option<cocore_provider::error::ProviderError> = None;
+    for attempt in 1..=MAX_ATTEMPTS {
+        // Read latest. A transport/auth failure propagates and ABORTS — the
+        // republish never invents a record on top of an unreadable PDS.
+        let listed = pds.list_my_records(collection).await?;
+        let mut matching: Vec<(String, String, String, serde_json::Value)> = Vec::new();
+        let mut other_pubkey_count = 0usize;
+        for r in &listed {
+            let rkey = r.uri.rsplit('/').next().unwrap_or("").to_string();
+            let key = r.value.get("attestationPubKey").and_then(|v| v.as_str());
+            let created_at = r
+                .value
+                .get("createdAt")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            match key {
+                Some(k) if k == attestation_pub_key => {
+                    matching.push((rkey, r.cid.clone(), created_at, r.value.clone()));
+                }
+                Some(_) => other_pubkey_count += 1,
+                // No attestationPubKey — pre-2026-05 record; leave alone.
+                None => {}
             }
         }
-    }
-    if other_pubkey_count > 0 {
-        tracing::info!(
-            other_pubkey_count,
-            "saw provider records on this DID with a different attestationPubKey — those describe other machines; leaving alone"
-        );
-    }
-    // Sort newest-first by createdAt; the head wins.
-    matching.sort_by(|a, b| b.2.cmp(&a.2));
-    let mut kept_existing = false;
-    let mut deleted = 0usize;
-    let chosen_rkey = if let Some((rkey, _, _, _)) = matching.first() {
-        kept_existing = true;
-        // Delete losers.
+        if attempt == 1 && other_pubkey_count > 0 {
+            tracing::info!(
+                other_pubkey_count,
+                "saw provider records on this DID with a different attestationPubKey — those describe other machines; leaving alone"
+            );
+        }
+        // Sort newest-first by createdAt; the head is canonical.
+        matching.sort_by(|a, b| b.2.cmp(&a.2));
+
+        let Some((rkey, cid, _, existing_value)) = matching.first().cloned() else {
+            // First publish: no record yet. The agent authors everything; owner
+            // fields are absent (correct for a brand-new machine).
+            let published = pds.publish_provider(record).await?;
+            return Ok((published, false, deleted));
+        };
+
+        // Delete duplicate losers (best-effort; only need to run once).
         for (loser_rkey, loser_cid, _, _) in matching.iter().skip(1) {
-            match pds
-                .delete_record(collection, loser_rkey, Some(loser_cid))
-                .await
-            {
+            match pds.delete_record(collection, loser_rkey, Some(loser_cid)).await {
                 Ok(()) => {
                     deleted += 1;
                     tracing::info!(rkey = %loser_rkey, "deleted duplicate provider record");
                 }
                 Err(e) => {
-                    // Non-fatal: surface and move on. The dedup is
-                    // best-effort; partial cleanup is better than
-                    // none, and the user can re-run on next serve.
-                    tracing::warn!(error = %e, rkey = %loser_rkey, "failed to delete duplicate provider record");
+                    tracing::warn!(error = %e, rkey = %loser_rkey, "failed to delete duplicate provider record")
                 }
             }
         }
-        Some(rkey.clone())
-    } else {
-        None
-    };
 
-    let published = match chosen_rkey {
-        Some(rkey) => {
-            // Refresh the swapRecord (CID) right before the put — the
-            // delete loop above might've changed nothing, but a
-            // future caller could have written between our list and
-            // our put. Re-getRecord is overkill; pass the CID we saw
-            // at list time. If a swap conflict happens, the user
-            // re-running serve will re-list and recover.
-            let (swap, existing_value) = matching
-                .first()
-                .map(|(_, cid, _, val)| (cid.clone(), val.clone()))
-                .unwrap_or_default();
-            // Preserve the owner/console-authored switches from the kept
-            // record (see `preserve_console_fields`): the agent never authors
-            // them, and re-publishing without them resets the DID's
-            // payouts-eligibility and restarts a machine the owner stopped.
-            let mut merged = record.clone();
-            preserve_console_fields(&mut merged, &existing_value);
-            pds.put_provider(
-                &rkey,
-                &merged,
-                if swap.is_empty() { None } else { Some(&swap) },
-            )
-            .await?
+        // Merge the agent's fields onto the LATEST body and CAS-put.
+        let merged = cocore_provider::pds::merge_agent_provider_fields(&existing_value, record);
+        match pds.put_record(collection, &rkey, &merged, Some(&cid)).await {
+            Ok(published) => return Ok((published, true, deleted)),
+            Err(e) if is_swap_conflict(&e) && attempt < MAX_ATTEMPTS => {
+                // Someone (a console edit, a sibling write) committed between our
+                // read and put. Re-read the now-current record and replay.
+                tracing::warn!(attempt, "provider record swap conflict; re-reading and retrying");
+                last_conflict = Some(e);
+                tokio::time::sleep(std::time::Duration::from_millis(50 * attempt as u64)).await;
+                continue;
+            }
+            Err(e) => return Err(e.into()),
         }
-        None => pds.publish_provider(record).await?,
-    };
-    Ok((published, kept_existing, deleted))
+    }
+    Err(last_conflict
+        .map(anyhow::Error::from)
+        .unwrap_or_else(|| anyhow::anyhow!("provider record publish exhausted retries")))
 }
 
 /// `~/.cocore/serving-paused` — present while the owner has this machine
@@ -832,14 +847,55 @@ fn clear_serving_paused() {
 /// tray reflects it; clears it once we're active again. This is what makes
 /// a console "Stop serving" actually pause the machine: the agent stays out
 /// of the advisor's registry (no jobs) until the owner starts it.
+/// Whether the serve gate should connect now or keep waiting.
+#[derive(Debug, PartialEq, Eq)]
+enum ActiveGate {
+    Serve,
+    Wait,
+}
+
+/// Pure decision for {@link wait_until_active}: given this poll's `active` read
+/// — `None` means the read couldn't be RESOLVED (a transient blip), `Some(b)`
+/// is a confirmed value — and whether we've previously confirmed a pause,
+/// decide whether to serve or keep waiting, latching `confirmed_paused`.
+///
+/// The invariant this encodes: a read blip must NEVER flip the decision. Once
+/// we've confirmed the owner paused us, an unresolved read keeps us paused (it
+/// can't un-pause us). Until we've ever confirmed a pause, an unresolved read
+/// serves optimistically so a PDS outage doesn't strand a healthy machine — the
+/// advisor's own control poll re-checks and disconnects if we were wrong.
+fn active_gate_decision(read: Option<bool>, confirmed_paused: &mut bool) -> ActiveGate {
+    match read {
+        Some(true) => ActiveGate::Serve,
+        Some(false) => {
+            *confirmed_paused = true;
+            ActiveGate::Wait
+        }
+        None => {
+            if *confirmed_paused {
+                ActiveGate::Wait
+            } else {
+                ActiveGate::Serve
+            }
+        }
+    }
+}
+
 async fn wait_until_active(pds: &cocore_provider::pds::PdsClient, rkey: Option<&str>) {
     let Some(rk) = rkey else {
         clear_serving_paused();
         return;
     };
     let mut announced = false;
+    // Whether we've CONFIRMED (via a successful read) that the owner paused us.
+    let mut confirmed_paused = false;
     loop {
-        if pds.get_provider_active(rk).await.unwrap_or(true) {
+        // `get_provider_control` returns `None` ONLY when the read couldn't be
+        // resolved (a transient PDS / console-proxy blip), distinct from a
+        // confirmed `Some(active)`. Acting on that blip as if it were a real
+        // value is the conflation that let a paused machine un-pause itself.
+        let read = pds.get_provider_control(rk).await.map(|(active, _, _)| active);
+        if active_gate_decision(read, &mut confirmed_paused) == ActiveGate::Serve {
             clear_serving_paused();
             return;
         }
@@ -945,13 +1001,22 @@ async fn prepare_native_confidential_model() {
         tracing::info!("native MLX model already configured via env; skipping download probe");
         return;
     }
-    // Choose the model: the owner's first non-`stub` desiredModels, else the
-    // small default. The native engine serves a single model.
-    let model = read_my_desired_models()
-        .await
-        .into_iter()
-        .find(|m| m != "stub")
-        .unwrap_or_else(|| DEFAULT_MODEL.to_string());
+    // Choose the model the native engine serves (it serves exactly one): the
+    // owner's PDS `desiredModels` (website picker) first, then the local
+    // `COCORE_INFERENCE_MODELS` the macOS tray / launchd plist set, then the
+    // small default. The tray sets its model choice through the plist, NOT
+    // `desiredModels`, so reading `desiredModels` alone made every tray-
+    // configured confidential machine ignore the owner's pick and fall back to
+    // the default. The singular `COCORE_INFERENCE_MODEL` is honoured for plist
+    // back-compat, matching `build_engines`.
+    let inference_models_env = std::env::var("COCORE_INFERENCE_MODELS")
+        .or_else(|_| std::env::var("COCORE_INFERENCE_MODEL"))
+        .ok();
+    let model = pick_confidential_native_model(
+        &read_my_desired_models().await,
+        inference_models_env.as_deref(),
+        DEFAULT_MODEL,
+    );
 
     // Resolve the venv interpreter the install script bootstrapped.
     let venv_python = std::env::var("COCORE_PYTHON_VENV")
@@ -1061,18 +1126,46 @@ async fn read_my_desired_models() -> Vec<String> {
     let Ok(signer) = secure_enclave::load_or_create_identity() else {
         return Vec::new();
     };
-    match find_my_provider_record(&pds, &signer.public_key_b64()).await {
-        Ok((_, value, _)) => value
-            .get("desiredModels")
-            .and_then(|v| v.as_array())
-            .map(|a| {
-                a.iter()
-                    .filter_map(|m| m.as_str().map(str::to_string))
-                    .collect()
-            })
-            .unwrap_or_default(),
-        Err(_) => Vec::new(),
+    let pubkey = signer.public_key_b64();
+    // The console proxy that fronts these PDS reads 502s transiently. A failed
+    // read here used to fall straight through to the hardcoded default model —
+    // silently overriding the owner's website model pick and serving (and
+    // downloading) the WRONG model until the next restart happened to read
+    // cleanly. Retry a few times with short backoff so a blip doesn't downgrade
+    // the model; a record that genuinely lists no `desiredModels` still yields
+    // an empty list on the first read (Ok path) with no retry.
+    const ATTEMPTS: u32 = 3;
+    for attempt in 1..=ATTEMPTS {
+        match find_my_provider_record(&pds, &pubkey).await {
+            Ok((_, value, _)) => {
+                return value
+                    .get("desiredModels")
+                    .and_then(|v| v.as_array())
+                    .map(|a| {
+                        a.iter()
+                            .filter_map(|m| m.as_str().map(str::to_string))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+            }
+            Err(e) if attempt < ATTEMPTS => {
+                tracing::warn!(
+                    error = %e,
+                    attempt,
+                    "couldn't read desiredModels (transient read / no record yet); retrying before any fallback to the default model"
+                );
+                tokio::time::sleep(std::time::Duration::from_secs(2 * attempt as u64)).await;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "couldn't read desiredModels after retries; falling back to the default confidential model"
+                );
+                return Vec::new();
+            }
+        }
     }
+    Vec::new()
 }
 
 /// Non-confidential builds: no push host, serve directly on the main runtime.
@@ -1531,8 +1624,9 @@ async fn cmd_serve(
         // idle machine. `None` clears any stale fault on a clean (re-)attestation.
         attestationFault: boot_attestation.fault.clone(),
         // Coarse, opt-in location resolved above (refresh-on-serve). Absent
-        // when sharing is off or the lookup failed. Agent-authored, so it is
-        // deliberately NOT in `preserve_console_fields`.
+        // when sharing is off or the lookup failed. Agent-authored, so the merge
+        // overwrites it when present and CLEARS it when absent (it's in
+        // `AGENT_OPTIONAL_KEYS`) — turning off sharing drops the stale region.
         region,
         regionSource: region_source,
         regionObservedAt: region_observed_at,
@@ -1858,8 +1952,6 @@ async fn cmd_serve(
                 // those fields, CAS-ing on the CID we just read so we don't
                 // race the pause's own write.
                 let publish = async {
-                    let (rk, value, cid) =
-                        find_my_provider_record(&pds, &attestation_pub_key).await?;
                     let mut offline = provider_record.clone();
                     offline.serving = Some(false);
                     offline.provisioning = Some(false);
@@ -1867,14 +1959,15 @@ async fn cmd_serve(
                     // machine simply stopped serving.
                     offline.engineFault = None;
                     offline.createdAt = chrono::Utc::now();
-                    // Preserve the owner/console-authored switches verbatim —
-                    // crucially `active`, so a machine paused moments ago stays
-                    // paused instead of being un-paused by this write.
-                    preserve_console_fields(&mut offline, &value);
-                    pds.put_provider(&rk, &offline, Some(&cid)).await
+                    // The single CAS write path merges this onto the LATEST
+                    // record — preserving the owner's `active` (so a machine
+                    // paused moments ago stays paused instead of being un-paused
+                    // by this marker) and every other owner/unknown field — and
+                    // retries on a swap conflict.
+                    dedup_and_publish_provider(&pds, &attestation_pub_key, &offline).await
                 };
                 match tokio::time::timeout(std::time::Duration::from_secs(5), publish).await {
-                    Ok(Ok(published)) => tracing::info!(uri = %published.uri, "published provider record with serving=false (active/payouts/desiredModels preserved)"),
+                    Ok(Ok((published, _, _))) => tracing::info!(uri = %published.uri, "published provider record with serving=false (owner switches preserved)"),
                     Ok(Err(e)) => tracing::warn!(error = %e, "failed to publish offline marker (active switch left intact)"),
                     Err(_) => tracing::warn!("offline-marker publish timed out after 5s"),
                 }
@@ -2083,15 +2176,15 @@ async fn republish_attestation_fault(
     fault: Option<AttestationFault>,
 ) {
     let publish = async {
-        let (rk, value, cid) = find_my_provider_record(pds, attestation_pub_key).await?;
         let mut rec = base_record.clone();
         rec.attestationFault = fault.clone();
         // Mid-serve: the machine is up and past provisioning.
         rec.serving = Some(true);
         rec.provisioning = Some(false);
         rec.createdAt = chrono::Utc::now();
-        preserve_console_fields(&mut rec, &value);
-        pds.put_provider(&rk, &rec, Some(&cid)).await
+        // Single CAS write path: merges onto the latest record (owner switches +
+        // unknown fields preserved) and retries on conflict.
+        dedup_and_publish_provider(pds, attestation_pub_key, &rec).await
     };
     match tokio::time::timeout(std::time::Duration::from_secs(10), publish).await {
         Ok(Ok(_)) => {}
@@ -2280,6 +2373,47 @@ fn inference_models_action(confidential: bool, desired: &[String]) -> InferenceM
     } else {
         InferenceModelsAction::Set(desired.join(","))
     }
+}
+
+/// Pick the single model a confidential machine's native (in-process) MLX
+/// engine should serve, from the owner's intent.
+///
+/// Mirrors the best-effort priority in {@link inference_models_action}: the PDS
+/// `desiredModels` (the web-console model picker) wins, then the local
+/// `COCORE_INFERENCE_MODELS` the macOS tray and launchd plist set, then a small
+/// default. The native engine serves exactly ONE model, so we take the first
+/// non-`stub` entry from whichever source is populated.
+///
+/// The two sources matter because the tray and the website set the owner's
+/// choice through DIFFERENT channels: the website writes PDS `desiredModels`,
+/// while the tray's "Add a model" runs `cocore agent models`, which edits the
+/// LaunchAgent plist's `COCORE_INFERENCE_MODELS` and bounces the daemon (it does
+/// NOT write `desiredModels`). The best-effort path already honours both — it
+/// loads `desiredModels` when present and otherwise leaves the plist value in
+/// place. Confidential native selection has to honour both too, or a machine
+/// configured from the tray (the common case) silently ignores the owner's pick
+/// and serves the default.
+// Only called from the apns-gated confidential path, but kept un-gated so its
+// unit tests build (and run) on every platform — like `inference_models_action`.
+#[cfg_attr(not(all(target_os = "macos", feature = "apns")), allow(dead_code))]
+fn pick_confidential_native_model(
+    desired_models: &[String],
+    inference_models_env: Option<&str>,
+    default_model: &str,
+) -> String {
+    let first_servable = |raw: &str| {
+        raw.split(',')
+            .map(str::trim)
+            .find(|m| !m.is_empty() && *m != "stub")
+            .map(str::to_string)
+    };
+    desired_models
+        .iter()
+        .map(|s| s.trim())
+        .find(|m| !m.is_empty() && *m != "stub")
+        .map(str::to_string)
+        .or_else(|| inference_models_env.and_then(first_servable))
+        .unwrap_or_else(|| default_model.to_string())
 }
 
 /// Build the per-model engine registry for this serve invocation.
@@ -2976,6 +3110,60 @@ mod inference_models_action_tests {
             InferenceModelsAction::Leave
         );
     }
+
+    const DEFAULT: &str = "mlx-community/Qwen2.5-0.5B-Instruct-4bit";
+
+    #[test]
+    fn confidential_native_prefers_pds_desired_models() {
+        // The website picker (PDS `desiredModels`) wins, even when the tray
+        // plist also set something. First non-`stub` entry, order preserved.
+        assert_eq!(
+            pick_confidential_native_model(
+                &v(&["stub", "mlx-community/gemma-3-4b-it-qat-4bit"]),
+                Some("mlx-community/Qwen2.5-7B-Instruct-4bit"),
+                DEFAULT,
+            ),
+            "mlx-community/gemma-3-4b-it-qat-4bit"
+        );
+    }
+
+    #[test]
+    fn confidential_native_falls_back_to_tray_plist_env() {
+        // The common case: configured from the tray, which sets the plist's
+        // `COCORE_INFERENCE_MODELS` and never writes `desiredModels`. Without
+        // this fallback the machine ignored the owner's pick (the bug).
+        assert_eq!(
+            pick_confidential_native_model(
+                &[],
+                Some("mlx-community/gemma-3-4b-it-qat-4bit,stub"),
+                DEFAULT,
+            ),
+            "mlx-community/gemma-3-4b-it-qat-4bit"
+        );
+        // `stub` is never a servable native pick — skip it in the env list too.
+        assert_eq!(
+            pick_confidential_native_model(
+                &v(&["stub"]),
+                Some("stub , mlx-community/gemma-3-4b-it-qat-4bit"),
+                DEFAULT,
+            ),
+            "mlx-community/gemma-3-4b-it-qat-4bit"
+        );
+    }
+
+    #[test]
+    fn confidential_native_defaults_when_no_owner_choice() {
+        // Neither source has a servable model → the small default.
+        assert_eq!(pick_confidential_native_model(&[], None, DEFAULT), DEFAULT);
+        assert_eq!(
+            pick_confidential_native_model(&v(&["stub"]), Some("stub"), DEFAULT),
+            DEFAULT
+        );
+        assert_eq!(
+            pick_confidential_native_model(&[], Some(""), DEFAULT),
+            DEFAULT
+        );
+    }
 }
 
 #[cfg(test)]
@@ -3114,6 +3302,45 @@ mod vision_fault_tests {
 }
 
 #[cfg(test)]
+mod active_gate_tests {
+    use super::*;
+
+    #[test]
+    fn confirmed_active_serves_and_confirmed_pause_waits() {
+        let mut paused = false;
+        assert_eq!(active_gate_decision(Some(true), &mut paused), ActiveGate::Serve);
+        assert!(!paused);
+        assert_eq!(active_gate_decision(Some(false), &mut paused), ActiveGate::Wait);
+        assert!(paused, "a confirmed pause latches");
+    }
+
+    #[test]
+    fn a_read_blip_after_a_confirmed_pause_stays_paused() {
+        // The regression: owner pauses (Some(false)); then the next read blips
+        // (None). The machine must STAY paused — a blip can't un-pause it.
+        let mut paused = false;
+        assert_eq!(active_gate_decision(Some(false), &mut paused), ActiveGate::Wait);
+        assert_eq!(
+            active_gate_decision(None, &mut paused),
+            ActiveGate::Wait,
+            "an unresolved read must never un-pause a confirmed-paused machine"
+        );
+        // …and once the owner resumes (Some(true)), it serves.
+        assert_eq!(active_gate_decision(Some(true), &mut paused), ActiveGate::Serve);
+    }
+
+    #[test]
+    fn a_read_blip_with_no_prior_pause_serves_optimistically() {
+        // A PDS outage at startup (never confirmed a pause) must not strand a
+        // healthy machine offline — serve, and let the advisor's control poll
+        // catch a pause if there is one.
+        let mut paused = false;
+        assert_eq!(active_gate_decision(None, &mut paused), ActiveGate::Serve);
+        assert!(!paused);
+    }
+}
+
+#[cfg(test)]
 mod offline_marker_tests {
     use super::*;
     use cocore_provider::pds::{ProviderRecord, TrustLevel};
@@ -3159,26 +3386,22 @@ mod offline_marker_tests {
         }
     }
 
+    use cocore_provider::pds::merge_agent_provider_fields;
+
     /// The regression: a machine the owner just PAUSED (`active=false` on the
-    /// live PDS record) must stay paused after the agent writes its
-    /// shutdown offline marker. Before the fix the marker was the
-    /// agent-built record (active=None) written blind, which omitted
-    /// `active` and let it read back as the default `true` — un-pausing the
-    /// machine so the tray reconciler restarted it.
+    /// live PDS record) must stay paused after the agent writes its shutdown
+    /// offline marker. The marker is the agent-built record (`active=None`);
+    /// merging it onto the live record must keep the live `active=false`.
     #[test]
     fn offline_marker_keeps_a_paused_machine_paused() {
         let mut offline = agent_built_record();
         offline.serving = Some(false);
         let live = serde_json::json!({ "active": false, "serving": true });
 
-        preserve_console_fields(&mut offline, &live);
+        let merged = merge_agent_provider_fields(&live, &offline);
 
-        assert_eq!(offline.active, Some(false), "pause must be preserved");
-        // And it must SERIALIZE with active:false present — the whole bug was
-        // the field being omitted, so an absent field reading back as `true`.
-        let json = serde_json::to_value(&offline).unwrap();
-        assert_eq!(json.get("active"), Some(&serde_json::json!(false)));
-        assert_eq!(json.get("serving"), Some(&serde_json::json!(false)));
+        assert_eq!(merged.get("active"), Some(&serde_json::json!(false)), "pause preserved");
+        assert_eq!(merged.get("serving"), Some(&serde_json::json!(false)), "agent serving=false applied");
     }
 
     /// The reverse must also hold: quitting a SERVING machine must not
@@ -3189,72 +3412,124 @@ mod offline_marker_tests {
         offline.serving = Some(false);
         let live = serde_json::json!({ "active": true });
 
-        preserve_console_fields(&mut offline, &live);
+        let merged = merge_agent_provider_fields(&live, &offline);
 
-        assert_eq!(offline.active, Some(true));
+        assert_eq!(merged.get("active"), Some(&serde_json::json!(true)));
     }
 
-    /// `payoutsEnabled` and `desiredModels` ride the same path and must be
-    /// carried through too (regression guard for the broader clobber).
+    /// Every owner-intent field on the live record rides through an agent
+    /// re-publish untouched — the agent never authors them, so the merge keeps
+    /// the live values verbatim.
     #[test]
-    fn offline_marker_preserves_payouts_and_desired_models() {
-        let mut offline = agent_built_record();
+    fn merge_preserves_all_owner_intent_fields() {
+        let offline = agent_built_record();
         let live = serde_json::json!({
             "active": false,
             "payoutsEnabled": true,
             "desiredModels": ["mlx-community/Qwen2.5-3B-Instruct-4bit", "stub"],
-            "desiredTier": "attested-confidential"
-        });
-
-        preserve_console_fields(&mut offline, &live);
-
-        assert_eq!(offline.payoutsEnabled, Some(true));
-        assert_eq!(
-            offline.desiredModels,
-            Some(vec![
-                "mlx-community/Qwen2.5-3B-Instruct-4bit".to_string(),
-                "stub".to_string()
-            ])
-        );
-        // The owner's confidential opt-in survives a re-publish.
-        assert_eq!(
-            offline.desiredTier,
-            Some("attested-confidential".to_string())
-        );
-    }
-
-    /// The owner's console-written pro-bono election and location-sharing
-    /// opt-in ride the same preserve path — a re-publish must not drop them.
-    #[test]
-    fn preserve_carries_pro_bono_and_share_location() {
-        let mut rebuilt = agent_built_record();
-        let live = serde_json::json!({
+            "desiredTier": "attested-confidential",
             "proBono": { "mode": "direct", "dids": ["did:plc:friend"] },
             "shareLocation": true
         });
 
-        preserve_console_fields(&mut rebuilt, &live);
+        let merged = merge_agent_provider_fields(&live, &offline);
 
-        let pro_bono = rebuilt.proBono.expect("pro-bono election preserved");
-        assert_eq!(pro_bono.mode, "direct");
-        assert_eq!(pro_bono.dids, vec!["did:plc:friend".to_string()]);
-        assert_eq!(rebuilt.shareLocation, Some(true));
+        assert_eq!(merged.get("active"), Some(&serde_json::json!(false)));
+        assert_eq!(merged.get("payoutsEnabled"), Some(&serde_json::json!(true)));
+        assert_eq!(
+            merged.get("desiredModels"),
+            Some(&serde_json::json!(["mlx-community/Qwen2.5-3B-Instruct-4bit", "stub"]))
+        );
+        assert_eq!(merged.get("desiredTier"), Some(&serde_json::json!("attested-confidential")));
+        assert_eq!(
+            merged.get("proBono"),
+            Some(&serde_json::json!({ "mode": "direct", "dids": ["did:plc:friend"] }))
+        );
+        assert_eq!(merged.get("shareLocation"), Some(&serde_json::json!(true)));
     }
 
-    /// When the live record has no switches set (a brand-new machine), the
-    /// fields stay `None` — we don't fabricate values.
+    /// THE property that kills the whole bug class: a field this agent build has
+    /// never heard of (a future owner setting) is preserved by default. The old
+    /// allowlist would have dropped it.
     #[test]
-    fn offline_marker_leaves_absent_switches_absent() {
-        let mut offline = agent_built_record();
-        let live = serde_json::json!({ "serving": true });
+    fn merge_preserves_an_unknown_future_field() {
+        let offline = agent_built_record();
+        let live = serde_json::json!({
+            "active": true,
+            "someFutureOwnerToggle": { "nested": [1, 2, 3] }
+        });
 
-        preserve_console_fields(&mut offline, &live);
+        let merged = merge_agent_provider_fields(&live, &offline);
 
-        assert_eq!(offline.active, None);
-        assert_eq!(offline.payoutsEnabled, None);
-        assert_eq!(offline.desiredModels, None);
-        assert_eq!(offline.desiredTier, None);
-        assert!(offline.proBono.is_none());
-        assert_eq!(offline.shareLocation, None);
+        assert_eq!(
+            merged.get("someFutureOwnerToggle"),
+            Some(&serde_json::json!({ "nested": [1, 2, 3] })),
+            "an unknown field must survive an agent re-publish"
+        );
+    }
+
+    /// The agent OWNS its fields: it overwrites present ones and CLEARS the
+    /// optional ones it no longer emits (a stale tier / engineFault / region).
+    #[test]
+    fn merge_overwrites_agent_fields_and_clears_absent_ones() {
+        let mut rebuilt = agent_built_record();
+        rebuilt.supportedModels = vec!["mlx-community/gemma-3-4b-it-qat-4bit".into(), "stub".into()];
+        // Healthy this serve: no fault, not confidential, not sharing location.
+        rebuilt.engineFault = None;
+        rebuilt.tier = None;
+        rebuilt.region = None;
+        let live = serde_json::json!({
+            "supportedModels": ["old-model"],
+            "engineFault": { "code": "stale", "message": "old", "models": [], "at": "2020-01-01T00:00:00Z" },
+            "tier": "attested-confidential",
+            "region": "US",
+            "active": true
+        });
+
+        let merged = merge_agent_provider_fields(&live, &rebuilt);
+
+        // Always-present agent field overwritten.
+        assert_eq!(
+            merged.get("supportedModels"),
+            Some(&serde_json::json!(["mlx-community/gemma-3-4b-it-qat-4bit", "stub"]))
+        );
+        // Stale agent-authored optional fields cleared.
+        assert_eq!(merged.get("engineFault"), None, "cleared fault");
+        assert_eq!(merged.get("tier"), None, "cleared achieved tier");
+        assert_eq!(merged.get("region"), None, "cleared region");
+        // Owner field still preserved.
+        assert_eq!(merged.get("active"), Some(&serde_json::json!(true)));
+    }
+
+    /// Defence in depth: even if a bug populated an owner-intent field on the
+    /// agent record, the merge must NOT write it — the live value wins.
+    #[test]
+    fn merge_never_lets_the_agent_write_an_owner_field() {
+        let mut rebuilt = agent_built_record();
+        rebuilt.active = Some(true); // agent erroneously authoring an owner field
+        rebuilt.desiredModels = Some(vec!["agent-should-not-set-this".into()]);
+        let live = serde_json::json!({ "active": false, "desiredModels": ["owner-choice"] });
+
+        let merged = merge_agent_provider_fields(&live, &rebuilt);
+
+        assert_eq!(merged.get("active"), Some(&serde_json::json!(false)), "owner value wins");
+        assert_eq!(
+            merged.get("desiredModels"),
+            Some(&serde_json::json!(["owner-choice"])),
+            "agent can never overwrite the owner's model pick"
+        );
+    }
+
+    /// First publish (empty base): the agent authors everything; owner-intent
+    /// fields are simply absent, which is correct for a brand-new machine.
+    #[test]
+    fn merge_onto_empty_base_yields_agent_fields_only() {
+        let rebuilt = agent_built_record();
+        let merged = merge_agent_provider_fields(&serde_json::json!({}), &rebuilt);
+
+        assert_eq!(merged.get("chip"), Some(&serde_json::json!("Apple M1")));
+        assert_eq!(merged.get("supportedModels"), Some(&serde_json::json!(["stub"])));
+        assert_eq!(merged.get("active"), None);
+        assert_eq!(merged.get("desiredModels"), None);
     }
 }

--- a/provider/src/models_cli.rs
+++ b/provider/src/models_cli.rs
@@ -70,14 +70,14 @@ const ENV_KEY: &str = "EnvironmentVariables:COCORE_INFERENCE_MODELS";
 #[cfg(target_os = "macos")]
 const LEGACY_ENV_KEY: &str = "EnvironmentVariables:COCORE_INFERENCE_MODEL";
 
-pub fn run(cmd: ModelsCmd) -> Result<()> {
+pub async fn run(cmd: ModelsCmd) -> Result<()> {
     match cmd {
         ModelsCmd::List => list(),
         ModelsCmd::Set { models } => {
             let next = normalize(&models);
             let prev = read_current().unwrap_or_default();
             let added: Vec<String> = next.iter().filter(|m| !prev.contains(m)).cloned().collect();
-            commit(&next, "set", &added)
+            commit(&next, "set", &added).await
         }
         ModelsCmd::Add { model } => {
             // Resolve the model id: either the explicit positional or
@@ -111,7 +111,7 @@ pub fn run(cmd: ModelsCmd) -> Result<()> {
                 return Ok(());
             }
             current.push(m.clone());
-            commit(&current, "add", std::slice::from_ref(&m))
+            commit(&current, "add", std::slice::from_ref(&m)).await
         }
         ModelsCmd::Remove { model } => {
             let m = model.trim();
@@ -122,7 +122,7 @@ pub fn run(cmd: ModelsCmd) -> Result<()> {
                 println!("'{m}' was not in the list; no change.");
                 return Ok(());
             }
-            commit(&current, "remove", &[])
+            commit(&current, "remove", &[]).await
         }
     }
 }
@@ -185,11 +185,33 @@ fn normalize(raw: &str) -> Vec<String> {
     out
 }
 
-fn commit(models: &[String], verb: &str, await_models: &[String]) -> Result<()> {
+async fn commit(models: &[String], verb: &str, await_models: &[String]) -> Result<()> {
     let joined = models.join(",");
+
+    // Percolate the owner's model pick to the PDS source of truth FIRST, on
+    // every platform: write `desiredModels` (the same field the website's model
+    // picker sets) so the choice propagates to the AppView, the confidential
+    // native engine, and any serving sibling that reconciles — not just the
+    // local plist. On macOS this complements the plist+bounce below; on a
+    // never-served machine it's a no-op (the plist carries the set until first
+    // serve). A failure here is non-fatal on macOS (the local plist write still
+    // drives this machine, and the next serve republish reconciles), but we
+    // surface it so the user knows cross-device sync is delayed.
+    let pds_wrote = match crate::cmd_set_desired_models(models.to_vec()).await {
+        Ok(wrote) => wrote,
+        Err(e) => {
+            tracing::warn!(error = %e, "couldn't write desiredModels to PDS");
+            eprintln!(
+                "warning: couldn't sync your model choice to your account ({e}). \
+                 Applied locally; it will sync on the next serve."
+            );
+            false
+        }
+    };
 
     #[cfg(target_os = "macos")]
     {
+        let _ = pds_wrote;
         let plist = plist_path()?;
         write_env_var(&plist, ENV_KEY, &joined)
             .with_context(|| format!("updating {ENV_KEY} in {}", plist.display()))?;
@@ -246,12 +268,24 @@ fn commit(models: &[String], verb: &str, await_models: &[String]) -> Result<()> 
     }
     #[cfg(not(target_os = "macos"))]
     {
-        let _ = (models, verb, await_models, joined);
-        anyhow::bail!(
-            "`cocore agent models` mutations require macOS today (the plist + LaunchAgent live there). \
-             On Linux, edit your service-manager env file to set COCORE_INFERENCE_MODELS and restart \
-             the unit."
-        )
+        let _ = (verb, await_models, joined);
+        // On Linux there's no LaunchAgent to edit/bounce, but the PDS write
+        // above IS the action: a serving agent reconciles `desiredModels` on its
+        // ~30s poll (and restarts to reload). So this is no longer a hard error.
+        if pds_wrote {
+            println!(
+                "Wrote your model selection ({} model(s)) to your account. A running agent will \
+                 reconcile within ~30s and reload; restart the service to apply immediately.",
+                models.len()
+            );
+            Ok(())
+        } else {
+            anyhow::bail!(
+                "Couldn't sync the model selection — this machine has no provider record yet \
+                 (has it served at least once?). On Linux, also set COCORE_INFERENCE_MODELS in \
+                 your service-manager env file and restart the unit."
+            )
+        }
     }
 }
 

--- a/provider/src/pds.rs
+++ b/provider/src/pds.rs
@@ -181,6 +181,106 @@ pub struct ProviderRecord {
     pub createdAt: chrono::DateTime<chrono::Utc>,
 }
 
+/// Owner-INTENT fields on the provider record. The console (web UI and, via the
+/// proxy, the tray) is the ONLY writer of these; the agent reconciles its
+/// runtime toward them but must NEVER author them. They are the contested
+/// settings, so the merge below treats the latest PDS value as authoritative
+/// and the agent's republish leaves them exactly as-is.
+///
+/// This is the one list that must stay in sync with the lexicon's owner-intent
+/// fields. Adding a new owner setting? Add its key here (and the console writes
+/// it). Forgetting to is the failure we are designing OUT — see
+/// {@link merge_agent_provider_fields}, which preserves unknown keys by default,
+/// so even an owner field missing from this list is carried through rather than
+/// clobbered. The list exists only so the agent can defensively refuse to write
+/// these even if a bug populated them.
+pub const OWNER_INTENT_KEYS: &[&str] = &[
+    "active",
+    "payoutsEnabled",
+    "desiredModels",
+    "desiredTier",
+    "proBono",
+    "shareLocation",
+];
+
+/// Agent-authored OPTIONAL fields — present some serves, absent others (a tier
+/// the machine earned then lost, an engineFault that cleared, region when the
+/// owner turns location sharing off). The agent owns these, so when it does NOT
+/// emit one this serve the merge must DELETE it from the published record, or a
+/// stale value would linger. Always-present agent fields (chip, ram,
+/// supportedModels, keys, …) don't need listing — the overlay overwrites them
+/// every serve regardless.
+///
+/// A new agent optional field forgotten here just goes stale (the old value
+/// lingers until the next field-setting serve) — benign, and never touches
+/// owner data. Contrast the old `preserve_console_fields` allowlist, whose
+/// omission silently DESTROYED an owner setting.
+const AGENT_OPTIONAL_KEYS: &[&str] = &[
+    "gpuCores",
+    "memoryBandwidthGBs",
+    "cpuCores",
+    "pCores",
+    "eCores",
+    "modelIdentifier",
+    "os",
+    "tier",
+    "acceptedExchanges",
+    "contactEndpoint",
+    "binaryVersion",
+    "provisioning",
+    "serving",
+    "engineFault",
+    "attestationFault",
+    "region",
+    "regionSource",
+    "regionObservedAt",
+];
+
+/// Produce the JSON body the agent should publish for its provider record, by
+/// applying its freshly-built `agent_record` onto the LATEST record body read
+/// from the PDS (`base`). This is the field-ownership merge that replaces the
+/// old "rebuild the record and copy an allowlist of the owner's fields onto it"
+/// (`preserve_console_fields`) — inverted so the safe default is PRESERVE:
+///
+///   1. Start from `base` (the latest PDS body) — so every key, including
+///      owner-intent fields AND any field this build has never heard of, is
+///      carried through by default. A new owner setting can never be clobbered.
+///   2. Overlay every key the agent authored this serve (present in the
+///      serialized `agent_record`), except — defensively — any owner-intent key
+///      (the agent must never write those; it builds them as `None` so they're
+///      already absent, but we strip them belt-and-suspenders).
+///   3. Delete any agent-authored OPTIONAL key the agent did NOT emit this
+///      serve, so a tier/fault/region the machine no longer has doesn't linger.
+///
+/// The result is then written under compare-and-swap by the caller, so a
+/// concurrent owner edit either is already in `base` (and preserved) or wins
+/// the swap and forces a re-read.
+pub fn merge_agent_provider_fields(
+    base: &serde_json::Value,
+    agent_record: &ProviderRecord,
+) -> serde_json::Value {
+    let mut out = base.as_object().cloned().unwrap_or_default();
+    let patch = serde_json::to_value(agent_record).unwrap_or(serde_json::Value::Null);
+    let patch_obj = patch.as_object();
+    // (3) Clear agent-authored optional fields the agent isn't emitting now.
+    for key in AGENT_OPTIONAL_KEYS {
+        let emitted_now = patch_obj.map(|o| o.contains_key(*key)).unwrap_or(false);
+        if !emitted_now {
+            out.remove(*key);
+        }
+    }
+    // (2) Overlay the agent's authored fields, never an owner-intent field.
+    if let Some(obj) = patch_obj {
+        for (k, v) in obj {
+            if OWNER_INTENT_KEYS.contains(&k.as_str()) {
+                continue;
+            }
+            out.insert(k.clone(), v.clone());
+        }
+    }
+    serde_json::Value::Object(out)
+}
+
 /// The owner's pro-bono election for a machine, mirroring the lexicon
 /// `dev.cocore.compute.provider#proBonoPolicy`. Decides, per requester,
 /// whether a job is served free + unmetered with no exchange cut.
@@ -516,23 +616,34 @@ impl PdsClient {
 
     /// Read the owner-set controls — the `active` start/stop switch, the
     /// `desiredModels` list, and the `desiredTier` intent — from this DID's
-    /// provider record at `rkey` in one list. Defaults: `active` true
-    /// (serving) when absent, `desired` empty when absent, `desiredTier` None
-    /// when absent. On any read error returns the serving default with an
-    /// empty list and no tier so a transient blip never looks like a stop, a
-    /// model change, or a tier change. The agent polls this to honour remote
-    /// pause + model changes; the serve loop also restarts on a `desiredTier`
-    /// change so the supervisor can re-select the confidential worker binary.
-    pub async fn get_provider_control(&self, rkey: &str) -> (bool, Vec<String>, Option<String>) {
-        let Ok(listed) = self.list_my_records("dev.cocore.compute.provider").await else {
-            return (true, Vec::new(), None);
-        };
-        let Some(rec) = listed
+    /// provider record at `rkey` in one list. Within the record the per-field
+    /// defaults are: `active` true (serving) when absent, `desired` empty when
+    /// absent, `desiredTier` None when absent.
+    ///
+    /// Returns `None` when the controls couldn't be determined — the list read
+    /// failed (the console proxy fronting these reads 502s transiently) OR no
+    /// record currently matches `rkey`. The caller MUST treat `None` as "owner
+    /// intent unknown THIS cycle" and skip reconciliation, NOT as a reset to
+    /// defaults. A previous version returned `(true, [], None)` on a read
+    /// error, which a transient blip made indistinguishable from the owner
+    /// clearing their models AND opting out of the confidential tier
+    /// (`desiredTier` None normalises to best-effort) — so every blip tripped a
+    /// spurious "tier/models changed" restart and the machine churned. Reading
+    /// `None` here is the only blip-safe contract. The agent polls this to
+    /// honour remote pause + model changes; the serve loop also restarts on a
+    /// `desiredTier` change so the supervisor can re-select the confidential
+    /// worker binary.
+    pub async fn get_provider_control(
+        &self,
+        rkey: &str,
+    ) -> Option<(bool, Vec<String>, Option<String>)> {
+        let listed = self
+            .list_my_records("dev.cocore.compute.provider")
+            .await
+            .ok()?;
+        let rec = listed
             .iter()
-            .find(|r| r.uri.rsplit('/').next() == Some(rkey))
-        else {
-            return (true, Vec::new(), None);
-        };
+            .find(|r| r.uri.rsplit('/').next() == Some(rkey))?;
         let active = rec
             .value
             .get("active")
@@ -553,7 +664,7 @@ impl PdsClient {
             .get("desiredTier")
             .and_then(|v| v.as_str())
             .map(str::to_string);
-        (active, desired, desired_tier)
+        Some((active, desired, desired_tier))
     }
 
     /// Walk the DID PLC directory to find this DID's PDS host. The


### PR DESCRIPTION
## Why

Settings configured in the **tray**, on the **console/appview**, or **directly on a PDS record** must all converge — last-writer-wins, with the **PDS authoritative** on contention. We kept re-hitting this (most recently: a confidential machine serving the wrong model + a spurious restart loop) because the pieces of a correct system existed but weren't unified, so every new field re-introduced the same bug class: a rebuild-and-preserve-an-allowlist write that silently dropped any field someone forgot to list, plus read paths that treated a transient failure as an authoritative "owner reset to defaults."

## The rule (one, enforced in two mirrored implementations)

> Every mutation is a **field-scoped patch applied to the LATEST PDS record, read under compare-and-swap, retried on `InvalidSwap`, aborted on read failure.**

A writer sets only the keys it owns; all other keys — owner-intent, agent-authored, **and unknown/future** — ride through by default. Result: last-writer-wins per field, different fields never collide, PDS wins (decisions read PDS, CAS is against the PDS CID), and a failed read never writes a guessed default.

## Changes

**TypeScript (console — the chokepoint all UI + agent-proxy writes funnel through)**
- New `record-transactor.server.ts`: `transactRecord(store, rkey, patch, opts)` — read→patch→CAS→retry→abort-on-read-error. Storage-agnostic (`CasRecordStore`) so it's unit-testable.
- All six `setProviderRecord*` are now one-line patches through it. **Adds the previously-missing CAS retry** — a concurrent agent republish used to make a console write throw `InvalidSwap` and silently lose the user's setting.

**Rust agent**
- `merge_agent_provider_fields` **replaces and deletes `preserve_console_fields`** (the fragile owner-field allowlist). Inverts the model: start from the latest record (preserve everything), overlay agent-authored keys, clear absent agent-*optional* keys, never touch `OWNER_INTENT_KEYS`. A new owner setting is preserved automatically; a forgotten agent field merely goes stale (benign).
- `dedup_and_publish_provider` is now a CAS-retry loop using it; the shutdown offline-marker and `republish_attestation_fault` route through it too.
- **Tray model picks now percolate**: `cocore agent models` writes PDS `desiredModels` (`cmd_set_desired_models`, CAS) in addition to the local plist — closing the gap that made a tray model change never reach PDS (also makes the command work on Linux).
- **Fail-closed reads**: `wait_until_active` uses a pure `active_gate_decision` so a read blip can't un-pause a confirmed-paused machine (advisor's 30s control poll backstops). Coheres with the earlier `get_provider_control`→`Option`, `read_my_desired_models` retry, and `pick_confidential_native_model` fixes.

## Tests
- **TS (10):** patch + preserve; `createdAt` bump; **conflict → re-read → merge competitor's change** (last-writer-wins); **read failure aborts without writing**; create-if-missing; exhaust-retries; non-conflict errors fail fast; classifiers.
- **Rust (10):** paused-stays-paused; serving-stays-serving; all owner fields preserved; **an unknown future field survives**; agent overwrites/clears its own fields; **agent can never write an owner field**; empty-base create; + 3 `active_gate` blip-safety tests.

All green: provider `cargo clippy` (default + `apns`) clean, 163 lib + 39 bin tests; console `tsc` clean, transactor 10/10.

## Scope notes
- Append-only records (settlement/receipt) intentionally don't use the transactor — creates with no read-modify-write contention.
- Ships in a new agent build + console deploy; machines converge after updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)