### PR TITLE
fix(native-mlx): stop on chat-turn delimiters (runaway <end_of_turn>)

### DIFF
--- a/provider/mlx-engine/Sources/CoCoreMLX/MLXEngine.swift
+++ b/provider/mlx-engine/Sources/CoCoreMLX/MLXEngine.swift
@@ -30,7 +30,9 @@ public final class MLXEngine {
     /// everything else loads through `LLMModelFactory`. Both return a uniform
     /// `ModelContainer`, so generation below is identical.
     public static func load(modelDir: String) async throws -> MLXEngine {
-        let config = ModelConfiguration(directory: URL(fileURLWithPath: modelDir))
+        let config = ModelConfiguration(
+            directory: URL(fileURLWithPath: modelDir),
+            extraEOSTokens: extraEOSTokens(modelDir: modelDir))
         let container: ModelContainer
         if isVisionModelDir(modelDir) {
             container = try await VLMModelFactory.shared.loadContainer(configuration: config)
@@ -49,6 +51,62 @@ public final class MLXEngine {
             let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
         else { return false }
         return obj["vision_config"] != nil
+    }
+
+    /// Stop tokens that must end generation but that the loaded tokenizer may
+    /// not expose as its single `eosTokenId`.
+    ///
+    /// Instruction-tuned models close each turn with a delimiter token —
+    /// Gemma's `<end_of_turn>`, Qwen/ChatML's `<|im_end|>`, Llama-3's
+    /// `<|eot_id|>` — that is listed in `generation_config.json`'s
+    /// `eos_token_id` and baked into the chat template, yet swift-transformers
+    /// only loads the lone `eos_token` from `tokenizer_config.json` as the
+    /// stop id. Without these the model emits its turn-ender forever (it never
+    /// counts as a stop) until `maxTokens` — the runaway-`<end_of_turn>` bug.
+    ///
+    /// We resolve every id in `generation_config.json`'s `eos_token_id` to its
+    /// string form via `tokenizer_config.json`'s `added_tokens_decoder`, and
+    /// union a small static set of well-known chat delimiters as a safety net
+    /// for models with a missing/partial `generation_config.json`. Strings a
+    /// given model doesn't have resolve to nil downstream
+    /// (`convertTokenToId`) and are simply ignored.
+    private static func extraEOSTokens(modelDir: String) -> Set<String> {
+        var tokens: Set<String> = ["<end_of_turn>", "<|im_end|>", "<|eot_id|>", "<|end|>"]
+        let dir = URL(fileURLWithPath: modelDir)
+
+        // id -> token string, from tokenizer_config.json's added_tokens_decoder.
+        var idToContent: [Int: String] = [:]
+        if let data = try? Data(
+            contentsOf: dir.appendingPathComponent("tokenizer_config.json")),
+            let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let decoder = obj["added_tokens_decoder"] as? [String: Any]
+        {
+            for (idStr, info) in decoder {
+                if let id = Int(idStr), let info = info as? [String: Any],
+                    let content = info["content"] as? String
+                {
+                    idToContent[id] = content
+                }
+            }
+        }
+
+        // eos_token_id (Int or [Int]) from generation_config.json — the
+        // authoritative stop set the model was trained/exported with.
+        if let data = try? Data(
+            contentsOf: dir.appendingPathComponent("generation_config.json")),
+            let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        {
+            var ids: [Int] = []
+            if let one = obj["eos_token_id"] as? Int {
+                ids = [one]
+            } else if let many = obj["eos_token_id"] as? [Int] {
+                ids = many
+            }
+            for id in ids {
+                if let content = idToContent[id] { tokens.insert(content) }
+            }
+        }
+        return tokens
     }
 
     /// Stream a completion token-by-token through `onDelta`, in-process.


### PR DESCRIPTION
## Problem

Native-engine generation runs away on instruction-tuned models. After a correct completion, the model emits its turn-ender (`<end_of_turn>` for gemma) repeatedly, then collapses into degenerate output (a run of dots), continuing until `max_tokens`:

```
mlx-community/gemma-3-4b-it-qat-4bit
...could be a professional, perhaps in a creative field.<end_of_turn><end_of_turn><end_of_turn>...........
```

## Root cause

The upstream generation loop ([`Evaluate.swift:621-622`](https://github.com/ml-explore/mlx-swift-examples)) stops on exactly: `unknownTokenId`, the tokenizer's single `eosTokenId`, or `additionalEOSTokenIds` (built from `ModelConfiguration.extraEOSTokens`).

- Gemma's `tokenizer_config.json` sets `eos_token` = `<eos>` (id 1), so that's the only `eosTokenId`.
- But the instruction-tuned chat template trains the model to end turns with `<end_of_turn>` (id 106). Gemma's `generation_config.json` knows this (`eos_token_id: [1, 106]`), but swift-transformers only loads the lone `eos_token`.
- `MLXEngine.load` built `ModelConfiguration(directory:)` with `extraEOSTokens` left empty, so id 106 was **never** a stop token → runaway.

**Intermittent** ("some models, some times") because the model only *sometimes* samples `<eos>` (stops cleanly) vs `<end_of_turn>` (runs away); and only multi-delimiter models (gemma, Qwen/ChatML, Llama-3) are affected. The subprocess/vllm-mlx path already reads the full EOS list and was never affected.

## Fix

`MLXEngine.load` now resolves the model's real stop set and passes it as `extraEOSTokens`:

1. Read `generation_config.json` `eos_token_id` (scalar or list).
2. Map each id → token string via `tokenizer_config.json` `added_tokens_decoder`.
3. Union a static safety net of well-known chat delimiters (`<end_of_turn>`, `<|im_end|>`, `<|eot_id|>`, `<|end|>`) for models with a missing/partial `generation_config.json`.

Strings a given model doesn't define resolve to nil via `convertTokenToId` downstream and are ignored, so the extras are harmless. Native engine only.

## Testing

- `swift build` passes.
- Not run end-to-end: no gemma-3 snapshot on the build machine. Quickest manual confirm is the `cocore-mlx-smoke` harness against a local gemma-3 model dir — should now stop cleanly at `<end_of_turn>`.

## Shipping note

The fix compiles into `libCoCoreMLX.dylib`, so it reaches the fleet only via a **rebuilt provider binary** (native-release build + version bump), not a code merge alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)