### PR TITLE
fix(exchange): drop TS parameter properties (AppView crash-loop under strip-only types)

### DIFF
--- a/packages/exchange/src/app-password-session.ts
+++ b/packages/exchange/src/app-password-session.ts
@@ -78,8 +78,13 @@ export class AppPasswordSession {
   private readonly fetchImpl: typeof fetch;
   private readonly now: () => number;
   private readonly refreshSkewMs: number;
+  // Explicit field + assignment (not a constructor parameter property):
+  // the services container runs the TS source under Node's strip-only type
+  // stripping, which rejects `constructor(private ...)` parameter properties.
+  private readonly opts: AppPasswordSessionOptions;
 
-  constructor(private readonly opts: AppPasswordSessionOptions) {
+  constructor(opts: AppPasswordSessionOptions) {
+    this.opts = opts;
     this.pds = opts.pdsEndpoint?.replace(/\/$/, "") ?? null;
     this.fetchImpl = opts.fetchImpl ?? fetch;
     this.now = opts.now ?? (() => Date.now());

--- a/packages/exchange/src/publisher.ts
+++ b/packages/exchange/src/publisher.ts
@@ -181,7 +181,14 @@ export class ConsoleProxySettlementTransport implements SettlementTransport {
  *  write can never be blocked by an expired OAuth session needing a human
  *  re-auth (the 2026-06 root cause), nor by the console→appview hop. */
 export class AppPasswordSettlementTransport implements SettlementTransport {
-  constructor(private readonly session: AppPasswordSession) {}
+  // Explicit field + assignment, not a constructor parameter property — the
+  // services container runs the TS source under Node's strip-only type
+  // stripping, which rejects `constructor(private ...)`.
+  private readonly session: AppPasswordSession;
+
+  constructor(session: AppPasswordSession) {
+    this.session = session;
+  }
 
   async publish(exchangeDid: string, record: SettlementRecord): Promise<PublishedRecord> {
     const effect = Effect.tryPromise({


### PR DESCRIPTION
## Hotfix — AppView service is crash-looping on boot

After #143 merged, the **AppView** service (which runs `infra/services`) crash-loops at startup:

```
SyntaxError [ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX]: TypeScript parameter property is not supported in strip-only mode
  packages/exchange/src/publisher.ts:184
  constructor(private readonly session: AppPasswordSession) {}
```

### Cause
The services container runs the TypeScript **source** directly under Node's `--experimental-strip-types` (strip-only) mode, which cannot transform **constructor parameter properties** (`constructor(private readonly x: T)`) — it only strips types, it doesn't emit the field assignment. Both new classes from #143 used them:
- `AppPasswordSettlementTransport` (`publisher.ts`)
- `AppPasswordSession` (`app-password-session.ts`)

`tsc` and vitest (esbuild) both accept parameter properties, so this passed CI's typecheck **and** tests — only the runtime rejects it. The rest of the codebase avoids parameter properties for exactly this reason.

### Fix
Replace both with an explicit field declaration + assignment (the codebase convention). Verified the modules now load under `node --experimental-strip-types`:
```
$ node --experimental-strip-types -e "await import('./src/publisher.ts'); await import('./src/app-password-session.ts')"
STRIP-ONLY LOAD OK
```
Exchange tests (6) green, `tsc`/`oxlint`/`oxfmt` clean. Two-line change.

**Impact:** this restores the AppView service (indexer / relay / bridge / exchange / read API), independent of the app-password env vars. Once merged + redeployed, set `COCORE_EXCHANGE_APP_PASSWORD` + `COCORE_EXCHANGE_IDENTIFIER=cocore.dev` on AppView to activate the direct-PDS settlement path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEbytgbQLfLLpHe3TP7Uo8)_