### PR TITLE
chore(release): bump version to 0.9.35

### DIFF
--- a/provider-shell/Sources/CoCoreShell/Resources/Info.plist
+++ b/provider-shell/Sources/CoCoreShell/Resources/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleName</key>
 	<string>co/core</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.34</string>
+	<string>0.9.35</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -22,7 +22,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>934</string>
+	<string>935</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/provider/Cargo.lock
+++ b/provider/Cargo.lock
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "cocore-provider"
-version = "0.9.34"
+version = "0.9.35"
 dependencies = [
  "anyhow",
  "asn1-rs",

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cocore-provider"
-version = "0.9.34"
+version = "0.9.35"
 edition = "2021"
 description = "co/core provider agent: runs hardened compute and publishes signed receipts to AT Protocol."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Release 0.9.35 of the cocore tray app.

Ships everything on main since v0.9.34, notably:
- #137 / #139 — keep tool-call streams alive until a meaningful delta (don't abort on slow first token)

Standard release cut: bumped version in all 3 sites (provider/Cargo.toml, Cargo.lock, Info.plist Short=0.9.35 / Bundle=935). Notarized `cocore.app` (COCORE_BUILD_APNS=1, nested confidential worker) + cdHash registered to the advisor known-good set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)