### PR TITLE
Follow-up: stream tool calls with correct finish reason

### DIFF
--- a/packages/console/src/lib/openai-chat-completions.server.ts
+++ b/packages/console/src/lib/openai-chat-completions.server.ts
@@ -681,6 +681,7 @@ export function streamingResponse(
   const stream = new ReadableStream<Uint8Array>({
     async start(controller) {
       const send = (s: string) => controller.enqueue(encoder.encode(`data: ${s}\n\n`));
+      let emittedToolCalls = false;
       // OpenAI clients expect a leading role-only delta.
       send(chunkPayload(id, model, { role: "assistant" }, null));
 
@@ -692,6 +693,7 @@ export function streamingResponse(
             if (ev.channel === "tool_call") {
               try {
                 const toolCalls = JSON.parse(ev.text);
+                emittedToolCalls = true;
                 send(chunkPayload(id, model, { tool_calls: toolCalls }, null));
               } catch {
                 // Malformed tool_call JSON — skip rather than crash the stream.
@@ -704,10 +706,19 @@ export function streamingResponse(
               send(chunkPayload(id, model, delta, null));
             }
           } else if (ev.kind === "complete") {
-            // The final `stop` chunk carries the x_cocore credit so a
-            // streaming client gets the same "who ran it" metadata the
-            // buffered path returns.
-            send(chunkPayload(id, model, {}, "stop", cocoreMeta(ev.providerCredit, ev.receiptUri)));
+            // The final chunk carries the x_cocore credit so a streaming
+            // client gets the same "who ran it" metadata the buffered path
+            // returns. If the stream emitted tool_call deltas, use the OpenAI
+            // finish_reason that tells agents to execute the accumulated calls.
+            send(
+              chunkPayload(
+                id,
+                model,
+                {},
+                emittedToolCalls ? "tool_calls" : "stop",
+                cocoreMeta(ev.providerCredit, ev.receiptUri),
+              ),
+            );
             controller.enqueue(encoder.encode("data: [DONE]\n\n"));
             return;
           } else if (ev.kind === "error") {
@@ -762,7 +773,7 @@ export async function bufferedResponse(
 ): Promise<Response> {
   let content = "";
   let reasoning = "";
-  let toolCallChunks: string[] = [];
+  const toolCallChunks: string[] = [];
   let tokensIn = 0;
   let tokensOut = 0;
   let providerCredit: ProviderCredit | undefined;

--- a/packages/console/src/lib/openai-chat-completions.test.ts
+++ b/packages/console/src/lib/openai-chat-completions.test.ts
@@ -762,11 +762,20 @@ describe("streamingResponse with tool calls", () => {
     const data = await readSseData(res);
     assert.equal(data.at(-1), "[DONE]");
 
-    // Find the chunk that carries tool_calls (skip [DONE] terminator).
-    const toolCallChunk = data
+    const chunks = data
       .filter((d) => d !== "[DONE]")
-      .map((d) => JSON.parse(d) as { choices: Array<{ delta: { tool_calls?: unknown[] } }> })
-      .find((c) => c.choices[0]?.delta.tool_calls);
+      .map(
+        (d) =>
+          JSON.parse(d) as {
+            choices: Array<{
+              delta: { tool_calls?: unknown[] };
+              finish_reason: string | null;
+            }>;
+          },
+      );
+
+    // Find the chunk that carries tool_calls (skip [DONE] terminator).
+    const toolCallChunk = chunks.find((c) => c.choices[0]?.delta.tool_calls);
 
     assert.ok(toolCallChunk, "at least one SSE chunk should carry delta.tool_calls");
     const tc = toolCallChunk!.choices[0]!.delta.tool_calls as Array<{
@@ -776,6 +785,9 @@ describe("streamingResponse with tool calls", () => {
     assert.equal(tc[0]!.id, "call_abc");
     assert.equal(tc[0]!.function.name, "get_weather");
     assert.equal(tc[0]!.function.arguments, '{"city":"Tokyo"}');
+
+    const finalChunk = chunks.at(-1)!;
+    assert.equal(finalChunk.choices[0]!.finish_reason, "tool_calls");
   });
 
   test("emits content and tool_calls in separate SSE chunks", async () => {
@@ -803,13 +815,19 @@ describe("streamingResponse with tool calls", () => {
     const data = await readSseData(res);
     const chunks = data
       .slice(0, -1) // drop [DONE]
-      .map((d) => JSON.parse(d) as { choices: Array<{ delta: Record<string, unknown> }> });
+      .map(
+        (d) =>
+          JSON.parse(d) as {
+            choices: Array<{ delta: Record<string, unknown>; finish_reason: string | null }>;
+          },
+      );
 
     const contentChunks = chunks.filter((c) => c.choices[0]?.delta.content);
     const toolCallChunks = chunks.filter((c) => c.choices[0]?.delta.tool_calls);
 
     assert.ok(contentChunks.length > 0, "at least one content chunk");
     assert.ok(toolCallChunks.length > 0, "at least one tool_call chunk");
+    assert.equal(chunks.at(-1)!.choices[0]!.finish_reason, "tool_calls");
   });
 });
 

--- a/provider/src/engines/subprocess.rs
+++ b/provider/src/engines/subprocess.rs
@@ -1207,13 +1207,17 @@ impl SubprocessEngine {
 
     /// Drain complete `data:` lines from an SSE body buffer. Returns
     /// when the buffer ends mid-line so the caller can read more bytes.
+    ///
+    /// The boolean return value reports whether this call emitted at least
+    /// one meaningful, user-visible delta (content, reasoning, or tool_calls).
     fn process_sse_buffer(
         buf: &mut Vec<u8>,
         cursor: &mut usize,
         splitter: &mut ThinkTagSplitter,
         on_data: &mut dyn FnMut(DeltaChannel, &str) -> Result<()>,
         tokens: &mut (u64, u64),
-    ) -> Result<()> {
+    ) -> Result<bool> {
+        let mut emitted_delta = false;
         while *cursor < buf.len() {
             let rest = &buf[*cursor..];
             let Some(nl) = rest.iter().position(|&b| b == b'\n') else {
@@ -1248,6 +1252,7 @@ impl SubprocessEngine {
                 .and_then(|c| c.as_str())
             {
                 if !reasoning.is_empty() {
+                    emitted_delta = true;
                     on_data(DeltaChannel::Reasoning, reasoning)?;
                 }
             }
@@ -1259,6 +1264,7 @@ impl SubprocessEngine {
                 if !tool_calls.is_null() {
                     let json = serde_json::to_string(tool_calls).unwrap_or_default();
                     if !json.is_empty() {
+                        emitted_delta = true;
                         on_data(DeltaChannel::ToolCall, &json)?;
                     }
                 }
@@ -1271,6 +1277,7 @@ impl SubprocessEngine {
                 .and_then(|c| c.as_str())
             {
                 if !content.is_empty() {
+                    emitted_delta = true;
                     splitter.push(content, on_data)?;
                 }
             }
@@ -1287,7 +1294,7 @@ impl SubprocessEngine {
             buf.drain(..*cursor);
             *cursor = 0;
         }
-        Ok(())
+        Ok(emitted_delta)
     }
 
     fn http_post_stream_uds(
@@ -1338,7 +1345,7 @@ impl SubprocessEngine {
 
         let started = Instant::now();
         let mut last_progress = Instant::now();
-        let mut body_started = false;
+        let mut meaningful_stream_started = false;
 
         loop {
             let n = match stream.read(&mut read_buf) {
@@ -1357,7 +1364,7 @@ impl SubprocessEngine {
                         std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
                     ) =>
                 {
-                    if body_started {
+                    if meaningful_stream_started {
                         if last_progress.elapsed() > HTTP_STREAM_IDLE_TIMEOUT {
                             bail!(
                                 "engine stream stalled (no bytes for {}s)",
@@ -1379,7 +1386,7 @@ impl SubprocessEngine {
                 }
                 Err(e) => return Err(e.into()),
             };
-            last_progress = Instant::now();
+            let read_at = Instant::now();
             buf.extend_from_slice(&read_buf[..n]);
 
             if header_end.is_none() {
@@ -1399,21 +1406,25 @@ impl SubprocessEngine {
                     continue;
                 }
             }
-            // Latch once real body bytes are in hand: only then does a quiet
-            // slice mean a mid-stream idle rather than first-token prefill. We
-            // fall through to process here (rather than `continue`-ing) so a
-            // response whose head and body land in the same read isn't dropped.
-            if body_cursor < buf.len() {
-                body_started = true;
-            }
-
-            Self::process_sse_buffer(
+            // Do not treat every SSE body byte as meaningful stream progress:
+            // vLLM/vllm-mlx often emits an initial role/empty chunk, then goes
+            // quiet while it finishes a buffered tool call. Stay on the longer
+            // first-token budget until we see content, reasoning, or tool_calls.
+            // Once meaningful output has started, any subsequent body byte is
+            // progress for the mid-stream idle timer.
+            let emitted_delta = Self::process_sse_buffer(
                 &mut buf,
                 &mut body_cursor,
                 &mut splitter,
                 on_delta,
                 &mut tokens,
             )?;
+            if emitted_delta {
+                meaningful_stream_started = true;
+            }
+            if meaningful_stream_started {
+                last_progress = read_at;
+            }
         }
         // Flush any partial <think> marker held at end of stream.
         splitter.finish(on_delta)?;
@@ -2080,6 +2091,60 @@ mod tests {
         let second: serde_json::Value =
             serde_json::from_str(tool_call_deltas[1]).expect("second delta is JSON");
         assert_eq!(second[0]["function"]["arguments"], "{\"city\":\"Tokyo\"}");
+    }
+
+    #[test]
+    fn process_sse_buffer_reports_only_meaningful_deltas_as_progress() {
+        let mut buf = Vec::new();
+        let mut cursor = 0;
+        let mut splitter = ThinkTagSplitter::new();
+        let mut deltas: Vec<(DeltaChannel, String)> = Vec::new();
+        let mut tokens = (0u64, 0u64);
+
+        // vllm-mlx commonly emits a leading role-only SSE chunk before doing
+        // the expensive/buffered tool-call work. That chunk should not switch
+        // the UDS reader from the first-token budget to the mid-stream idle
+        // budget, because no user-visible content/tool_call has arrived yet.
+        let role_only =
+            "data: {\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":null}]}\n\n";
+        buf.extend_from_slice(role_only.as_bytes());
+        let emitted = {
+            let mut on_data = |ch: DeltaChannel, s: &str| {
+                deltas.push((ch, s.to_string()));
+                Ok(())
+            };
+            SubprocessEngine::process_sse_buffer(
+                &mut buf,
+                &mut cursor,
+                &mut splitter,
+                &mut on_data,
+                &mut tokens,
+            )
+        }
+        .unwrap();
+        assert!(
+            !emitted,
+            "role-only chunks are not meaningful stream progress"
+        );
+        assert!(deltas.is_empty());
+
+        let tool_call = "data: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"arguments\":\"{}\"}}]},\"finish_reason\":null}]}\n\n";
+        buf.extend_from_slice(tool_call.as_bytes());
+        let emitted = {
+            let mut on_data = |ch: DeltaChannel, s: &str| {
+                deltas.push((ch, s.to_string()));
+                Ok(())
+            };
+            SubprocessEngine::process_sse_buffer(
+                &mut buf,
+                &mut cursor,
+                &mut splitter,
+                &mut on_data,
+                &mut tokens,
+            )
+        }
+        .unwrap();
+        assert!(emitted, "tool_call chunks are meaningful stream progress");
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #137. Keeps scope narrow to generally useful cocore/OpenAI-compatible behavior; does not include any Pi-specific prompt/tool-choice workaround.

## Changes

- Refine #137's stream-timeout behavior: role-only or empty SSE chunks no longer count as meaningful stream progress. The shorter mid-stream idle timeout starts only after non-empty content, reasoning, or tool_calls is emitted.
- Fix OpenAI-compatible streaming tool-call semantics: when `streamingResponse` emits `delta.tool_calls`, the final streamed chunk now uses `finish_reason: "tool_calls"` instead of `"stop"`, matching the buffered path and standard client expectations.
- Add focused regression coverage for both behaviors.

## Validation

```
cargo test --manifest-path provider/Cargo.toml --lib subprocess
pnpm --filter @cocore/console test -- openai-chat-completions
pnpm exec oxfmt --check packages/console/src/lib/openai-chat-completions.server.ts packages/console/src/lib/openai-chat-completions.test.ts
```

Vitest reports its existing post-success close-timeout warning; all 276 tests pass.

## Notes from testing

Against Nostromo (`mlx-community/Qwen2.5-3B-Instruct-4bit` + Hermes parser), the `finish_reason` fix is required for OpenAI-compatible clients to execute streamed tool calls. With a reduced Pi run plus a local shim of these stream semantics, Pi received and executed a real bash tool call end-to-end.

The remaining default-Pi issue appears to be model/prompt compatibility: the full Pi system prompt plus 22 tools can make this small 3B model empty-stop or time out. That finding is intentionally not addressed here because any workaround would be model/client-specific.
