### PR TITLE
chore(release): bump version to 0.9.34

### DIFF
--- a/provider-shell/Sources/CoCoreShell/Resources/Info.plist
+++ b/provider-shell/Sources/CoCoreShell/Resources/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleName</key>
 	<string>co/core</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.33</string>
+	<string>0.9.34</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -22,7 +22,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>933</string>
+	<string>934</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/provider/Cargo.lock
+++ b/provider/Cargo.lock
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "cocore-provider"
-version = "0.9.33"
+version = "0.9.34"
 dependencies = [
  "anyhow",
  "asn1-rs",

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cocore-provider"
-version = "0.9.33"
+version = "0.9.34"
 edition = "2021"
 description = "co/core provider agent: runs hardened compute and publishes signed receipts to AT Protocol."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Release **0.9.34**.

Ships the native-MLX runaway-`<end_of_turn>` fix ([#135](https://github.com/graze-social/cocore/pull/135)): the in-process confidential engine now resolves the model's real stop set from `generation_config.json` (mapped via `tokenizer_config.json`'s `added_tokens_decoder`) plus a static chat-delimiter safety net, and passes it as `extraEOSTokens`. Instruction-tuned models (gemma, Qwen/ChatML, Llama-3) now stop at their turn delimiter instead of looping until `max_tokens`.

Native/confidential build only — it reaches machines via the notarized app bundle, so a release is required. The confidential worker's cdHash will be appended to the advisor's known-good set as part of `make mac-release`.

Version bumped in `provider/Cargo.toml`, `provider/Cargo.lock`, and `Info.plist` (`0.9.34` / build `934`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)