### PR TITLE
fix(settlement): make settlement resilient to relay/mirror/session failure

### DIFF
--- a/infra/services/src/main.ts
+++ b/infra/services/src/main.ts
@@ -40,6 +40,7 @@ import { parsePrivateJwk, signRecord } from "@cocore/exchange/signing";
 import { TokenLedger, type TokenLedgerPolicy } from "@cocore/exchange/token-balance";
 import { startAutoresponder } from "./autorespond.ts";
 import { createReceiptPipeline } from "./receipt-pipeline.ts";
+import { makePdsBackedResolver } from "./resolve-record.ts";
 
 // Optional secret: read as Redacted (never serializes into logs/traces)
 // and, to match the old `if (process.env[X])` truthiness, treat an empty
@@ -128,6 +129,10 @@ const CONFIG = Effect.runSync(
     advisorUrl: Config.string("COCORE_ADVISOR_URL").pipe(Config.option),
     // Operator-only wipe gate: enabled only when set to exactly "1".
     allowWipe: Config.string("COCORE_ALLOW_WIPE").pipe(Config.withDefault("0")),
+    // Comma-separated extra service DIDs whose OAuth sessions the AppView
+    // should keep warm (the exchange DID is added automatically when it's a
+    // real, API-key-backed exchange). See startServiceSessionKeepAlive.
+    oauthKeepAliveDids: Config.string("COCORE_OAUTH_KEEPALIVE_DIDS").pipe(Config.withDefault("")),
   }),
 );
 
@@ -389,6 +394,13 @@ async function main() {
     }
   }
 
+  // o11y runtime for the processing boundary. Long-lived (the scoped OTel
+  // tracer stays open for the process lifetime); a no-op until
+  // OTEL_EXPORTER_OTLP_* is configured. Shared by the receipt pipeline for
+  // its per-receipt spans + cross-cutting metrics, and by the dependency
+  // resolver for its store/pds resolution metric.
+  const runtime = makeRuntime({ serviceName: "cocore-services" });
+
   const exchange = new Exchange({
     exchangeDid: EXCHANGE_DID,
     feePolicy,
@@ -397,7 +409,12 @@ async function main() {
     ...(attestationRef ? { attestationRef } : {}),
     ...(signingKey ? { signingKey } : {}),
     publisher,
-    resolveRecord: async (uri) => store.get(uri) ?? null,
+    // Store-first, PDS-backed resolution. A local-store miss falls back to
+    // the record's PDS (the source of truth) and back-fills the cache, so a
+    // dead relay or a dropped mirror hint can no longer strand a receipt in
+    // resolve-failed forever (the 2026-06 settlement stall). See
+    // resolve-record.ts.
+    resolveRecord: makePdsBackedResolver({ store, runtime, log: (l) => console.error(l) }),
   });
   // Wrap publisher.publish so settlements re-enter the firehose for
   // any subscriber that watches it directly (tests, etc.).
@@ -434,12 +451,6 @@ async function main() {
   console.error(
     `token-ledger: db=${TOKEN_LEDGER_DB} grant=${TOKEN_GRANT} floor=${TOKEN_FLOOR} treasuryFee=${FEE_BPS}bps treasury=${TREASURY_DID}`,
   );
-
-  // o11y runtime for the processing boundary. Long-lived (the scoped
-  // OTel tracer stays open for the process lifetime); a no-op until
-  // OTEL_EXPORTER_OTLP_* is configured. Shared by the receipt pipeline
-  // for its per-receipt spans + cross-cutting metrics.
-  const runtime = makeRuntime({ serviceName: "cocore-services" });
 
   // Settlement pipeline: wires exchange.onReceipt + the pending-
   // receipt queue + token-ledger application together. See
@@ -599,6 +610,28 @@ async function main() {
   // private :8081 listener (the console reaches it over the Railway internal
   // network) and `public` on the bridge port below — keeping /internal off
   // the wire while still answering appview.* reads / account.* / /pds there.
+  // Keep the exchange DID's OAuth session warm so it can't lapse from disuse
+  // and 401 every settlement write (the 2026-06 root cause). Only for a real,
+  // API-key-backed exchange — the did:web:exchange.local default is a dev
+  // placeholder with no session. Operators can add more DIDs via
+  // COCORE_OAUTH_KEEPALIVE_DIDS.
+  const keepAliveDids = (() => {
+    const set = new Set(
+      CONFIG.oauthKeepAliveDids
+        .split(",")
+        .map((s) => s.trim())
+        .filter((s) => s.startsWith("did:")),
+    );
+    if (
+      Option.isSome(EXCHANGE_API_KEY) &&
+      EXCHANGE_DID.startsWith("did:") &&
+      EXCHANGE_DID !== "did:web:exchange.local"
+    ) {
+      set.add(EXCHANGE_DID);
+    }
+    return [...set];
+  })();
+
   const appview = buildAppviewSplit(store, {
     accountStore,
     appviewDid: APPVIEW_DID,
@@ -611,6 +644,7 @@ async function main() {
     // under the requester's AppView-owned session; both enable the SSE route.
     advisorUrl: ADVISOR_URL,
     exchangeDid: EXCHANGE_DID,
+    keepAliveDids,
   });
 
   // Internal :8081 listener serves the FULL app (incl /internal/*). Traced
@@ -789,6 +823,11 @@ async function main() {
           pending: pipeline.pendingSnapshot(),
           recentOutcomes: recent,
           publisherSettled: publisher.alreadySettled().size,
+          // Relay/indexer liveness: a large idleMs while the process is up
+          // means the upstream feed (the store's durable backstop) has gone
+          // silent — the failure that starved resolution in 2026-06. null
+          // when the relay is disabled in this deployment.
+          relay: relay ? relay.getLiveness() : null,
           // Quick at-a-glance counters across the ring buffer: helps operators
           // see "are we mostly resolve-failing, or mostly settling, or mostly
           // rejecting?" without scrolling the per-receipt list.

--- a/infra/services/src/receipt-pipeline.ts
+++ b/infra/services/src/receipt-pipeline.ts
@@ -143,6 +143,13 @@ export interface ReconcileSummary {
   skippedRejected: number;
 }
 
+/** The collection segment of an at-uri (`at://<did>/<collection>/<rkey>`),
+ *  for low-cardinality metric tagging. Returns "unknown" for non-at-uris. */
+function collectionFromUri(uri: string): string {
+  const m = /^at:\/\/[^/]+\/([^/]+)\//.exec(uri);
+  return m?.[1] ?? "unknown";
+}
+
 const DEFAULT_MAX_RETRIES = 8;
 const DEFAULT_RECONCILE_BATCH_SIZE = 200;
 const SETTLEMENT_SCAN_LIMIT = 5000;
@@ -206,6 +213,14 @@ export function createReceiptPipeline(opts: ReceiptPipelineOptions): ReceiptPipe
     if (!rt) return;
     record(rt, Metric.increment(metrics.receiptsIndexed));
     record(rt, Metric.increment(metrics.settlementOutcome(outcome.kind)));
+    // Tag resolve-failed by the LOW-CARDINALITY collection of the missing dep
+    // (job / paymentAuthorization / attestation), never the URI — so an
+    // operator can see WHICH kind of dependency is going missing (and alert
+    // on it) without Railway log access. This is the signal that was
+    // completely invisible during the 2026-06 stall.
+    if (outcome.kind === "resolve-failed") {
+      record(rt, Metric.increment(metrics.resolveFailed(collectionFromUri(outcome.missing))));
+    }
     if ((outcome.kind === "settled" || outcome.kind === "duplicate") && body?.tokens) {
       const tin = body.tokens.in;
       const tout = body.tokens.out;

--- a/infra/services/src/resolve-record.test.ts
+++ b/infra/services/src/resolve-record.test.ts
@@ -1,0 +1,112 @@
+// Tests for the PDS-backed durable dependency resolver.
+//
+// The 2026-06 incident: the exchange resolved receipt deps against the local
+// store only, so a dead relay + a dropped mirror hint stranded receipts in
+// resolve-failed forever. These tests pin the fallback contract: store-first,
+// PDS on miss, back-fill the cache, negative-cache genuine absences, and
+// NEVER cache a transient error (so it retries).
+
+import { describe, expect, it, vi } from "vitest";
+
+import type { IndexedRecord } from "@cocore/sdk";
+import { ResolveError } from "@cocore/sdk/resolve";
+
+import { makePdsBackedResolver, type ResolverStore } from "./resolve-record.ts";
+
+function makeStore(): ResolverStore & { rows: Map<string, IndexedRecord> } {
+  const rows = new Map<string, IndexedRecord>();
+  return {
+    rows,
+    get: (uri) => rows.get(uri) ?? null,
+    upsert: (rec) => {
+      rows.set(rec.uri, rec);
+    },
+  };
+}
+
+function rec(uri: string): IndexedRecord {
+  return {
+    uri,
+    cid: "bafyfake",
+    collection: "dev.cocore.compute.attestation",
+    repo: "did:plc:provider",
+    rkey: uri.split("/").pop() ?? "",
+    body: { hello: "world" },
+  } as IndexedRecord;
+}
+
+const URI = "at://did:plc:provider/dev.cocore.compute.attestation/att1";
+
+describe("makePdsBackedResolver", () => {
+  it("returns a local store hit without touching the PDS", async () => {
+    const store = makeStore();
+    store.upsert(rec(URI));
+    const resolveOverPds = vi.fn();
+    const resolve = makePdsBackedResolver({ store, resolveOverPds, log: () => {} });
+
+    expect(await resolve(URI)).toMatchObject({ uri: URI });
+    expect(resolveOverPds).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the PDS on a store miss and back-fills the cache", async () => {
+    const store = makeStore();
+    const resolveOverPds = vi.fn().mockResolvedValue(rec(URI));
+    const resolve = makePdsBackedResolver({ store, resolveOverPds, log: () => {} });
+
+    // First call: store miss → PDS fetch → back-fill.
+    expect(await resolve(URI)).toMatchObject({ uri: URI });
+    expect(resolveOverPds).toHaveBeenCalledTimes(1);
+    expect(store.rows.has(URI)).toBe(true);
+
+    // Second call: now a local hit — no further PDS round-trip.
+    expect(await resolve(URI)).toMatchObject({ uri: URI });
+    expect(resolveOverPds).toHaveBeenCalledTimes(1);
+  });
+
+  it("negative-caches a genuine not-found, then re-queries after the TTL", async () => {
+    const store = makeStore();
+    const resolveOverPds = vi.fn().mockResolvedValue(null);
+    let clock = 1_000;
+    const resolve = makePdsBackedResolver({
+      store,
+      resolveOverPds,
+      log: () => {},
+      negativeTtlMs: 30_000,
+      now: () => clock,
+    });
+
+    expect(await resolve(URI)).toBeNull();
+    expect(await resolve(URI)).toBeNull(); // within TTL → no second PDS call
+    expect(resolveOverPds).toHaveBeenCalledTimes(1);
+
+    clock += 30_001; // TTL elapsed
+    expect(await resolve(URI)).toBeNull();
+    expect(resolveOverPds).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT cache a transient PDS error — every call retries", async () => {
+    const store = makeStore();
+    const resolveOverPds = vi
+      .fn()
+      .mockRejectedValue(new ResolveError("plc-fetch", "plc.directory 503"));
+    const resolve = makePdsBackedResolver({ store, resolveOverPds, log: () => {} });
+
+    expect(await resolve(URI)).toBeNull();
+    expect(await resolve(URI)).toBeNull();
+    // No negative cache for errors: both calls hit the PDS.
+    expect(resolveOverPds).toHaveBeenCalledTimes(2);
+  });
+
+  it("recovers: a transient error then a success resolves + back-fills", async () => {
+    const store = makeStore();
+    const resolveOverPds = vi
+      .fn()
+      .mockRejectedValueOnce(new ResolveError("get-record", "getRecord 502"))
+      .mockResolvedValueOnce(rec(URI));
+    const resolve = makePdsBackedResolver({ store, resolveOverPds, log: () => {} });
+
+    expect(await resolve(URI)).toBeNull(); // transient
+    expect(await resolve(URI)).toMatchObject({ uri: URI }); // recovered
+    expect(store.rows.has(URI)).toBe(true);
+  });
+});

--- a/infra/services/src/resolve-record.ts
+++ b/infra/services/src/resolve-record.ts
@@ -1,0 +1,134 @@
+// Durable, self-healing dependency resolution for the exchange.
+//
+// Before settling a receipt the exchange must resolve the records it
+// strong-refs: the `job`, the job's `paymentAuthorization`, and the
+// `attestation`. Historically `resolveRecord` read ONLY the local AppView
+// store — a cache fed by a best-effort firehose mirror plus the relay
+// backstop. When BOTH of those feeds stalled (the 2026-06 incident: the
+// relay subscription died and the fire-and-forget mirror silently dropped
+// writes during a bridge outage), every referenced dependency went missing
+// and every receipt parked in `resolve-failed` FOREVER — silently, because
+// there was no fallback to the source of truth.
+//
+// The PDS is the canonical home of every cocore record (core invariant #1:
+// "the provider's PDS is the source of truth"). So the robust fix is to fall
+// back to it: on a local-store miss, fetch the record directly from the
+// owner's PDS via `resolveRecordOverPds` (which the SDK built for exactly
+// this), back-fill the store so subsequent lookups are local, and only then
+// give up. This makes settlement correctness independent of relay/mirror
+// liveness — a record that actually exists always resolves.
+//
+// A short negative cache keeps a genuinely-not-yet-published dependency (the
+// usual receipt-beats-its-deps race) from hammering plc.directory + the PDS
+// on every reconcile tick, without delaying settlement once the dep lands.
+
+import { resolveRecordOverPds, ResolveError } from "@cocore/sdk/resolve";
+import type { IndexedRecord } from "@cocore/sdk";
+import { metrics, record, type O11yRuntime } from "@cocore/o11y";
+import { Metric } from "effect";
+
+/** Minimal store surface the resolver needs: a local read and a back-fill
+ *  write. Matches both the real `Store` and the in-memory test stub. */
+export interface ResolverStore {
+  get(uri: string): IndexedRecord | null;
+  upsert(rec: IndexedRecord): void;
+}
+
+export interface PdsBackedResolverOptions {
+  store: ResolverStore;
+  /** PDS fetch seam. Defaults to the SDK's HTTPS getRecord resolver; tests
+   *  inject a stub. Returns the record, or null when the DID has no PDS
+   *  service entry / the record doesn't exist yet. Throws `ResolveError` for
+   *  transient failures (network, malformed doc). */
+  resolveOverPds?: (uri: string) => Promise<IndexedRecord | null>;
+  /** o11y runtime for the dep-resolution metric. Omit in tests (no-op). */
+  runtime?: O11yRuntime;
+  /** Log seam (defaults to console.error). */
+  log?: (line: string) => void;
+  /** How long (ms) to remember a "not published yet" miss before re-querying
+   *  the PDS for the same URI. Long enough to dampen the reconcile loop's
+   *  re-drives, short enough that a dep landing soon still settles promptly.
+   *  Default 30s. Transient PDS errors are NOT cached — they retry next tick. */
+  negativeTtlMs?: number;
+  /** Clock seam for the negative cache (tests inject a fake). */
+  now?: () => number;
+}
+
+const DEFAULT_NEGATIVE_TTL_MS = 30_000;
+
+/** The collection segment of an at-uri, for low-cardinality tagging/logging.
+ *  Returns "unknown" for anything that isn't a well-formed at-uri. */
+function collectionOf(uri: string): string {
+  const m = /^at:\/\/[^/]+\/([^/]+)\//.exec(uri);
+  return m?.[1] ?? "unknown";
+}
+
+/** Build a store-first, PDS-backed `resolveRecord` for the exchange.
+ *
+ *  Resolution order for each URI:
+ *    1. local store hit            → return it (source "store")
+ *    2. negative cache still warm   → return null (no PDS call)
+ *    3. PDS getRecord hit           → back-fill store, return it (source "pds")
+ *    4. PDS reports not-found       → negative-cache + return null (source "miss")
+ *    5. PDS throws (transient)      → log, return null, DON'T cache (source "error")
+ *
+ *  Returning null is the pipeline's "park and retry" signal, so a transient
+ *  PDS blip just defers the receipt to the next reconcile pass — it never
+ *  becomes a permanent stall. */
+export function makePdsBackedResolver(
+  opts: PdsBackedResolverOptions,
+): (uri: string) => Promise<IndexedRecord | null> {
+  const resolveOverPds = opts.resolveOverPds ?? ((uri: string) => resolveRecordOverPds(uri));
+  const log = opts.log ?? ((line: string) => console.error(line));
+  const now = opts.now ?? (() => Date.now());
+  const negativeTtlMs = opts.negativeTtlMs ?? DEFAULT_NEGATIVE_TTL_MS;
+  const runtime = opts.runtime;
+  // uri -> epoch ms after which we'll re-query the PDS for this miss.
+  const negativeUntil = new Map<string, number>();
+
+  const tick = (source: "store" | "pds" | "miss" | "error") => {
+    if (runtime) record(runtime, Metric.increment(metrics.depResolution(source)));
+  };
+
+  return async function resolveRecord(uri: string): Promise<IndexedRecord | null> {
+    const local = opts.store.get(uri);
+    if (local) {
+      tick("store");
+      return local;
+    }
+
+    const until = negativeUntil.get(uri);
+    if (until !== undefined) {
+      if (now() < until) {
+        // Still within the negative window — treat as a fast miss.
+        tick("miss");
+        return null;
+      }
+      negativeUntil.delete(uri);
+    }
+
+    try {
+      const fetched = await resolveOverPds(uri);
+      if (fetched) {
+        // Back-fill the cache: future lookups (and the AppView dashboards
+        // reading the same store) are now local, and a dep we had to fetch
+        // once never costs a PDS round-trip again.
+        opts.store.upsert(fetched);
+        tick("pds");
+        log(`resolve: fetched ${collectionOf(uri)} ${uri} from PDS (store miss)`);
+        return fetched;
+      }
+      // Not published yet (no PDS entry / 404). Dampen re-queries.
+      negativeUntil.set(uri, now() + negativeTtlMs);
+      tick("miss");
+      return null;
+    } catch (e) {
+      // Transient — network, plc.directory hiccup, malformed doc. Do NOT
+      // negative-cache; the next reconcile pass should retry immediately.
+      tick("error");
+      const detail = e instanceof ResolveError ? `${e.code}: ${e.message}` : String(e);
+      log(`resolve: PDS fetch failed for ${uri} (${detail}); will retry`);
+      return null;
+    }
+  };
+}

--- a/packages/appview/src/api/server.ts
+++ b/packages/appview/src/api/server.ts
@@ -20,6 +20,7 @@ import {
   type AppviewOAuthClient,
   isOAuthConfigured,
   makeAppviewOAuth,
+  startServiceSessionKeepAlive,
 } from "../auth/oauth-client.ts";
 import { buildDevicePairRouter } from "../devicepair/routes.ts";
 import { PairStore } from "../devicepair/pair-store.ts";
@@ -52,6 +53,15 @@ export interface BuildServerOptions {
   advisorUrl?: string;
   /** Exchange DID stamped onto dispatch's paymentAuthorization + job. */
   exchangeDid?: string;
+  /** Long-lived SERVICE DIDs (e.g. the exchange DID) whose OAuth sessions
+   *  this AppView should keep warm so they never lapse from disuse and brick
+   *  every write under them — the way the exchange session died in 2026-06.
+   *  The AppView is the sole session owner, so the keep-alive runs here and
+   *  nowhere else. Empty/absent → disabled. */
+  keepAliveDids?: string[];
+  /** Interval between keep-alive refreshes. Default 6h — comfortably inside a
+   *  typical refresh-token lifetime. */
+  keepAliveIntervalMs?: number;
 }
 
 /** Constant-time string compare that tolerates length differences. */
@@ -223,6 +233,21 @@ function buildAppviewRouters(
     } catch (e) {
       console.error(`appview: OAuth client init failed: ${(e as Error).message}`);
     }
+  }
+
+  // Keep configured service-DID sessions warm. The AppView is the single
+  // session owner (single-use refresh tokens), so this is the one correct
+  // place to do it — a periodic refresh stops a long-idle service session
+  // (the exchange DID) from lapsing and 401ing every settlement write.
+  if (oauth && opts.keepAliveDids && opts.keepAliveDids.length > 0) {
+    startServiceSessionKeepAlive({
+      client: oauth,
+      dids: opts.keepAliveDids,
+      intervalMs: opts.keepAliveIntervalMs ?? 6 * 60 * 60_000,
+    });
+    console.error(
+      `appview: oauth keep-alive enabled for ${opts.keepAliveDids.length} service DID(s)`,
+    );
   }
 
   // PDS-write executor + its `/api/pds/*` alias (a paired agent's apiBase

--- a/packages/appview/src/auth/oauth-client.test.ts
+++ b/packages/appview/src/auth/oauth-client.test.ts
@@ -1,0 +1,95 @@
+// Tests for the OAuth resilience helpers added after the 2026-06 incident:
+//   * classifyRestoreError — turns a swallowed restore failure into a coarse,
+//     alertable reason (needs_reauth vs transient).
+//   * startServiceSessionKeepAlive — keeps a long-lived service session warm
+//     so it can't lapse from disuse and 401 every write under it.
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  classifyRestoreError,
+  startServiceSessionKeepAlive,
+  type AppviewOAuthClient,
+} from "./oauth-client.ts";
+
+const fakeClient = {} as unknown as AppviewOAuthClient;
+
+describe("classifyRestoreError", () => {
+  it("flags spent/expired/revoked grants as needs_reauth", () => {
+    expect(classifyRestoreError(new Error("invalid_grant"))).toBe("needs_reauth");
+    expect(classifyRestoreError(new Error("refresh token has expired"))).toBe("needs_reauth");
+    expect(classifyRestoreError(new Error("token was revoked"))).toBe("needs_reauth");
+  });
+
+  it("flags network / 5xx / timeouts as transient", () => {
+    expect(classifyRestoreError(new Error("fetch failed"))).toBe("transient");
+    expect(classifyRestoreError(new Error("ECONNREFUSED 127.0.0.1:443"))).toBe("transient");
+    expect(classifyRestoreError(new Error("503 Service Unavailable"))).toBe("transient");
+    expect(classifyRestoreError(new Error("socket hang up"))).toBe("transient");
+  });
+
+  it("defaults to unknown for unrecognized errors", () => {
+    expect(classifyRestoreError(new Error("something odd"))).toBe("unknown");
+    expect(classifyRestoreError("not even an error")).toBe("unknown");
+  });
+});
+
+describe("startServiceSessionKeepAlive", () => {
+  it("is a no-op for an empty or all-invalid DID list", () => {
+    const restore = vi.fn();
+    const stop = startServiceSessionKeepAlive({
+      client: fakeClient,
+      dids: ["", "not-a-did"],
+      intervalMs: 1000,
+      restore,
+      log: () => {},
+    });
+    stop();
+    expect(restore).not.toHaveBeenCalled();
+  });
+
+  it("warms each service DID on the eager tick and again on the interval", async () => {
+    vi.useFakeTimers();
+    try {
+      const restore = vi.fn().mockResolvedValue({});
+      const stop = startServiceSessionKeepAlive({
+        client: fakeClient,
+        dids: ["did:plc:exchange", "did:web:foo"],
+        intervalMs: 60_000,
+        restore,
+        log: () => {},
+      });
+
+      await vi.advanceTimersByTimeAsync(5_000); // eager warm-up
+      expect(restore).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(60_000); // one interval
+      expect(restore).toHaveBeenCalledTimes(4);
+
+      stop();
+      await vi.advanceTimersByTimeAsync(120_000); // stopped → no more
+      expect(restore).toHaveBeenCalledTimes(4);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("skips non-did entries", async () => {
+    vi.useFakeTimers();
+    try {
+      const restore = vi.fn().mockResolvedValue({});
+      startServiceSessionKeepAlive({
+        client: fakeClient,
+        dids: ["", "nope", "did:plc:x"],
+        intervalMs: 60_000,
+        restore,
+        log: () => {},
+      });
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(restore).toHaveBeenCalledTimes(1);
+      expect(restore).toHaveBeenCalledWith(fakeClient, "did:plc:x");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/appview/src/auth/oauth-client.ts
+++ b/packages/appview/src/auth/oauth-client.ts
@@ -26,11 +26,39 @@ import {
 import { NodeDnsHandleResolver } from "@atcute/identity-resolver-node";
 import { MemoryStore, OAuthClient } from "@atcute/oauth-node-client";
 import { oauthScopes } from "@cocore/sdk/oauth-scope";
+import { logWarn, makeRuntime, metrics, record } from "@cocore/o11y";
+import { Metric } from "effect";
 
 import type { AccountStore } from "../operational/account-store.ts";
 import { AccountOauthSessionStore } from "./oauth-session-store.ts";
 
 const OAUTH_STATE_TTL_MS = 15 * 60_000;
+
+// One o11y runtime for the module (no-op until OTLP is configured). Used to
+// surface session-restore failures, which were previously swallowed silently
+// — the 2026-06 incident's dead exchange session showed up only as a
+// downstream 401 string with no cause attached.
+const runtime = makeRuntime({ serviceName: "cocore-appview" });
+
+/** Classify a `client.restore()` failure into a coarse, low-cardinality
+ *  reason so a metric/log can distinguish "a human must re-authenticate"
+ *  from "retry later". Single-use refresh tokens mean an `invalid_grant` is
+ *  terminal (the session is dead until re-auth); network/5xx errors are
+ *  transient. Errs toward "unknown" rather than mislabeling. */
+export function classifyRestoreError(e: unknown): "needs_reauth" | "transient" | "unknown" {
+  const msg = (e instanceof Error ? e.message : String(e)).toLowerCase();
+  if (/invalid_grant|invalid_token|revoked|expired|unauthorized_client|no.*session/.test(msg)) {
+    return "needs_reauth";
+  }
+  if (
+    /fetch failed|network|timeout|timed out|socket|econnrefused|econnreset|enotfound|etimedout|503|502|504|429/.test(
+      msg,
+    )
+  ) {
+    return "transient";
+  }
+  return "unknown";
+}
 
 /** Base URL of the console origin that owns the OAuth client identity
  *  (serves /api/auth/atproto/metadata.json + jwks.json). Same precedence
@@ -131,7 +159,75 @@ export async function restoreSession(
 ): Promise<RestoredSession | null> {
   try {
     return await client.restore(did);
-  } catch {
+  } catch (e) {
+    // Don't swallow silently. The 2026-06 settlement stall hid here: a dead
+    // exchange session surfaced only as a downstream 401 string with no
+    // cause, so it took days to spot. Emit a classified metric + structured
+    // log so "this service DID needs re-auth" is a first-class, alertable
+    // signal. Still return null (the caller's "session gone → 401" contract
+    // is unchanged) — we only make the failure observable.
+    const reason = classifyRestoreError(e);
+    record(runtime, Metric.increment(metrics.oauthRestoreFailed(reason)));
+    record(
+      runtime,
+      logWarn("oauth session restore failed", {
+        did,
+        reason,
+        error: e instanceof Error ? e.message : String(e),
+      }),
+    );
     return null;
   }
+}
+
+/** Keep a set of long-lived SERVICE DID sessions warm so they never lapse
+ *  from disuse. The AppView is the single owner/refresher of every session
+ *  (refresh tokens are single-use — two refreshers cannibalize one token), so
+ *  this MUST run in exactly one place: here, inside the AppView. Each tick
+ *  calls `restoreSession`, which rotates + persists the refresh token, so a
+ *  session that would otherwise sit idle past its refresh-token lifetime (the
+ *  way the exchange DID died in 2026-06, blocking every settlement write)
+ *  stays alive — and any failure is surfaced by `restoreSession`'s metric/log
+ *  above. Returns a stop function. No-op for an empty DID list. */
+export function startServiceSessionKeepAlive(opts: {
+  client: AppviewOAuthClient;
+  dids: string[];
+  intervalMs: number;
+  /** Seam for tests; defaults to the real `restoreSession`. */
+  restore?: (client: AppviewOAuthClient, did: Did) => Promise<RestoredSession | null>;
+  log?: (line: string) => void;
+}): () => void {
+  const dids = opts.dids.filter((d) => typeof d === "string" && d.startsWith("did:"));
+  if (dids.length === 0 || opts.intervalMs <= 0) return () => {};
+  const restore = opts.restore ?? restoreSession;
+  const log = opts.log ?? ((l: string) => console.error(l));
+
+  const tick = async () => {
+    for (const did of dids) {
+      try {
+        const session = await restore(opts.client, did as Did);
+        if (!session) {
+          log(`oauth-keepalive: ${did} session could not be restored (needs re-auth?)`);
+        }
+      } catch (e) {
+        // restore() shouldn't throw (it catches internally), but never let a
+        // keep-alive tick crash the timer.
+        log(`oauth-keepalive: ${did} threw: ${(e as Error).message}`);
+      }
+    }
+  };
+
+  // Fire once on the next tick (not synchronously — let the caller finish
+  // wiring) and then on the interval. unref so the timer never holds the
+  // process open on its own.
+  const timer = setInterval(() => void tick(), opts.intervalMs);
+  if (typeof timer.unref === "function") timer.unref();
+  // Eager warm-up shortly after boot.
+  const warm = setTimeout(() => void tick(), 5_000);
+  if (typeof warm.unref === "function") warm.unref();
+
+  return () => {
+    clearInterval(timer);
+    clearTimeout(warm);
+  };
 }

--- a/packages/appview/src/indexer/relay-firehose.test.ts
+++ b/packages/appview/src/indexer/relay-firehose.test.ts
@@ -1,0 +1,57 @@
+// Tests for the relay supervisor's reconnect contract.
+//
+// The 2026-06 indexer stall: the supervised reconnect only retried on
+// FAILURE, but @atproto/sync's start() RESOLVES on a clean upstream end
+// (server close / idle cutoff). A clean end therefore silently completed the
+// supervisor fiber and the relay never reconnected, starving the store.
+// `superviseRelay` fixes that by turning a clean completion into a retryable
+// failure. These tests pin both reconnect paths deterministically (no socket,
+// no real backoff) via Schedule.recurs.
+
+import { describe, expect, it } from "vitest";
+import { Effect, Schedule } from "effect";
+
+import { RelayStreamEnded, superviseRelay } from "./relay-firehose.ts";
+
+describe("superviseRelay", () => {
+  it("reconnects after a CLEAN stream end (the bug: success used to stop the fiber)", async () => {
+    let attempts = 0;
+    // connect resolves cleanly every time — simulates a graceful upstream EOF.
+    const connect = () =>
+      Effect.sync(() => {
+        attempts += 1;
+      });
+    // recurs(3) = initial attempt + 3 retries, then give up.
+    await Effect.runPromise(Effect.either(superviseRelay(connect, Schedule.recurs(3))));
+    expect(attempts).toBe(4);
+  });
+
+  it("reconnects after a drop (error) too", async () => {
+    let attempts = 0;
+    const connect = () =>
+      Effect.failSync(() => {
+        attempts += 1;
+        return new Error("subscription dropped");
+      });
+    await Effect.runPromise(Effect.either(superviseRelay(connect, Schedule.recurs(2))));
+    expect(attempts).toBe(3);
+  });
+
+  it("invokes onAttemptEnd for each terminated attempt, flagging clean ends", async () => {
+    const ends: string[] = [];
+    let attempts = 0;
+    const connect = () =>
+      Effect.sync(() => {
+        attempts += 1;
+      });
+    await Effect.runPromise(
+      Effect.either(
+        superviseRelay(connect, Schedule.recurs(2), (err) => {
+          ends.push(err instanceof RelayStreamEnded ? "ended" : "error");
+        }),
+      ),
+    );
+    // initial + 2 retries = 3 terminated attempts, all clean ends.
+    expect(ends).toEqual(["ended", "ended", "ended"]);
+  });
+});

--- a/packages/appview/src/indexer/relay-firehose.ts
+++ b/packages/appview/src/indexer/relay-firehose.ts
@@ -18,14 +18,14 @@ import {
   type Event as AtEvent,
 } from "@atproto/sync";
 import { IdResolver } from "@atproto/identity";
-import { logWarn, makeRuntime, type O11yRuntime } from "@cocore/o11y";
+import { logWarn, makeRuntime, metrics, record, type O11yRuntime } from "@cocore/o11y";
 import {
   COLLECTIONS,
   type CollectionId,
   type Firehose as CocoreFirehose,
   type IndexedRecord,
 } from "@cocore/sdk";
-import { Effect, Fiber, Schedule } from "effect";
+import { Effect, Fiber, Metric, Schedule } from "effect";
 
 /** All cocore collections the firehose listens for. `COLLECTIONS`
  *  itself only enumerates `dev.cocore.compute.*` (the receipt-side
@@ -59,6 +59,46 @@ const RECONNECT_SCHEDULE = Schedule.exponential("1 second").pipe(
   Schedule.either(Schedule.spaced("30 seconds")),
 );
 
+/** Signals a relay subscription that ENDED cleanly rather than errored — the
+ *  @atproto/sync stream's `start()` promise resolved (server close, idle
+ *  cutoff, graceful EOF). We convert it into a retryable failure so the
+ *  supervised backoff reconnects; see `start()`. Before this, a clean end
+ *  silently terminated the supervisor fiber and the relay never came back —
+ *  the indexer-starvation half of the 2026-06 settlement stall. */
+export class RelayStreamEnded extends Error {
+  constructor(message = "relay subscription ended; reconnecting") {
+    super(message);
+    this.name = "RelayStreamEnded";
+  }
+}
+
+/** Compose one relay connection attempt into a forever-reconnecting
+ *  supervised effect. The fix at the heart of the 2026-06 indexer stall: a
+ *  CLEAN stream end (connect resolves) is turned into a `RelayStreamEnded`
+ *  failure so `Effect.retry` reconnects it — previously only an ERROR triggered
+ *  a reconnect, so a graceful upstream close silently ended the supervisor and
+ *  the relay never came back. A drop (connect fails) retries as before.
+ *  `onAttemptEnd` fires once per terminated attempt (clean or errored) for
+ *  logging. Exported so the reconnect-on-clean-end contract is unit-testable
+ *  without a live socket. */
+export function superviseRelay<E>(
+  connect: () => Effect.Effect<void, E>,
+  schedule: Schedule.Schedule<unknown, unknown>,
+  onAttemptEnd?: (err: E | RelayStreamEnded) => void,
+): Effect.Effect<void, E | RelayStreamEnded> {
+  return connect().pipe(
+    Effect.zipRight(Effect.fail(new RelayStreamEnded())),
+    Effect.tapError((err) => (onAttemptEnd ? Effect.sync(() => onAttemptEnd(err)) : Effect.void)),
+    Effect.retry(schedule),
+  );
+}
+
+// Record one relay liveness tick every Nth upstream event. The full
+// bsky.network firehose fires constantly, so a sampled counter stays cheap
+// while still dropping to zero the instant the feed dies — exactly what a
+// "RATE_SUM == 0 over N minutes" alert needs to catch a dead indexer.
+const LIVENESS_SAMPLE_EVERY = 500;
+
 export interface RelayFirehoseOpts {
   /** WebSocket URL of the relay. e.g. `wss://bsky.network` or
    *  `ws://localhost:NNNN` for the dev PDS. */
@@ -87,6 +127,12 @@ export class RelayFirehose {
   private runner: MemoryRunner;
   /** Fiber running the supervised reconnect loop; set by `start()`. */
   private fiber?: Fiber.RuntimeFiber<void, unknown>;
+  /** Wall-clock ms of the last upstream event consumed; 0 until the first.
+   *  Drives `getLiveness()` — a large idle while the process is up means the
+   *  feed has gone silent. */
+  private lastEventAt = 0;
+  /** Rolling event counter for liveness-tick sampling. */
+  private eventCount = 0;
 
   constructor(opts: RelayFirehoseOpts) {
     this.opts = opts;
@@ -112,6 +158,13 @@ export class RelayFirehose {
         // Firehose so the AppView's store can prune.
         const seq = (evt as { seq?: number }).seq;
         if (typeof seq === "number") lastCursor = seq;
+        // Liveness: any consumed event (any collection) proves the feed is
+        // alive. Stamp the time and tick a sampled counter so a silent feed
+        // is observable (idleMs climbs; the counter's rate falls to zero).
+        this.lastEventAt = Date.now();
+        if (++this.eventCount % LIVENESS_SAMPLE_EVERY === 0) {
+          record(runtime, Metric.increment(metrics.relayEvents));
+        }
       },
       onError: (err: Error) => {
         // A subscription-level error means the upstream connection
@@ -172,7 +225,41 @@ export class RelayFirehose {
 
   start(): void {
     if (this.fiber) return;
-    this.fiber = runtime.runFork(this.connectOnce().pipe(Effect.retry(RECONNECT_SCHEDULE)));
+    // Supervise the connection so it reconnects on ANY termination — a clean
+    // stream end (connectOnce resolves) as well as a drop (connectOnce
+    // fails). See `superviseRelay`: before it, a graceful upstream close
+    // silently ended the supervisor fiber and the relay never came back. An
+    // intentional `stop()` interrupts the fiber before the fail/retry runs,
+    // so it still winds down cleanly. connectOnce already logs its own drops;
+    // we log the clean-end case here.
+    const supervised = superviseRelay(
+      () => this.connectOnce(),
+      RECONNECT_SCHEDULE,
+      (err) => {
+        if (err instanceof RelayStreamEnded) {
+          runtime.runFork(
+            logWarn("relay-firehose subscription ended; reconnecting", {
+              service: this.opts.service,
+              cursor: this.runner.getCursor(),
+            }),
+          );
+        }
+      },
+    );
+    this.fiber = runtime.runFork(supervised);
+  }
+
+  /** Relay liveness snapshot for health/admin endpoints. `lastEventAt` is
+   *  null until the first event; `idleMs` is ms since the last consumed
+   *  event. While the process is up, a large `idleMs` means the upstream
+   *  feed has gone silent — the indexer is no longer being fed, even if the
+   *  socket looks connected. */
+  getLiveness(): { lastEventAt: string | null; idleMs: number | null } {
+    if (this.lastEventAt === 0) return { lastEventAt: null, idleMs: null };
+    return {
+      lastEventAt: new Date(this.lastEventAt).toISOString(),
+      idleMs: Date.now() - this.lastEventAt,
+    };
   }
 
   async stop(): Promise<void> {

--- a/packages/appview/src/pds/write.ts
+++ b/packages/appview/src/pds/write.ts
@@ -32,7 +32,8 @@
 import type { Did } from "@atcute/lexicons";
 import { timingSafeEqual } from "node:crypto";
 import { HttpRouter, HttpServerRequest, type HttpServerResponse } from "@effect/platform";
-import { Effect } from "effect";
+import { Effect, Metric } from "effect";
+import { logWarn, makeRuntime, metrics, record } from "@cocore/o11y";
 
 import type { AccountStore } from "../operational/account-store.ts";
 import {
@@ -74,6 +75,26 @@ function rkeyFromUri(uri: string): string {
   return parts[parts.length - 1] ?? "";
 }
 
+// Module o11y runtime (no-op until OTLP is configured) so the otherwise
+// fire-and-forget mirror can emit a failure metric/log instead of vanishing.
+const mirrorRuntime = makeRuntime({ serviceName: "cocore-appview" });
+
+const MIRROR_ATTEMPTS = 3;
+const MIRROR_BACKOFF_MS = [200, 500];
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => {
+    const t = setTimeout(r, ms);
+    if (typeof t.unref === "function") t.unref();
+  });
+}
+
+/** Best-effort AppView→bridge mirror. Still fire-and-forget (the relay is the
+ *  durable backstop and a write must never block on it), but now RETRIED and
+ *  OBSERVABLE: a transient bridge blip no longer silently drops the index
+ *  hint on the first try, and a sustained failure increments
+ *  `cocore.mirror.failed` + logs — turning the previously-invisible gap that
+ *  helped strand records in 2026-06 into a signal. */
 function mirrorPublish(
   bridgeUrl: string | undefined,
   args: {
@@ -85,20 +106,40 @@ function mirrorPublish(
   },
 ): void {
   if (!bridgeUrl) return;
-  void fetch(`${bridgeUrl.replace(/\/$/, "")}/xrpc/dev.cocore.bridge.publish`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({
-      uri: args.uri,
-      cid: args.cid,
-      collection: args.collection,
-      repo: args.repo,
-      rkey: rkeyFromUri(args.uri),
-      body: args.record,
-    }),
-  }).catch(() => {
-    /* swallowed — cache hint, not a checkpoint */
+  const url = `${bridgeUrl.replace(/\/$/, "")}/xrpc/dev.cocore.bridge.publish`;
+  const body = JSON.stringify({
+    uri: args.uri,
+    cid: args.cid,
+    collection: args.collection,
+    repo: args.repo,
+    rkey: rkeyFromUri(args.uri),
+    body: args.record,
   });
+  void (async () => {
+    for (let attempt = 0; attempt < MIRROR_ATTEMPTS; attempt++) {
+      try {
+        const r = await fetch(url, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body,
+        });
+        if (r.ok) return;
+      } catch {
+        /* retry below */
+      }
+      if (attempt < MIRROR_ATTEMPTS - 1) await sleep(MIRROR_BACKOFF_MS[attempt] ?? 500);
+    }
+    // Every attempt failed. The record is on the PDS; the relay backstop is
+    // now the only path that will index it — make that fact loud.
+    record(mirrorRuntime, Metric.increment(metrics.mirrorFailed));
+    record(
+      mirrorRuntime,
+      logWarn("appview→bridge mirror publish failed; relying on relay backstop", {
+        collection: args.collection,
+        repo: args.repo,
+      }),
+    );
+  })();
 }
 
 function mirrorUnpublish(bridgeUrl: string | undefined, uri: string): void {

--- a/packages/o11y/src/metrics.ts
+++ b/packages/o11y/src/metrics.ts
@@ -37,3 +37,68 @@ const tokens = Metric.counter("cocore.tokens", {
 export function tokenThroughput(direction: "in" | "out") {
   return tokens.pipe(Metric.tagged("direction", direction));
 }
+
+/** Receipt-dependency (job / paymentAuthorization / attestation) resolutions,
+ *  tagged by where the record was found. "store" = local AppView cache hit;
+ *  "pds" = fetched from the owner's PDS source-of-truth (the durable
+ *  fallback); "miss" = not yet published anywhere; "error" = transient PDS /
+ *  network failure. A healthy system is almost all "store"/"pds"; a spike in
+ *  "miss"/"error" is the leading indicator of the 2026-06 settlement stall. */
+const depResolutions = Metric.counter("cocore.dep_resolutions", {
+  description: "receipt dependency resolutions by source",
+});
+
+/** Counter for dependency resolutions, tagged by source. */
+export function depResolution(source: "store" | "pds" | "miss" | "error") {
+  return depResolutions.pipe(Metric.tagged("source", source));
+}
+
+/** Receipts that parked in `resolve-failed`, tagged by the LOW-CARDINALITY
+ *  collection of the missing dependency (job / paymentAuthorization /
+ *  attestation / unknown) — never the URI. Lets an operator see WHICH kind of
+ *  dependency is going missing without Railway log access. */
+const resolveFailures = Metric.counter("cocore.resolve_failed", {
+  description: "receipts parked on a missing dependency, by missing collection",
+});
+
+/** Counter for resolve-failed receipts, tagged by missing-dep collection. */
+export function resolveFailed(collection: string) {
+  return resolveFailures.pipe(Metric.tagged("collection", collection));
+}
+
+/** Relay-firehose liveness: incremented once per upstream event the relay
+ *  consumes (any collection). On the full bsky.network firehose a healthy
+ *  relay ticks this constantly, so `RATE_SUM == 0` over a few minutes is an
+ *  unambiguous "indexer feed is dead" signal — the failure that silently
+ *  starved the store for days in 2026-06. Sampled (1/N) to keep volume sane;
+ *  the absolute rate doesn't matter, only that it's non-zero. */
+const relayEventsSeen = Metric.counter("cocore.relay.events", {
+  description: "upstream relay-firehose events consumed (sampled liveness tick)",
+});
+
+/** Counter for relay liveness ticks. */
+export const relayEvents = relayEventsSeen;
+
+/** OAuth session restore failures on the AppView (the sole session owner),
+ *  tagged by a coarse reason so a dead service session is VISIBLE instead of
+ *  surfacing only as a downstream 401 string. "needs_reauth" = the refresh
+ *  token is spent/revoked/expired and a human must re-authenticate;
+ *  "transient" = network/timeout (retryable); "unknown" = unclassified. */
+const oauthRestoreFailures = Metric.counter("cocore.oauth.restore_failed", {
+  description: "OAuth session restore failures by reason",
+});
+
+/** Counter for OAuth restore failures, tagged by reason. */
+export function oauthRestoreFailed(reason: "needs_reauth" | "transient" | "unknown") {
+  return oauthRestoreFailures.pipe(Metric.tagged("reason", reason));
+}
+
+/** Best-effort AppView→bridge mirror publish failures. The mirror is a cache
+ *  hint backed by the relay, but when BOTH fail a record never gets indexed;
+ *  counting the failures turns a previously-silent gap into a signal. */
+const mirrorFailures = Metric.counter("cocore.mirror.failed", {
+  description: "AppView→bridge mirror publish failures",
+});
+
+/** Counter for mirror publish failures. */
+export const mirrorFailed = mirrorFailures;


### PR DESCRIPTION
## Why

Investigation of the "leaderboard frozen / no settlements since Jun 21 / balances stale" report (see the linked debugging session). Settlements stopped because of a chain of **silent, single-point failures**, each of which is fixed here.

### The lifecycle of the break
A receipt settles only if the exchange can (1) **resolve** its dependency records (`job` → `paymentAuthorization` → `attestation`), (2) verify them, (3) **write** a settlement to the exchange DID's PDS, and (4) move tokens. The leaderboard and balances are pure functions of the ledger, so they only advance when step 4 runs.

Around Jun 21, two things broke at once and nothing caught it:
- **Indexer feed died.** The relay subscription's supervisor only reconnected on *failure*, but `@atproto/sync`'s `start()` *resolves* on a clean stream end — so a graceful upstream close silently ended the supervisor and the relay never came back. The store's only other feed, the AppView→bridge mirror, is fire-and-forget (`void fetch().catch()`), so writes dropped during bridge blips were lost with no backstop.
- **Exchange OAuth session lapsed.** `restoreSession` swallowed the failure and returned `null`, surfacing only as a downstream `401 "underlying ATProto session no longer valid"` with no cause.

The exchange resolved deps **only against the local store**, so once deps went missing every receipt parked in `resolve-failed` **forever** — the reconcile loop re-drove the same ~282 stuck receipts ~30k times/day, silently. Honeycomb confirms: `cocore.tokens` flatlined Jun 21 23:50; outcome was ~all `resolve-failed`; the only 8 `settled` in 14 days landed exactly at the one brief relay reconnect.

## What changed (defense in depth)

**Layer 1 — durable resolution (root fix).** `resolveRecord` now falls back from the local store to the record's **PDS** (`resolveRecordOverPds`, which the SDK already had for exactly this) and back-fills the cache. The PDS is the source of truth (core invariant #1), so a real dependency always resolves regardless of relay/mirror health. Short negative cache for the receipt-beats-its-deps race; transient PDS errors are never cached so they retry. — `infra/services/src/resolve-record.ts`, wired in `main.ts`.

**Layer 2 — relay supervisor + liveness.** `superviseRelay()` reconnects on *any* termination (clean end or drop). Adds `lastEventAt`/`getLiveness()` (surfaced on `/xrpc/dev.cocore.admin.pipelineState`) and a sampled `cocore.relay.events` liveness tick. — `relay-firehose.ts`.

**Layer 3 — OAuth resilience.** `restoreSession()` classifies failures (`needs_reauth` vs `transient`) and emits a metric + structured log instead of swallowing them. `startServiceSessionKeepAlive()` keeps the exchange DID's session warm so it can't lapse from disuse; wired via the new `keepAliveDids` build option (auto-includes a real, API-key-backed exchange DID). — `oauth-client.ts`, `server.ts`, `main.ts`.

**Layer 4 — observability.** New metrics: `cocore.dep_resolutions{source}`, `cocore.resolve_failed{collection}`, `cocore.relay.events`, `cocore.oauth.restore_failed{reason}`, `cocore.mirror.failed`. The mirror now retries (3×, backoff) and reports failure instead of vanishing. — `metrics.ts`, `receipt-pipeline.ts`, `pds/write.ts`.

## Tests
- `resolve-record.test.ts` — store-first, PDS fallback + back-fill, negative cache, no-cache-on-transient-error, recovery.
- `relay-firehose.test.ts` — reconnect on clean end (the bug) *and* on drop.
- `oauth-client.test.ts` — error classification + keep-alive scheduling/filtering.
- All affected suites green; `tsc --noEmit` + `oxlint` + `oxfmt` clean on touched packages.

## Follow-up (not in this diff)
Honeycomb alert **routing** isn't configured yet (the team has no recipients). Recommended triggers once a channel exists:
- `cocore.relay.events` rate `== 0` over ~10m → **indexer feed dead** (never legitimately 0 on the full firehose).
- `cocore.tokens` flat over ~1h → **economy frozen**.
- `cocore.resolve_failed` surge / `cocore.oauth.restore_failed{reason=needs_reauth} > 0` → **needs re-auth / missing deps**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEbytgbQLfLLpHe3TP7Uo8)_