### PR TITLE
fix(subprocess): don't abort tool-call streams on slow first token (#133)

### DIFF
--- a/packages/console/src/lib/openai-chat-completions.server.ts
+++ b/packages/console/src/lib/openai-chat-completions.server.ts
@@ -681,6 +681,7 @@ export function streamingResponse(
   const stream = new ReadableStream<Uint8Array>({
     async start(controller) {
       const send = (s: string) => controller.enqueue(encoder.encode(`data: ${s}\n\n`));
+      let emittedToolCalls = false;
       // OpenAI clients expect a leading role-only delta.
       send(chunkPayload(id, model, { role: "assistant" }, null));
 
@@ -692,6 +693,7 @@ export function streamingResponse(
             if (ev.channel === "tool_call") {
               try {
                 const toolCalls = JSON.parse(ev.text);
+                emittedToolCalls = true;
                 send(chunkPayload(id, model, { tool_calls: toolCalls }, null));
               } catch {
                 // Malformed tool_call JSON — skip rather than crash the stream.
@@ -704,10 +706,19 @@ export function streamingResponse(
               send(chunkPayload(id, model, delta, null));
             }
           } else if (ev.kind === "complete") {
-            // The final `stop` chunk carries the x_cocore credit so a
-            // streaming client gets the same "who ran it" metadata the
-            // buffered path returns.
-            send(chunkPayload(id, model, {}, "stop", cocoreMeta(ev.providerCredit, ev.receiptUri)));
+            // The final chunk carries the x_cocore credit so a streaming
+            // client gets the same "who ran it" metadata the buffered path
+            // returns. If the stream emitted tool_call deltas, use the OpenAI
+            // finish_reason that tells agents to execute the accumulated calls.
+            send(
+              chunkPayload(
+                id,
+                model,
+                {},
+                emittedToolCalls ? "tool_calls" : "stop",
+                cocoreMeta(ev.providerCredit, ev.receiptUri),
+              ),
+            );
             controller.enqueue(encoder.encode("data: [DONE]\n\n"));
             return;
           } else if (ev.kind === "error") {
@@ -762,7 +773,7 @@ export async function bufferedResponse(
 ): Promise<Response> {
   let content = "";
   let reasoning = "";
-  let toolCallChunks: string[] = [];
+  const toolCallChunks: string[] = [];
   let tokensIn = 0;
   let tokensOut = 0;
   let providerCredit: ProviderCredit | undefined;

--- a/packages/console/src/lib/openai-chat-completions.test.ts
+++ b/packages/console/src/lib/openai-chat-completions.test.ts
@@ -762,11 +762,20 @@ describe("streamingResponse with tool calls", () => {
     const data = await readSseData(res);
     assert.equal(data.at(-1), "[DONE]");
 
-    // Find the chunk that carries tool_calls (skip [DONE] terminator).
-    const toolCallChunk = data
+    const chunks = data
       .filter((d) => d !== "[DONE]")
-      .map((d) => JSON.parse(d) as { choices: Array<{ delta: { tool_calls?: unknown[] } }> })
-      .find((c) => c.choices[0]?.delta.tool_calls);
+      .map(
+        (d) =>
+          JSON.parse(d) as {
+            choices: Array<{
+              delta: { tool_calls?: unknown[] };
+              finish_reason: string | null;
+            }>;
+          },
+      );
+
+    // Find the chunk that carries tool_calls (skip [DONE] terminator).
+    const toolCallChunk = chunks.find((c) => c.choices[0]?.delta.tool_calls);
 
     assert.ok(toolCallChunk, "at least one SSE chunk should carry delta.tool_calls");
     const tc = toolCallChunk!.choices[0]!.delta.tool_calls as Array<{
@@ -776,6 +785,9 @@ describe("streamingResponse with tool calls", () => {
     assert.equal(tc[0]!.id, "call_abc");
     assert.equal(tc[0]!.function.name, "get_weather");
     assert.equal(tc[0]!.function.arguments, '{"city":"Tokyo"}');
+
+    const finalChunk = chunks.at(-1)!;
+    assert.equal(finalChunk.choices[0]!.finish_reason, "tool_calls");
   });
 
   test("emits content and tool_calls in separate SSE chunks", async () => {
@@ -803,13 +815,19 @@ describe("streamingResponse with tool calls", () => {
     const data = await readSseData(res);
     const chunks = data
       .slice(0, -1) // drop [DONE]
-      .map((d) => JSON.parse(d) as { choices: Array<{ delta: Record<string, unknown> }> });
+      .map(
+        (d) =>
+          JSON.parse(d) as {
+            choices: Array<{ delta: Record<string, unknown>; finish_reason: string | null }>;
+          },
+      );
 
     const contentChunks = chunks.filter((c) => c.choices[0]?.delta.content);
     const toolCallChunks = chunks.filter((c) => c.choices[0]?.delta.tool_calls);
 
     assert.ok(contentChunks.length > 0, "at least one content chunk");
     assert.ok(toolCallChunks.length > 0, "at least one tool_call chunk");
+    assert.equal(chunks.at(-1)!.choices[0]!.finish_reason, "tool_calls");
   });
 });
 

--- a/provider/src/engines/subprocess.rs
+++ b/provider/src/engines/subprocess.rs
@@ -412,10 +412,21 @@ const READY_HARD_CAP: Duration = Duration::from_secs(6 * 60 * 60);
 /// ceiling vllm-mlx's `--timeout` uses by default.
 const HTTP_TIMEOUT: Duration = Duration::from_secs(300);
 
-/// Idle timeout between streamed body reads. Reset implicitly on each
-/// successful read; if the engine stalls mid-stream for longer than
-/// this we treat it as a disconnect.
+/// Idle timeout between streamed body reads, applied only AFTER the
+/// engine has started emitting the response body. The wait for the
+/// *first* token is governed by `HTTP_TIMEOUT` instead (see
+/// `http_post_stream_uds`): a large tool-schema prompt can spend well
+/// over a minute in prefill on slow hardware before the first SSE byte,
+/// and that must not be mistaken for a mid-stream stall.
 const HTTP_STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Granularity at which the streaming read loop wakes to re-evaluate its
+/// time budgets. The socket read timeout is set to this short slice so a
+/// `WouldBlock`/`TimedOut` wakeup lets us decide whether we're still
+/// within the first-token (`HTTP_TIMEOUT`) or idle
+/// (`HTTP_STREAM_IDLE_TIMEOUT`) budget rather than bailing on the first
+/// quiet slice.
+const HTTP_STREAM_READ_POLL: Duration = Duration::from_secs(5);
 
 /// vLLM/vllm-mlx tool-calling launch configuration.
 ///
@@ -1293,7 +1304,9 @@ impl SubprocessEngine {
             )
         })?;
         stream.set_write_timeout(Some(Duration::from_secs(10)))?;
-        stream.set_read_timeout(Some(HTTP_STREAM_IDLE_TIMEOUT))?;
+        // Poll in short slices; the loop below converts a quiet slice into a
+        // first-token vs. mid-stream-stall decision against the budgets above.
+        stream.set_read_timeout(Some(HTTP_STREAM_READ_POLL))?;
 
         let req_head = format!(
             "POST {path} HTTP/1.1\r\n\
@@ -1323,18 +1336,50 @@ impl SubprocessEngine {
             ThinkTagSplitter::new()
         };
 
+        let started = Instant::now();
+        let mut last_progress = Instant::now();
+        let mut body_started = false;
+
         loop {
             let n = match stream.read(&mut read_buf) {
                 Ok(0) => break,
                 Ok(n) => n,
-                Err(e) if e.kind() == std::io::ErrorKind::TimedOut => {
-                    bail!(
-                        "engine stream stalled (no bytes for {}s)",
-                        HTTP_STREAM_IDLE_TIMEOUT.as_secs()
-                    );
+                // A read interrupted by a signal is not an error — re-arm.
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                // The socket read timeout (`SO_RCVTIMEO`) expired with no
+                // bytes this slice. Rust maps that to `WouldBlock` on Unix
+                // (EAGAIN, "Resource temporarily unavailable", os error 35)
+                // and `TimedOut` on Windows — both mean the same thing here.
+                // Decide whether we're still within budget or genuinely stuck.
+                Err(e)
+                    if matches!(
+                        e.kind(),
+                        std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                    ) =>
+                {
+                    if body_started {
+                        if last_progress.elapsed() > HTTP_STREAM_IDLE_TIMEOUT {
+                            bail!(
+                                "engine stream stalled (no bytes for {}s)",
+                                HTTP_STREAM_IDLE_TIMEOUT.as_secs()
+                            );
+                        }
+                    } else if started.elapsed() > HTTP_TIMEOUT {
+                        // Still waiting for the first token. Tool-enabled
+                        // requests carry the full tool schemas, so prefill of
+                        // a big prompt on slow hardware can legitimately run
+                        // for minutes before the first SSE byte; allow the
+                        // same ceiling the non-streaming path uses.
+                        bail!(
+                            "engine produced no output within {}s",
+                            HTTP_TIMEOUT.as_secs()
+                        );
+                    }
+                    continue;
                 }
                 Err(e) => return Err(e.into()),
             };
+            last_progress = Instant::now();
             buf.extend_from_slice(&read_buf[..n]);
 
             if header_end.is_none() {
@@ -1347,8 +1392,19 @@ impl SubprocessEngine {
                     }
                     header_end = Some(end);
                     body_cursor = end;
+                } else {
+                    // Headers still incomplete — keep reading. (uvicorn flushes
+                    // the response head before the model's first token, so a
+                    // long prefill gap lands AFTER this point, not here.)
+                    continue;
                 }
-                continue;
+            }
+            // Latch once real body bytes are in hand: only then does a quiet
+            // slice mean a mid-stream idle rather than first-token prefill. We
+            // fall through to process here (rather than `continue`-ing) so a
+            // response whose head and body land in the same read isn't dropped.
+            if body_cursor < buf.len() {
+                body_started = true;
             }
 
             Self::process_sse_buffer(
@@ -2067,6 +2123,76 @@ mod tests {
 
         assert_eq!(content, "Let me check");
         assert_eq!(tool_calls.len(), 1);
+    }
+
+    /// Regression for #133. A slow first token — the engine flushes the HTTP
+    /// response head, then goes quiet through a full read-poll slice while it
+    /// prefills a big tool-schema prompt — must NOT abort the request. On
+    /// macOS the socket read timeout surfaces as `WouldBlock` (EAGAIN, os
+    /// error 35, "Resource temporarily unavailable"); an earlier revision only
+    /// caught `TimedOut` and returned that EAGAIN as a fatal error, so every
+    /// tool-enabled request through the advisor failed. The body delivered
+    /// after the gap must still arrive in full.
+    #[test]
+    fn stream_survives_prefill_gap_before_first_token() {
+        use std::os::unix::net::UnixListener;
+        use std::thread;
+
+        let engine = SubprocessEngine::new(
+            "test-model",
+            PathBuf::from("/nonexistent/python"),
+            VllmToolConfig::default(),
+        )
+        .expect("construct engine");
+
+        let _ = std::fs::remove_file(&engine.socket_path);
+        let listener = UnixListener::bind(&engine.socket_path).expect("bind uds");
+
+        let server = thread::spawn(move || {
+            let (mut conn, _) = listener.accept().expect("accept");
+            // Drain the request head so the client's write completes.
+            let mut req = [0u8; 1024];
+            let _ = conn.read(&mut req);
+            // Flush the HTTP response head immediately (as uvicorn's
+            // StreamingResponse does), then stay silent past one read-poll
+            // slice to emulate prefill of a large prompt before the first token.
+            conn.write_all(b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n")
+                .unwrap();
+            conn.flush().unwrap();
+            thread::sleep(HTTP_STREAM_READ_POLL + Duration::from_millis(500));
+            // Now deliver the tool call + usage + DONE and close (EOF).
+            conn.write_all(
+                concat!(
+                    "data: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"arguments\":\"{}\"}}]}}]}\n\n",
+                    "data: {\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5}}\n\n",
+                    "data: [DONE]\n\n"
+                )
+                .as_bytes(),
+            )
+            .unwrap();
+            conn.flush().unwrap();
+        });
+
+        let mut deltas: Vec<(DeltaChannel, String)> = Vec::new();
+        let tokens = engine
+            .http_post_stream_uds("/v1/chat/completions", b"{}", false, &mut |ch, s| {
+                deltas.push((ch, s.to_string()));
+                Ok(())
+            })
+            .expect("stream must survive the prefill gap, not bail on WouldBlock");
+
+        server.join().unwrap();
+
+        assert_eq!(tokens, (10, 5), "usage from after the gap is captured");
+        let tool_calls: Vec<&str> = deltas
+            .iter()
+            .filter(|(ch, _)| *ch == DeltaChannel::ToolCall)
+            .map(|(_, s)| s.as_str())
+            .collect();
+        assert_eq!(tool_calls.len(), 1, "tool call delivered after the gap");
+        let parsed: serde_json::Value =
+            serde_json::from_str(tool_calls[0]).expect("tool call json");
+        assert_eq!(parsed[0]["function"]["name"], "get_weather");
     }
 
     /// A pathological long home dir + a long model id must still produce an

--- a/provider/src/engines/subprocess.rs
+++ b/provider/src/engines/subprocess.rs
@@ -1207,13 +1207,17 @@ impl SubprocessEngine {
 
     /// Drain complete `data:` lines from an SSE body buffer. Returns
     /// when the buffer ends mid-line so the caller can read more bytes.
+    ///
+    /// The boolean return value reports whether this call emitted at least
+    /// one meaningful, user-visible delta (content, reasoning, or tool_calls).
     fn process_sse_buffer(
         buf: &mut Vec<u8>,
         cursor: &mut usize,
         splitter: &mut ThinkTagSplitter,
         on_data: &mut dyn FnMut(DeltaChannel, &str) -> Result<()>,
         tokens: &mut (u64, u64),
-    ) -> Result<()> {
+    ) -> Result<bool> {
+        let mut emitted_delta = false;
         while *cursor < buf.len() {
             let rest = &buf[*cursor..];
             let Some(nl) = rest.iter().position(|&b| b == b'\n') else {
@@ -1248,6 +1252,7 @@ impl SubprocessEngine {
                 .and_then(|c| c.as_str())
             {
                 if !reasoning.is_empty() {
+                    emitted_delta = true;
                     on_data(DeltaChannel::Reasoning, reasoning)?;
                 }
             }
@@ -1259,6 +1264,7 @@ impl SubprocessEngine {
                 if !tool_calls.is_null() {
                     let json = serde_json::to_string(tool_calls).unwrap_or_default();
                     if !json.is_empty() {
+                        emitted_delta = true;
                         on_data(DeltaChannel::ToolCall, &json)?;
                     }
                 }
@@ -1271,6 +1277,7 @@ impl SubprocessEngine {
                 .and_then(|c| c.as_str())
             {
                 if !content.is_empty() {
+                    emitted_delta = true;
                     splitter.push(content, on_data)?;
                 }
             }
@@ -1287,7 +1294,7 @@ impl SubprocessEngine {
             buf.drain(..*cursor);
             *cursor = 0;
         }
-        Ok(())
+        Ok(emitted_delta)
     }
 
     fn http_post_stream_uds(
@@ -1338,7 +1345,7 @@ impl SubprocessEngine {
 
         let started = Instant::now();
         let mut last_progress = Instant::now();
-        let mut body_started = false;
+        let mut meaningful_stream_started = false;
 
         loop {
             let n = match stream.read(&mut read_buf) {
@@ -1357,7 +1364,7 @@ impl SubprocessEngine {
                         std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
                     ) =>
                 {
-                    if body_started {
+                    if meaningful_stream_started {
                         if last_progress.elapsed() > HTTP_STREAM_IDLE_TIMEOUT {
                             bail!(
                                 "engine stream stalled (no bytes for {}s)",
@@ -1379,7 +1386,7 @@ impl SubprocessEngine {
                 }
                 Err(e) => return Err(e.into()),
             };
-            last_progress = Instant::now();
+            let read_at = Instant::now();
             buf.extend_from_slice(&read_buf[..n]);
 
             if header_end.is_none() {
@@ -1399,21 +1406,25 @@ impl SubprocessEngine {
                     continue;
                 }
             }
-            // Latch once real body bytes are in hand: only then does a quiet
-            // slice mean a mid-stream idle rather than first-token prefill. We
-            // fall through to process here (rather than `continue`-ing) so a
-            // response whose head and body land in the same read isn't dropped.
-            if body_cursor < buf.len() {
-                body_started = true;
-            }
-
-            Self::process_sse_buffer(
+            // Do not treat every SSE body byte as meaningful stream progress:
+            // vLLM/vllm-mlx often emits an initial role/empty chunk, then goes
+            // quiet while it finishes a buffered tool call. Stay on the longer
+            // first-token budget until we see content, reasoning, or tool_calls.
+            // Once meaningful output has started, any subsequent body byte is
+            // progress for the mid-stream idle timer.
+            let emitted_delta = Self::process_sse_buffer(
                 &mut buf,
                 &mut body_cursor,
                 &mut splitter,
                 on_delta,
                 &mut tokens,
             )?;
+            if emitted_delta {
+                meaningful_stream_started = true;
+            }
+            if meaningful_stream_started {
+                last_progress = read_at;
+            }
         }
         // Flush any partial <think> marker held at end of stream.
         splitter.finish(on_delta)?;
@@ -2080,6 +2091,60 @@ mod tests {
         let second: serde_json::Value =
             serde_json::from_str(tool_call_deltas[1]).expect("second delta is JSON");
         assert_eq!(second[0]["function"]["arguments"], "{\"city\":\"Tokyo\"}");
+    }
+
+    #[test]
+    fn process_sse_buffer_reports_only_meaningful_deltas_as_progress() {
+        let mut buf = Vec::new();
+        let mut cursor = 0;
+        let mut splitter = ThinkTagSplitter::new();
+        let mut deltas: Vec<(DeltaChannel, String)> = Vec::new();
+        let mut tokens = (0u64, 0u64);
+
+        // vllm-mlx commonly emits a leading role-only SSE chunk before doing
+        // the expensive/buffered tool-call work. That chunk should not switch
+        // the UDS reader from the first-token budget to the mid-stream idle
+        // budget, because no user-visible content/tool_call has arrived yet.
+        let role_only =
+            "data: {\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":null}]}\n\n";
+        buf.extend_from_slice(role_only.as_bytes());
+        let emitted = {
+            let mut on_data = |ch: DeltaChannel, s: &str| {
+                deltas.push((ch, s.to_string()));
+                Ok(())
+            };
+            SubprocessEngine::process_sse_buffer(
+                &mut buf,
+                &mut cursor,
+                &mut splitter,
+                &mut on_data,
+                &mut tokens,
+            )
+        }
+        .unwrap();
+        assert!(
+            !emitted,
+            "role-only chunks are not meaningful stream progress"
+        );
+        assert!(deltas.is_empty());
+
+        let tool_call = "data: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"arguments\":\"{}\"}}]},\"finish_reason\":null}]}\n\n";
+        buf.extend_from_slice(tool_call.as_bytes());
+        let emitted = {
+            let mut on_data = |ch: DeltaChannel, s: &str| {
+                deltas.push((ch, s.to_string()));
+                Ok(())
+            };
+            SubprocessEngine::process_sse_buffer(
+                &mut buf,
+                &mut cursor,
+                &mut splitter,
+                &mut on_data,
+                &mut tokens,
+            )
+        }
+        .unwrap();
+        assert!(emitted, "tool_call chunks are meaningful stream progress");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #133 — tool-enabled requests routed through the advisor failed 100% of the time on Apple Silicon with `Resource temporarily unavailable (os error 35)`, while plain (no-tools) requests, the startup tool-calling canary, and direct UDS hits all worked.

This PR carries the original provider fix plus the validated follow-up from #139 (merged into this branch), so it now spans both the provider's engine socket loop and the console's OpenAI-compatible streaming adapter.

## Root cause

The streaming UDS reader `http_post_stream_uds` (in `provider/src/engines/subprocess.rs`) set a 60s socket read timeout and only treated `ErrorKind::TimedOut` as the "idle stream" case:

- **Wrong error-kind on Unix.** A `SO_RCVTIMEO` expiry surfaces as `ErrorKind::WouldBlock` (EAGAIN / errno 35 = *"Resource temporarily unavailable"*) on macOS/Linux, and as `TimedOut` only on Windows. So the read-timeout fell straight through to the fatal error arm — leaking the raw EAGAIN.
- **The 60s window also governed time-to-first-token.** Tool-enabled requests carry the full tool JSON schemas, so prefill of that much larger prompt on weak hardware — combined with vllm-mlx buffering tool-call streaming until the call is complete — routinely exceeds 60s before the first SSE byte. Plain requests stream steadily and never hit it. The canary escaped because it uses the non-streaming path (300s timeout).

## Changes

**Provider (`provider/src/engines/subprocess.rs`):**
- Poll the socket in short slices and reclassify a quiet slice against two budgets: give the wait for the first token the same 300s ceiling the non-streaming path uses, and apply the 60s idle cap only once the stream is actually producing.
- Handle both `WouldBlock` and `TimedOut`, and re-arm on `Interrupted` (EINTR).
- Only treat **meaningful** deltas (content / reasoning / tool_calls) as stream progress — a leading role-only/empty SSE chunk no longer flips the request onto the short idle timeout while the engine finishes a buffered tool call (from #139).
- Process a response whose head and body land in the same read instead of dropping the body.

**Console (`packages/console/src/lib/openai-chat-completions.server.ts`, from #139):**
- When the stream emits `delta.tool_calls`, the final chunk now finishes with `finish_reason: "tool_calls"` (not `"stop"`), matching the buffered path. OpenAI-compatible clients only execute accumulated streamed tool calls when the final reason is `"tool_calls"` — without this, the provider emitted the calls but clients ignored them.

## Validation

```
cargo test --manifest-path provider/Cargo.toml --lib subprocess
pnpm --filter @cocore/console test -- openai-chat-completions
cargo fmt --check && cargo clippy --lib
```

Regression coverage added for: surviving a prefill gap before the first token, role-only chunks not counting as progress, and the streaming `finish_reason: "tool_calls"` semantics.

## Verified end-to-end

@tijs validated this branch against `mlx-community/Qwen2.5-3B-Instruct-4bit` + the Hermes parser: the os-error-35 failure is gone, and with the `finish_reason` fix an OpenAI-compatible client (pi) received and executed a real `bash` tool call. A remaining default-pi issue (full 14 KB system prompt + 22 tools can make this small 3B model empty-stop or time out) is model/prompt-specific and intentionally left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWRbMihrirhr3dKxxSpVYd