### PR TITLE
Remove unservable Gemma 4 E4B from the recommended model rotation

### DIFF
--- a/packages/console/src/lib/recommended-models.ts
+++ b/packages/console/src/lib/recommended-models.ts
@@ -43,11 +43,13 @@ export const RECOMMENDED_MODELS: readonly RecommendedModel[] = [
     minRamGb: 8,
     blurb: "Qwen3.5 4B — balanced default for 8GB+ Macs",
   },
-  {
-    id: "mlx-community/gemma-4-e4b-it-4bit",
-    minRamGb: 8,
-    blurb: "Gemma 4 E4B — efficient multimodal-class; 8GB+",
-  },
+  // NOTE: `mlx-community/gemma-4-e4b-it-4bit` was previously offered here but
+  // removed (issue #141). It is a merged/multimodal "E4B" checkpoint whose
+  // weights are nested under `language_model.*`, which the provider's text
+  // runtime can't load — picking it always failed provisioning and left the
+  // machine serving only the no-op `stub` engine. Keep this list to standard
+  // MLX text models the provider can actually serve. Mirror of the provider
+  // Rust catalog (provider/src/pricing.rs).
   {
     id: "mlx-community/Qwen3.5-9B-MLX-4bit",
     minRamGb: 16,

--- a/provider-shell/Sources/CoCoreShell/ModelsView.swift
+++ b/provider-shell/Sources/CoCoreShell/ModelsView.swift
@@ -481,7 +481,10 @@ final class ModelManager: ObservableObject {
         CatalogEntry(nsid: "mlx-community/Qwen3.5-0.8B-MLX-4bit", label: "Qwen 3.5 0.8B", minRamGB: 4, recommended: true, blurb: "Tiny & fast — fits almost any Mac."),
         CatalogEntry(nsid: "mlx-community/Qwen3.5-2B-MLX-4bit", label: "Qwen 3.5 2B", minRamGB: 6, recommended: true, blurb: "Small, snappy general chat model."),
         CatalogEntry(nsid: "mlx-community/Qwen3.5-4B-MLX-4bit", label: "Qwen 3.5 4B", minRamGB: 8, recommended: true, blurb: "Solid all-rounder for everyday work."),
-        CatalogEntry(nsid: "mlx-community/gemma-4-e4b-it-4bit", label: "Gemma 4 E4B", minRamGB: 8, recommended: true, blurb: "Google's compact instruct model."),
+        // `mlx-community/gemma-4-e4b-it-4bit` was removed (issue #141): it's a
+        // merged/multimodal "E4B" checkpoint (weights nested under
+        // `language_model.*`) the text runtime can't load, so picking it always
+        // failed provisioning. Keep this catalog to standard MLX text models.
         CatalogEntry(nsid: "mlx-community/Qwen3.5-9B-MLX-4bit", label: "Qwen 3.5 9B", minRamGB: 16, recommended: true, blurb: "Strong mid-size reasoning."),
         CatalogEntry(nsid: "mlx-community/Qwen3.6-27B-4bit", label: "Qwen 3.6 27B", minRamGB: 24, recommended: true, blurb: "High-quality dense model."),
         CatalogEntry(nsid: "mlx-community/Qwen3.6-35B-A3B-4bit", label: "Qwen 3.6 35B A3B", minRamGB: 32, recommended: true, blurb: "MoE — big quality at modest active cost."),

--- a/provider/src/pricing.rs
+++ b/provider/src/pricing.rs
@@ -104,15 +104,14 @@ pub const RATES: &[ModelRate] = &[
         description: "Qwen3.5 4B — balanced default for 8GB+ Macs",
         recommended: true,
     },
-    ModelRate {
-        model_id: "mlx-community/gemma-4-e4b-it-4bit",
-        input_per_mtok: 1_000_000,
-        output_per_mtok: 1_000_000,
-        currency: "CC",
-        min_ram_gb: 8,
-        description: "Gemma 4 E4B — efficient multimodal-class; 8GB+",
-        recommended: true,
-    },
+    // NOTE: `mlx-community/gemma-4-e4b-it-4bit` was previously here. It is a
+    // merged/multimodal (Gemma "E4B") checkpoint whose weights are nested under
+    // `language_model.*`, which the text runtime can't map onto a plain text
+    // model — every machine that pinned it failed provisioning and fell back to
+    // the no-op `stub` engine (see issue #141). Removed from the catalog rather
+    // than demoted to legacy: legacy entries are "still servable", and this one
+    // is not servable at all. Do not re-add a multimodal/merged checkpoint to
+    // this rotation; only standard MLX text models belong here.
     ModelRate {
         model_id: "mlx-community/Qwen3.5-9B-MLX-4bit",
         input_per_mtok: 1_000_000,


### PR DESCRIPTION
## Summary

Fixes #141.

A user went through machine onboarding, picked `mlx-community/gemma-4-e4b-it-4bit`, and hit **"Provisioning failed"** — the machine came online but only served the no-op `stub` engine.

The reported error message is the right one (the runtime already classifies this case as `model-multimodal-incompatible`):

> The model(s) [mlx-community/gemma-4-e4b-it-4bit] couldn't load: this looks like a merged or multimodal checkpoint whose weights are nested (e.g. under `language_model.*`), which the runtime can't map onto a text model…

The real defect is that the model was **offered in the picker at all**. `gemma-4-e4b-it-4bit` is a merged/multimodal ("E4B") checkpoint whose tensors live under `language_model.*`; the provider's text runtime can't key-map those onto its module tree, so loading it always fails. It can never be served as a text model — yet it was listed as a *recommended* rotation entry.

## Changes

Removed the entry from all three places that surface the curated catalog:

- `provider/src/pricing.rs` — the Rust `RATES` table (source of truth)
- `packages/console/src/lib/recommended-models.ts` — the TS mirror served via `/v1/recommended-models`
- `provider-shell/Sources/CoCoreShell/ModelsView.swift` — the menu-bar app's offline fallback catalog

Each site keeps a short comment explaining why it was removed and that only standard MLX **text** models belong in the rotation.

Removed entirely rather than demoted to the "legacy (still servable)" tier — legacy entries are by definition still servable, and this checkpoint is not servable at all. Any machine that had already pinned it was stub-only anyway, so dropping its catalog price/RAM-floor entry is harmless.

## Testing

- `cargo test --lib pricing` — all 15 pricing tests pass (including `recommended_set_is_the_rotation`).
- No test referenced the removed id; no hardcoded catalog counts to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AhsNWNvq1GVPoQM56M4zKr)_