### PR TITLE
feat(exchange): app-password session for direct PDS writes (no OAuth re-auth)

### DIFF
--- a/infra/services/src/main.ts
+++ b/infra/services/src/main.ts
@@ -24,18 +24,23 @@ import { timingSafeEqual } from "node:crypto";
 import Database from "better-sqlite3";
 
 import { HttpRouter } from "@effect/platform";
-import { Config, Duration, Effect, Option, Redacted, Schedule } from "effect";
+import { Config, Duration, Effect, Metric, Option, Redacted, Schedule } from "effect";
 
 import { Firehose, type IndexedRecord } from "@cocore/sdk";
 import { Indexer, RelayFirehose } from "@cocore/appview/indexer";
 import { Store } from "@cocore/appview/store";
 import { buildAppviewSplit } from "@cocore/appview/api";
 import { AccountStore } from "@cocore/appview/account-store";
-import { makeRuntime } from "@cocore/o11y";
+import { makeRuntime, metrics, record } from "@cocore/o11y";
 import { err, header, jsonBody, makeNodeHandler, ok, searchParams } from "@cocore/o11y/http";
 import { Exchange } from "@cocore/exchange";
 import { bootstrapExchangeRecords } from "@cocore/exchange/bootstrap";
-import { ConsoleProxySettlementTransport, SettlementPublisher } from "@cocore/exchange/publisher";
+import {
+  AppPasswordSettlementTransport,
+  ConsoleProxySettlementTransport,
+  SettlementPublisher,
+} from "@cocore/exchange/publisher";
+import { AppPasswordSession, createRecordViaSession } from "@cocore/exchange/app-password-session";
 import { parsePrivateJwk, signRecord } from "@cocore/exchange/signing";
 import { TokenLedger, type TokenLedgerPolicy } from "@cocore/exchange/token-balance";
 import { startAutoresponder } from "./autorespond.ts";
@@ -78,6 +83,14 @@ const CONFIG = Effect.runSync(
     exchangeApiBase: Config.string("COCORE_EXCHANGE_API_BASE").pipe(
       Config.withDefault("https://cocore.dev"),
     ),
+    // App-password credential for the exchange's own PDS writes. When set, the
+    // exchange writes settlements + bootstrap records directly to its PDS via a
+    // self-healing app-password session instead of the lapse-prone console
+    // OAuth proxy. Identifier defaults to the exchange DID; PDS is resolved
+    // from the DID unless overridden.
+    exchangeAppPassword: secretOption("COCORE_EXCHANGE_APP_PASSWORD"),
+    exchangeIdentifier: Config.string("COCORE_EXCHANGE_IDENTIFIER").pipe(Config.option),
+    exchangePdsUrl: Config.string("COCORE_EXCHANGE_PDS_URL").pipe(Config.option),
     exchangePrivateJwk: secretOption("COCORE_EXCHANGE_PRIVATE_KEY_JWK"),
     feeBps: Config.integer("COCORE_FEE_BPS").pipe(Config.withDefault(500)),
     feeMinMinor: Config.integer("COCORE_FEE_MIN_MINOR").pipe(Config.withDefault(0)),
@@ -158,6 +171,9 @@ const AUTORESPOND_PROVIDER_DID = CONFIG.autorespondProviderDid;
 // transport/fetch boundary.
 const EXCHANGE_API_KEY = CONFIG.exchangeApiKey;
 const EXCHANGE_API_BASE = CONFIG.exchangeApiBase;
+const EXCHANGE_APP_PASSWORD = CONFIG.exchangeAppPassword;
+const EXCHANGE_IDENTIFIER = Option.getOrUndefined(CONFIG.exchangeIdentifier) ?? EXCHANGE_DID;
+const EXCHANGE_PDS_URL = Option.getOrUndefined(CONFIG.exchangePdsUrl);
 
 const EXCHANGE_PRIVATE_JWK = CONFIG.exchangePrivateJwk;
 
@@ -333,12 +349,46 @@ async function main() {
 
   // 2. Exchange. Verifies receipts + publishes settlement records.
   //    Tokens move via the TokenLedger in the firehose hook below.
-  const transport = Option.isSome(EXCHANGE_API_KEY)
-    ? new ConsoleProxySettlementTransport({
-        apiBase: EXCHANGE_API_BASE,
-        apiKey: Redacted.value(EXCHANGE_API_KEY.value),
+  //
+  // o11y runtime for the processing boundary (no-op until OTEL_* is set).
+  // Created here so the exchange session, settlement transport, and dependency
+  // resolver below all share one runtime.
+  const runtime = makeRuntime({ serviceName: "cocore-services" });
+
+  const exchangeApiKeyStr = Option.isSome(EXCHANGE_API_KEY)
+    ? Redacted.value(EXCHANGE_API_KEY.value)
+    : undefined;
+
+  // App-password session for the exchange's OWN PDS writes. When configured,
+  // settlements + bootstrap records are written DIRECTLY to the exchange's PDS
+  // via a self-healing app-password session — no console OAuth proxy that can
+  // lapse and demand a human re-auth (the 2026-06 root cause), and no
+  // console→appview hop that was independently 502'ing. Falls back to the
+  // console-proxy transport when only an API key is configured.
+  const exchangeSession = Option.isSome(EXCHANGE_APP_PASSWORD)
+    ? new AppPasswordSession({
+        identifier: EXCHANGE_IDENTIFIER,
+        appPassword: Redacted.value(EXCHANGE_APP_PASSWORD.value),
+        did: EXCHANGE_DID,
+        ...(EXCHANGE_PDS_URL ? { pdsEndpoint: EXCHANGE_PDS_URL } : {}),
+        onEvent: (e) => record(runtime, Metric.increment(metrics.exchangeSession(e))),
+        log: (l) => console.error(l),
       })
     : undefined;
+  if (exchangeSession) {
+    console.error(
+      `exchange: app-password session enabled for ${EXCHANGE_IDENTIFIER} (direct PDS writes)`,
+    );
+  }
+
+  const transport = exchangeSession
+    ? new AppPasswordSettlementTransport(exchangeSession)
+    : exchangeApiKeyStr
+      ? new ConsoleProxySettlementTransport({
+          apiBase: EXCHANGE_API_BASE,
+          apiKey: exchangeApiKeyStr,
+        })
+      : undefined;
   const publisher = new SettlementPublisher(EXCHANGE_DID, transport);
   const signingKey = Option.isSome(EXCHANGE_PRIVATE_JWK)
     ? parsePrivateJwk(Redacted.value(EXCHANGE_PRIVATE_JWK.value))
@@ -346,16 +396,22 @@ async function main() {
   const feePolicy = { bps: FEE_BPS, minMinor: FEE_MIN_MINOR };
   const selfLoop = { feeWaived: SELF_LOOP_FEE_WAIVED };
 
-  // 2a. Bootstrap policy + attestation records. Skipped without an
-  //     exchange API key (no real PDS to publish to).
+  // 2a. Bootstrap policy + attestation records. Skipped without a write path
+  //     (no app-password session and no API key → no real PDS to publish to).
   let policyRef: { uri: string; cid: string } | undefined;
   let attestationRef: { uri: string; cid: string } | undefined;
-  if (Option.isSome(EXCHANGE_API_KEY)) {
+  if (exchangeSession || exchangeApiKeyStr) {
     try {
       const refs = await bootstrapExchangeRecords({
         exchangeDid: EXCHANGE_DID,
-        apiBase: EXCHANGE_API_BASE,
-        apiKey: Redacted.value(EXCHANGE_API_KEY.value),
+        // Same write path as the settlement transport: app-password direct-PDS
+        // when configured, else the console proxy.
+        ...(exchangeSession
+          ? {
+              writeRecord: (collection: string, record: Record<string, unknown>) =>
+                createRecordViaSession(exchangeSession, { collection, record }),
+            }
+          : { apiBase: EXCHANGE_API_BASE, apiKey: exchangeApiKeyStr }),
         feePolicy,
         feeCurrency: FEE_CURRENCY,
         supportedCurrencies: [FEE_CURRENCY],
@@ -393,13 +449,6 @@ async function main() {
       );
     }
   }
-
-  // o11y runtime for the processing boundary. Long-lived (the scoped OTel
-  // tracer stays open for the process lifetime); a no-op until
-  // OTEL_EXPORTER_OTLP_* is configured. Shared by the receipt pipeline for
-  // its per-receipt spans + cross-cutting metrics, and by the dependency
-  // resolver for its store/pds resolution metric.
-  const runtime = makeRuntime({ serviceName: "cocore-services" });
 
   const exchange = new Exchange({
     exchangeDid: EXCHANGE_DID,
@@ -622,7 +671,12 @@ async function main() {
         .map((s) => s.trim())
         .filter((s) => s.startsWith("did:")),
     );
+    // Only keep-alive the exchange DID when it actually has an OAuth session to
+    // warm — i.e. the console-proxy path. With an app-password session the
+    // exchange self-manages its own session, so there's nothing to keep warm
+    // (and a restore attempt would just fail + log noise).
     if (
+      !exchangeSession &&
       Option.isSome(EXCHANGE_API_KEY) &&
       EXCHANGE_DID.startsWith("did:") &&
       EXCHANGE_DID !== "did:web:exchange.local"

--- a/packages/exchange/package.json
+++ b/packages/exchange/package.json
@@ -7,6 +7,7 @@
   "type": "module",
   "exports": {
     ".": "./src/exchange.ts",
+    "./app-password-session": "./src/app-password-session.ts",
     "./bootstrap": "./src/bootstrap.ts",
     "./publisher": "./src/publisher.ts",
     "./signing": "./src/signing.ts",

--- a/packages/exchange/src/app-password-session.test.ts
+++ b/packages/exchange/src/app-password-session.test.ts
@@ -1,0 +1,156 @@
+// Tests for the exchange's app-password session manager.
+//
+// Pins the contract that makes the exchange's PDS writes self-healing (no
+// human re-auth ever again): mint on first use, refresh proactively before
+// expiry, refresh + retry once on a 401, and re-create straight from the app
+// password when a refresh fails.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  AppPasswordSession,
+  createRecordViaSession,
+  type SessionEvent,
+} from "./app-password-session.ts";
+
+/** A fake JWT whose payload carries `exp` (seconds). Only the payload is read. */
+function jwt(expSec: number): string {
+  const payload = Buffer.from(JSON.stringify({ exp: expSec }), "utf8").toString("base64url");
+  return `h.${payload}.s`;
+}
+
+const PDS = "https://pds.test";
+const DID = "did:plc:exchange";
+
+function sessionResponse(accessExpSec: number, refresh = "r-new") {
+  return new Response(
+    JSON.stringify({ accessJwt: jwt(accessExpSec), refreshJwt: refresh, did: DID }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+function setup(
+  routes: Record<string, () => Response>,
+  startMs = 1_000_000,
+): {
+  session: AppPasswordSession;
+  events: SessionEvent[];
+  calls: string[];
+  setClock: (ms: number) => void;
+} {
+  const events: SessionEvent[] = [];
+  const calls: string[] = [];
+  let clock = startMs;
+  const fetchImpl = (async (url: string) => {
+    calls.push(String(url));
+    for (const key of Object.keys(routes)) {
+      if (String(url).includes(key)) return routes[key]!();
+    }
+    return new Response("no route", { status: 404 });
+  }) as unknown as typeof fetch;
+  const session = new AppPasswordSession({
+    identifier: "cocore.dev",
+    appPassword: "app-pw-secret",
+    did: DID,
+    pdsEndpoint: PDS,
+    fetchImpl,
+    onEvent: (e) => events.push(e),
+    log: () => {},
+    now: () => clock,
+  });
+  return { session, events, calls, setClock: (ms) => (clock = ms) };
+}
+
+describe("AppPasswordSession", () => {
+  it("mints a session from the app password on first use", async () => {
+    const { session, events, calls } = setup({
+      createSession: () => sessionResponse(1_000_000 / 1000 + 3600),
+    });
+    const token = await session.accessToken();
+    expect(token).toBe(jwt(1_000_000 / 1000 + 3600));
+    expect(events).toEqual(["created"]);
+    expect(calls.some((c) => c.includes("createSession"))).toBe(true);
+    expect(session.did()).toBe(DID);
+  });
+
+  it("reuses a healthy token, then refreshes proactively near expiry", async () => {
+    const expSec = 1_000 + 3600; // base 1_000_000ms = 1_000s
+    const { session, events, setClock } = setup(
+      {
+        createSession: () => sessionResponse(expSec),
+        refreshSession: () => sessionResponse(expSec + 3600),
+      },
+      1_000_000,
+    );
+
+    const a = await session.accessToken();
+    const b = await session.accessToken(); // still healthy → same token, no refresh
+    expect(a).toBe(b);
+    expect(events).toEqual(["created"]);
+
+    // Move to 60s before expiry (inside the 120s skew) → must refresh.
+    setClock((expSec - 60) * 1000);
+    const c = await session.accessToken();
+    expect(c).toBe(jwt(expSec + 3600));
+    expect(events).toEqual(["created", "refreshed"]);
+  });
+
+  it("refreshes + retries once on a 401, then succeeds", async () => {
+    let createRecordCalls = 0;
+    const { session, events } = setup({
+      createSession: () => sessionResponse(1_000 + 3600),
+      refreshSession: () => sessionResponse(1_000 + 7200),
+      "com.atproto.repo.createRecord": () => {
+        createRecordCalls += 1;
+        return createRecordCalls === 1
+          ? new Response(JSON.stringify({ error: "ExpiredToken" }), { status: 401 })
+          : new Response(JSON.stringify({ uri: "at://did:plc:exchange/c/r", cid: "bafy" }), {
+              status: 200,
+            });
+      },
+    });
+
+    const out = await createRecordViaSession(session, {
+      collection: "dev.cocore.compute.settlement",
+      record: { hello: "world" },
+    });
+    expect(out).toEqual({ uri: "at://did:plc:exchange/c/r", cid: "bafy" });
+    expect(createRecordCalls).toBe(2); // 401 then retry
+    expect(events).toEqual(["created", "refreshed"]); // refreshed on the 401
+  });
+
+  it("re-creates from the app password when a refresh fails", async () => {
+    const expSec = 1_000 + 3600;
+    const { session, events, setClock } = setup({
+      createSession: () => sessionResponse(expSec),
+      refreshSession: () =>
+        new Response(JSON.stringify({ error: "ExpiredToken" }), { status: 400 }),
+    });
+
+    await session.accessToken(); // initial create
+    setClock((expSec - 60) * 1000); // force a refresh attempt
+    const token = await session.accessToken();
+    expect(token).toBe(jwt(expSec)); // re-created session
+    expect(events).toEqual(["created", "refresh_failed", "created"]);
+  });
+
+  it("createRecordViaSession throws on a non-401 error", async () => {
+    const { session } = setup({
+      createSession: () => sessionResponse(1_000 + 3600),
+      "com.atproto.repo.createRecord": () =>
+        new Response(JSON.stringify({ error: "InvalidRecord" }), { status: 400 }),
+    });
+    await expect(
+      createRecordViaSession(session, { collection: "dev.cocore.compute.settlement", record: {} }),
+    ).rejects.toThrow(/createRecord .* returned 400/);
+  });
+
+  it("emits create_failed when the app password itself is rejected", async () => {
+    const { session, events } = setup({
+      createSession: () =>
+        new Response(JSON.stringify({ error: "AuthFactorTokenRequired" }), { status: 401 }),
+    });
+    await expect(session.accessToken()).rejects.toThrow(/createSession 401/);
+    expect(events).toEqual(["create_failed"]);
+  });
+});

--- a/packages/exchange/src/app-password-session.ts
+++ b/packages/exchange/src/app-password-session.ts
@@ -1,0 +1,240 @@
+// App-password session manager for the exchange's OWN PDS writes.
+//
+// Why this exists: the exchange writes settlement / policy / attestation
+// records to its own repo (cocore.dev). Routing those through the console's
+// OAuth/DPoP proxy made settlement depend on a single-use, single-owner OAuth
+// refresh token that lapsed from disuse and required a HUMAN to
+// re-authenticate — the root cause of the 2026-06 settlement stall (and it
+// added a console→appview hop that was independently 502'ing).
+//
+// A service account is better served by a credential it fully controls: an
+// ATProto app password. From it the exchange can mint a fresh session
+// (com.atproto.server.createSession) at any time and keep the short-lived
+// access token fresh (com.atproto.server.refreshSession), re-minting straight
+// from the app password if a refresh ever fails. No browser, no human, no
+// expiry cliff. App-password sessions are plain Bearer (not DPoP-bound),
+// which is exactly what com.atproto.repo.createRecord accepts — so the
+// exchange writes directly to its PDS with no proxy in the path.
+//
+// This is scoped to the exchange's own service identity. It does NOT replace
+// per-user OAuth (the console can't hold one app password for every member).
+
+import { resolvePdsEndpoint } from "@cocore/sdk/resolve";
+
+export type SessionEvent = "created" | "refreshed" | "refresh_failed" | "create_failed";
+
+export interface AppPasswordSessionOptions {
+  /** Login identifier — the account handle (e.g. "cocore.dev") or its DID. */
+  identifier: string;
+  /** ATProto app password (xxxx-xxxx-xxxx-xxxx). A long-lived secret. */
+  appPassword: string;
+  /** DID of the account; used to resolve the PDS endpoint when one isn't
+   *  given explicitly, and as the fallback `repo` for writes. */
+  did: string;
+  /** Explicit PDS base URL. When absent, resolved from `did` via the DID doc. */
+  pdsEndpoint?: string;
+  /** Injectable fetch (tests). */
+  fetchImpl?: typeof fetch;
+  /** Observability hook — fired on each session lifecycle event. */
+  onEvent?: (event: SessionEvent) => void;
+  /** Logger seam (defaults to console.error). */
+  log?: (line: string) => void;
+  /** Refresh the access token this many ms before its `exp`. Default 120s. */
+  refreshSkewMs?: number;
+  /** Clock seam (tests). */
+  now?: () => number;
+}
+
+interface SessionTokens {
+  accessJwt: string;
+  refreshJwt: string;
+  did: string;
+  /** Access-token expiry (epoch ms); 0 if unknown, negative once invalidated. */
+  accessExpMs: number;
+}
+
+const DEFAULT_REFRESH_SKEW_MS = 120_000;
+
+/** Decode a JWT's `exp` (seconds) → epoch ms, or 0 when unavailable. Used only
+ *  to refresh PROACTIVELY; we still refresh REACTIVELY on any 401, so a
+ *  missing/garbled exp just degrades to refresh-on-demand. */
+function jwtExpMs(jwt: string): number {
+  const parts = jwt.split(".");
+  if (parts.length < 2) return 0;
+  try {
+    const payload = JSON.parse(Buffer.from(parts[1]!, "base64url").toString("utf8")) as {
+      exp?: number;
+    };
+    return typeof payload.exp === "number" ? payload.exp * 1000 : 0;
+  } catch {
+    return 0;
+  }
+}
+
+export class AppPasswordSession {
+  private tokens: SessionTokens | null = null;
+  private pds: string | null;
+  private inflight: Promise<SessionTokens> | null = null;
+  private readonly fetchImpl: typeof fetch;
+  private readonly now: () => number;
+  private readonly refreshSkewMs: number;
+
+  constructor(private readonly opts: AppPasswordSessionOptions) {
+    this.pds = opts.pdsEndpoint?.replace(/\/$/, "") ?? null;
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+    this.now = opts.now ?? (() => Date.now());
+    this.refreshSkewMs = opts.refreshSkewMs ?? DEFAULT_REFRESH_SKEW_MS;
+  }
+
+  private log(line: string): void {
+    (this.opts.log ?? ((l: string) => console.error(l)))(line);
+  }
+
+  /** Resolve (and cache) the account's PDS endpoint. */
+  async pdsEndpoint(): Promise<string> {
+    if (this.pds) return this.pds;
+    const ep = await resolvePdsEndpoint(this.opts.did);
+    if (!ep) throw new Error(`app-password: no PDS endpoint published for ${this.opts.did}`);
+    this.pds = ep.replace(/\/$/, "");
+    return this.pds;
+  }
+
+  /** The account's DID — from the minted session, falling back to config. */
+  did(): string {
+    return this.tokens?.did ?? this.opts.did;
+  }
+
+  /** A valid access token, minting or refreshing as needed. Concurrent callers
+   *  share one in-flight mint/refresh. */
+  async accessToken(): Promise<string> {
+    const t = this.tokens;
+    if (
+      t &&
+      t.accessExpMs >= 0 &&
+      (t.accessExpMs === 0 || this.now() < t.accessExpMs - this.refreshSkewMs)
+    ) {
+      return t.accessJwt;
+    }
+    return (await this.ensure()).accessJwt;
+  }
+
+  /** Force the next accessToken() to refresh — call after a 401. */
+  invalidate(): void {
+    if (this.tokens) this.tokens.accessExpMs = -1;
+  }
+
+  /** Authenticated request against the session's PDS, with one refresh+retry on
+   *  a 401 (stale access token). `path` is an xrpc path beginning with "/". */
+  async fetchAuthed(
+    path: string,
+    init: { method: string; body?: string; contentType?: string },
+  ): Promise<Response> {
+    const pds = await this.pdsEndpoint();
+    let last: Response | null = null;
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const token = await this.accessToken();
+      const headers: Record<string, string> = { authorization: `Bearer ${token}` };
+      if (init.contentType) headers["content-type"] = init.contentType;
+      last = await this.fetchImpl(`${pds}${path}`, {
+        method: init.method,
+        headers,
+        ...(init.body !== undefined ? { body: init.body } : {}),
+      });
+      if (last.status === 401 && attempt === 0) {
+        this.invalidate();
+        continue;
+      }
+      return last;
+    }
+    return last as Response;
+  }
+
+  private ensure(): Promise<SessionTokens> {
+    if (this.inflight) return this.inflight;
+    const p = (async () => {
+      try {
+        if (this.tokens?.refreshJwt) {
+          try {
+            return await this.refresh();
+          } catch (e) {
+            this.log(`app-password: refresh failed (${(e as Error).message}); re-creating session`);
+            this.opts.onEvent?.("refresh_failed");
+          }
+        }
+        return await this.create();
+      } finally {
+        this.inflight = null;
+      }
+    })();
+    this.inflight = p;
+    return p;
+  }
+
+  private async create(): Promise<SessionTokens> {
+    const pds = await this.pdsEndpoint();
+    const r = await this.fetchImpl(`${pds}/xrpc/com.atproto.server.createSession`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ identifier: this.opts.identifier, password: this.opts.appPassword }),
+    });
+    if (!r.ok) {
+      this.opts.onEvent?.("create_failed");
+      const text = await r.text().catch(() => "");
+      throw new Error(`createSession ${r.status}: ${text.slice(0, 200)}`);
+    }
+    this.tokens = this.tokensFrom(await r.json());
+    this.opts.onEvent?.("created");
+    return this.tokens;
+  }
+
+  private async refresh(): Promise<SessionTokens> {
+    const pds = await this.pdsEndpoint();
+    const r = await this.fetchImpl(`${pds}/xrpc/com.atproto.server.refreshSession`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${this.tokens!.refreshJwt}` },
+    });
+    if (!r.ok) {
+      const text = await r.text().catch(() => "");
+      throw new Error(`refreshSession ${r.status}: ${text.slice(0, 200)}`);
+    }
+    this.tokens = this.tokensFrom(await r.json());
+    this.opts.onEvent?.("refreshed");
+    return this.tokens;
+  }
+
+  private tokensFrom(body: unknown): SessionTokens {
+    const b = body as { accessJwt?: unknown; refreshJwt?: unknown; did?: unknown };
+    if (typeof b.accessJwt !== "string" || typeof b.refreshJwt !== "string") {
+      throw new Error("session response missing accessJwt/refreshJwt");
+    }
+    return {
+      accessJwt: b.accessJwt,
+      refreshJwt: b.refreshJwt,
+      did: typeof b.did === "string" ? b.did : this.opts.did,
+      accessExpMs: jwtExpMs(b.accessJwt),
+    };
+  }
+}
+
+/** Write a record to the session owner's repo, refreshing + retrying once on a
+ *  401. Returns the created record's strong-ref. Throws on any other non-2xx. */
+export async function createRecordViaSession(
+  session: AppPasswordSession,
+  args: { collection: string; record: unknown; rkey?: string },
+): Promise<{ uri: string; cid: string }> {
+  const r = await session.fetchAuthed("/xrpc/com.atproto.repo.createRecord", {
+    method: "POST",
+    contentType: "application/json",
+    body: JSON.stringify({
+      repo: session.did(),
+      collection: args.collection,
+      record: args.record,
+      ...(args.rkey ? { rkey: args.rkey } : {}),
+    }),
+  });
+  if (!r.ok) {
+    const text = await r.text().catch(() => "");
+    throw new Error(`createRecord ${args.collection} returned ${r.status}: ${text.slice(0, 300)}`);
+  }
+  return (await r.json()) as { uri: string; cid: string };
+}

--- a/packages/exchange/src/bootstrap.ts
+++ b/packages/exchange/src/bootstrap.ts
@@ -33,8 +33,16 @@ const runtime = makeRuntime({ serviceName: "cocore-exchange" });
 
 export interface BootstrapInputs {
   exchangeDid: string;
-  apiBase: string;
-  apiKey: string;
+  /** Console base + bearer key for the default console-proxy write path.
+   *  Optional when `writeRecord` is supplied (the app-password path writes
+   *  directly to the PDS and needs neither). */
+  apiBase?: string;
+  apiKey?: string;
+  /** Record-write seam. When provided, policy + attestation are written via
+   *  this (the app-password direct-to-PDS path); otherwise they go through the
+   *  console proxy using apiBase/apiKey. Lets the bootstrap share the exact
+   *  same lapse-proof write path the settlement transport uses. */
+  writeRecord?: (collection: string, record: Record<string, unknown>) => Promise<PublishedRecord>;
   feePolicy: FeePolicy;
   feeCurrency: string;
   supportedCurrencies: string[];
@@ -116,6 +124,21 @@ async function proxyCreate(
 export async function bootstrapExchangeRecords(inputs: BootstrapInputs): Promise<BootstrapResult> {
   const createdAt = new Date().toISOString();
 
+  // Prefer the injected writer (app-password direct-to-PDS); fall back to the
+  // console proxy. Either way the two bootstrap records go out the same path
+  // the settlement transport uses, so they can't diverge in auth health.
+  const write = (collection: string, record: Record<string, unknown>): Promise<PublishedRecord> => {
+    if (inputs.writeRecord) return inputs.writeRecord(collection, record);
+    if (!inputs.apiBase || !inputs.apiKey) {
+      return Promise.reject(
+        new Error(
+          "bootstrap: no writeRecord and missing apiBase/apiKey for console-proxy fallback",
+        ),
+      );
+    }
+    return proxyCreate(inputs.apiBase, inputs.apiKey, collection, record);
+  };
+
   // 1. Policy record.
   const policyRecord: Record<string, unknown> = {
     exchange: inputs.exchangeDid,
@@ -151,12 +174,7 @@ export async function bootstrapExchangeRecords(inputs: BootstrapInputs): Promise
     active: true,
     createdAt,
   };
-  const policyRef = await proxyCreate(
-    inputs.apiBase,
-    inputs.apiKey,
-    "dev.cocore.compute.exchangePolicy",
-    policyRecord,
-  );
+  const policyRef = await write("dev.cocore.compute.exchangePolicy", policyRecord);
 
   // 2. Attestation record (strong-refs the policy).
   const fingerprint = inputs.signingKey
@@ -170,12 +188,7 @@ export async function bootstrapExchangeRecords(inputs: BootstrapInputs): Promise
     ...(inputs.auditPosture ? { auditPosture: inputs.auditPosture } : {}),
     createdAt: new Date().toISOString(),
   };
-  const attestationRef = await proxyCreate(
-    inputs.apiBase,
-    inputs.apiKey,
-    "dev.cocore.compute.exchangeAttestation",
-    attestationRecord,
-  );
+  const attestationRef = await write("dev.cocore.compute.exchangeAttestation", attestationRecord);
 
   return { policyRef, attestationRef };
 }

--- a/packages/exchange/src/publisher.ts
+++ b/packages/exchange/src/publisher.ts
@@ -20,6 +20,7 @@ import { makeRuntime } from "@cocore/o11y";
 import { Effect } from "effect";
 
 import type { Money, SettlementRecord, StrongRef } from "@cocore/sdk/types";
+import { AppPasswordSession, createRecordViaSession } from "./app-password-session.ts";
 
 export interface PublishedRecord {
   uri: string;
@@ -169,6 +170,29 @@ export class ConsoleProxySettlementTransport implements SettlementTransport {
       exchangeDid,
       errorMessage: (status, text) => `proxy settlement createRecord ${status}: ${text}`,
     });
+  }
+}
+
+/** Production transport that writes settlements DIRECTLY to the exchange's
+ *  PDS using a self-managed app-password session — no console proxy, no
+ *  OAuth. This is the lapse-proof replacement for {@link
+ *  ConsoleProxySettlementTransport}: the session mints/refreshes itself from a
+ *  long-lived app password (see app-password-session.ts), so a settlement
+ *  write can never be blocked by an expired OAuth session needing a human
+ *  re-auth (the 2026-06 root cause), nor by the console→appview hop. */
+export class AppPasswordSettlementTransport implements SettlementTransport {
+  constructor(private readonly session: AppPasswordSession) {}
+
+  async publish(exchangeDid: string, record: SettlementRecord): Promise<PublishedRecord> {
+    const effect = Effect.tryPromise({
+      try: () =>
+        createRecordViaSession(this.session, {
+          collection: "dev.cocore.compute.settlement",
+          record,
+        }),
+      catch: (e) => (e instanceof Error ? e : new Error(String(e))),
+    }).pipe(Effect.withSpan("exchange.appPassword.publish", { attributes: { exchangeDid } }));
+    return runtime.runPromise(effect);
   }
 }
 

--- a/packages/o11y/src/metrics.ts
+++ b/packages/o11y/src/metrics.ts
@@ -102,3 +102,20 @@ const mirrorFailures = Metric.counter("cocore.mirror.failed", {
 
 /** Counter for mirror publish failures. */
 export const mirrorFailed = mirrorFailures;
+
+/** Exchange app-password session lifecycle events. The exchange writes its own
+ *  PDS records (settlements, policy, attestation) with a self-managed
+ *  app-password session instead of a lapse-prone OAuth session. "created" /
+ *  "refreshed" are healthy; a rising "refresh_failed" (recoverable — it
+ *  re-creates from the app password) or any "create_failed" (the app password
+ *  itself is bad/revoked → writes are down) is the signal to act. */
+const exchangeSessionOps = Metric.counter("cocore.exchange.session", {
+  description: "exchange app-password session lifecycle events by outcome",
+});
+
+/** Counter for exchange session lifecycle events, tagged by event. */
+export function exchangeSession(
+  event: "created" | "refreshed" | "refresh_failed" | "create_failed",
+) {
+  return exchangeSessionOps.pipe(Metric.tagged("event", event));
+}


### PR DESCRIPTION
## Why

Follow-up to the settlement-stall fix (#142). Even after that deployed, settlements still couldn't be **written**: the exchange account's (`cocore.dev`) OAuth session was dead and only a human re-auth could revive it (Honeycomb confirms it's still 401'ing `"underlying ATProto session no longer valid"`). Routing the exchange's own PDS writes through the console's OAuth/DPoP proxy tied settlement to a **single-use, single-owner OAuth refresh token** that lapses from disuse — plus a console→appview hop that was independently `502`'ing.

A backend service account is better served by a credential it controls. `cocore.dev` is on a Bluesky-managed PDS, which supports **app passwords**, so the exchange can mint/refresh its own session and never needs a human in the loop again.

## What changed

- **`AppPasswordSession`** (`packages/exchange/src/app-password-session.ts`): `createSession` from the app password → cache the access JWT → `refreshSession` before expiry → **re-create straight from the app password if a refresh ever fails** → refresh + retry once on a `401`. Resolves the PDS from the DID. App-password sessions are plain Bearer (exactly what `com.atproto.repo.createRecord` accepts), so writes go **direct to the PDS** — no proxy, no DPoP, no OAuth.
- **`AppPasswordSettlementTransport`** (`publisher.ts`) + a `writeRecord` seam on `bootstrapExchangeRecords`, so settlements **and** the policy/attestation bootstrap share the same lapse-proof path.
- **`main.ts`** wires it when `COCORE_EXCHANGE_APP_PASSWORD` is set (identifier defaults to the exchange DID; PDS auto-resolved), falling back to the console-proxy transport otherwise. The OAuth keep-alive stops warming the exchange DID in app-password mode (nothing to warm).
- **`cocore.exchange.session`** metric (`created` / `refreshed` / `refresh_failed` / `create_failed`) so a bad/revoked app password is alertable instead of silent.

**Scope:** the exchange's own service identity only. Per-user OAuth (console/inference writes by real members) is unchanged.

## Tests
`app-password-session.test.ts` — mint on first use, proactive refresh near expiry, `401` refresh+retry, re-create on refresh failure, and `create_failed` on a bad app password. All exchange (39) + services (17) suites green; `tsc`/`oxlint`/`oxfmt`/`knip` clean.

## Deploy steps (operator)
1. In Bluesky settings for **cocore.dev** → App Passwords, create a dedicated one (e.g. `cocore-exchange-railway`).
2. On the Railway **services** container, set `COCORE_EXCHANGE_APP_PASSWORD` (secret) and `COCORE_EXCHANGE_IDENTIFIER=cocore.dev`. (`COCORE_EXCHANGE_PDS_URL` optional — auto-resolved from the DID.)
3. Redeploy. The exchange mints a session on boot and settlement writes resume immediately; the reconcile loop then drains the backlog and balances/leaderboard catch up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEbytgbQLfLLpHe3TP7Uo8)_