### PR TITLE
chore(release): bump version to 0.9.33

### DIFF
--- a/provider-shell/Sources/CoCoreShell/Resources/Info.plist
+++ b/provider-shell/Sources/CoCoreShell/Resources/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleName</key>
 	<string>co/core</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.32</string>
+	<string>0.9.33</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -22,7 +22,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>932</string>
+	<string>933</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/provider/Cargo.lock
+++ b/provider/Cargo.lock
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "cocore-provider"
-version = "0.9.32"
+version = "0.9.33"
 dependencies = [
  "anyhow",
  "asn1-rs",

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cocore-provider"
-version = "0.9.32"
+version = "0.9.33"
 edition = "2021"
 description = "co/core provider agent: runs hardened compute and publishes signed receipts to AT Protocol."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Cuts **0.9.33**. Ships everything accumulated on `main` since v0.9.32 that only reaches machines via a release (both the app Updater and `cocore agent update` are version-gated):

- **#132** — record transactor / settings-sync fixes (Rust agent): wrong-model, restart churn, pause stickiness, tray model→PDS percolation.
- **#131** — Secure Mode wizard: treat "device not yet in NanoMDM" 500 as pending, not a failure (tray).
- **#130** — Secure Mode: no false "enabled" screen when not attested (tray).

Bumps `provider/Cargo.toml`, `provider/Cargo.lock`, and `Info.plist` (`CFBundleShortVersionString` 0.9.33 / `CFBundleVersion` 933). Notarized app + cdHash registration are done from the local build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)