### PR TITLE
fix(settlement): reconcile attestation selfSignature signed-vs-stored divergence

### DIFF
--- a/packages/sdk/src/p256.test.ts
+++ b/packages/sdk/src/p256.test.ts
@@ -2,7 +2,12 @@ import { test } from "vitest";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { derToRawSignature, verifyP256, verifyReceiptSignature } from "./p256.ts";
+import {
+  derToRawSignature,
+  verifyP256,
+  verifyReceiptSignature,
+  verifyAttestationSignature,
+} from "./p256.ts";
 import { canonicalize } from "./canonical.ts";
 
 test("derToRawSignature: 64 bytes for any P-256 sig", () => {
@@ -141,6 +146,77 @@ test("verifyReceiptSignature: ignores $type lexicon framing (2026-06 stall regre
     true,
     "stored body (with $type) must verify — $type must be stripped",
   );
+});
+
+test("verifyAttestationSignature: tolerates legacy signed-vs-stored divergence (2026-06 settlement stall)", async () => {
+  // The pre-2026-07 provider signed a canonical attestation body that differed
+  // from the record it actually wrote to its PDS in two ways, so every stored
+  // attestation failed selfSignature verification — which silently blocked
+  // settlement (verifyForChargeStrict checks the attestation selfSig):
+  //
+  //   1. mdaCertChain — signed as `[]`, but serde's skip_serializing_if dropped
+  //      the empty array from the stored record (the self-attested common case).
+  //   2. timestamps — signed at seconds precision (RFC3339 SecondsFormat::Secs),
+  //      but stored at chrono's default sub-second precision.
+  //
+  // Those records can't be re-signed (the key is enclave-bound), so the
+  // verifier must reconstruct what was signed. This test signs the LEGACY form
+  // and verifies the STORED form, exactly as the live records present.
+  const kp = await crypto.subtle.generateKey({ name: "ECDSA", namedCurve: "P-256" }, true, [
+    "sign",
+    "verify",
+  ]);
+  const rawPub = new Uint8Array(await crypto.subtle.exportKey("raw", kp.publicKey));
+  const pubB64 = btoa(String.fromCharCode(...rawPub.subarray(1)));
+
+  // Fields common to both forms.
+  const common = {
+    publicKey: pubB64,
+    encryptionPubKey: "enc",
+    chipName: "Apple M5 Max",
+    tier: "best-effort",
+    sipEnabled: true,
+  };
+  // SIGNED form: mdaCertChain present as [], timestamps at seconds precision.
+  const signedBody = {
+    ...common,
+    mdaCertChain: [],
+    attestedAt: "2026-06-29T21:21:08Z",
+    expiresAt: "2026-06-30T21:21:08Z",
+  };
+  const msg = new TextEncoder().encode(canonicalize(signedBody));
+  const rawSig = new Uint8Array(
+    await crypto.subtle.sign({ name: "ECDSA", hash: "SHA-256" }, kp.privateKey, msg),
+  );
+  const selfSignature = btoa(String.fromCharCode(...rawToDer(rawSig)));
+
+  // STORED form: mdaCertChain dropped (empty), timestamps at sub-second
+  // precision, $type added by atproto. This is what the indexer presents.
+  const stored = {
+    $type: "dev.cocore.compute.attestation",
+    ...common,
+    attestedAt: "2026-06-29T21:21:08.384834Z",
+    expiresAt: "2026-06-30T21:21:08.384834Z",
+    selfSignature,
+  };
+  assert.equal(
+    await verifyAttestationSignature(stored, pubB64),
+    true,
+    "stored attestation (mdaCertChain dropped, sub-second timestamps) must verify against the legacy signed form",
+  );
+
+  // A post-fix attestation that stores exactly what it signs must ALSO verify
+  // (the as-stored attempt, no reconstruction needed).
+  const postFix = { $type: "dev.cocore.compute.attestation", ...signedBody, selfSignature };
+  assert.equal(
+    await verifyAttestationSignature(postFix, pubB64),
+    true,
+    "post-fix attestation (signed bytes == stored bytes) must verify as-stored",
+  );
+
+  // Tampering with a signed field must still fail.
+  const tampered = { ...stored, tier: "attested-confidential" };
+  assert.equal(await verifyAttestationSignature(tampered, pubB64), false);
 });
 
 /** Inverse of {@link derToRawSignature}: P-1363 raw r||s (64 bytes, what

--- a/packages/sdk/src/p256.ts
+++ b/packages/sdk/src/p256.ts
@@ -101,13 +101,54 @@ export async function verifyAttestationSignature(
   const sig = attestation.selfSignature;
   if (!sig) return false;
   const { selfSignature: _omit, $type: _type, ...signed } = attestation as Record<string, unknown>;
-  const message = new TextEncoder().encode(canonicalize(signed));
-  try {
-    return await verifyP256(publicKeyB64, sig, message);
-  } catch (e) {
-    if (e instanceof SignatureVerifyError) return false;
-    throw e;
+  // Try the record exactly as stored first (correct for any attestation whose
+  // signed canonical bytes equal its stored bytes — the post-fix provider).
+  // Fall back to the LEGACY reconstruction for attestations published by the
+  // pre-2026-07 provider, whose signed bytes differed from the stored record
+  // in two ways (see legacyAttestationBody). Those records can't be re-signed
+  // (the signature is enclave-bound), so the verifier reconstructs what was
+  // signed. The exact-as-stored form is always tried first, so this fallback
+  // never weakens verification of a correctly-signed record — it only rescues
+  // records that would otherwise be unverifiable forever.
+  for (const body of [signed, legacyAttestationBody(signed)]) {
+    const message = new TextEncoder().encode(canonicalize(body));
+    try {
+      if (await verifyP256(publicKeyB64, sig, message)) return true;
+    } catch (e) {
+      if (e instanceof SignatureVerifyError) continue;
+      throw e;
+    }
   }
+  return false;
+}
+
+/** Reconstruct the canonical body the pre-2026-07 provider actually SIGNED,
+ *  given the attestation as STORED on the PDS. Two divergences existed between
+ *  what `provider/src/attestation.rs` signed and what it wrote:
+ *
+ *  1. `mdaCertChain` — the signed `unsigned` JSON always carried
+ *     `"mdaCertChain":[]`, but the stored record used
+ *     `#[serde(skip_serializing_if = "Vec::is_empty")]`, dropping the field
+ *     entirely for the (overwhelmingly common) self-attested case. So restore
+ *     `[]` when the field is absent. A NON-empty chain is stored verbatim and
+ *     was signed verbatim, so leave it untouched.
+ *  2. timestamps — the signed form used seconds-precision RFC3339
+ *     (`SecondsFormat::Secs`), but the stored record serialized
+ *     `DateTime<Utc>` at chrono's default sub-second precision
+ *     (`...:08.384834Z`). Truncate the fractional seconds back off to recover
+ *     the signed string.
+ *
+ *  This mirrors the post-fix provider, which now stores exactly what it signs
+ *  (seconds-precision String timestamps, mdaCertChain only when non-empty) —
+ *  so post-fix records verify on the as-stored attempt and never reach here. */
+function legacyAttestationBody(signed: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...signed };
+  if (!("mdaCertChain" in out)) out.mdaCertChain = [];
+  for (const key of ["attestedAt", "expiresAt"]) {
+    const v = out[key];
+    if (typeof v === "string") out[key] = v.replace(/\.\d+(Z|[+-]\d\d:\d\d)$/, "$1");
+  }
+  return out;
 }
 
 // ---- internals -------------------------------------------------------

--- a/provider/src/attestation.rs
+++ b/provider/src/attestation.rs
@@ -110,8 +110,16 @@ pub struct AttestationRecord {
     /// Bytes — Secure Enclave P-256 signature over canonical JSON of
     /// every other field in this struct.
     pub selfSignature: String, // base64
-    pub attestedAt: DateTime<Utc>,
-    pub expiresAt: DateTime<Utc>,
+    // Seconds-precision RFC3339 strings, NOT `DateTime<Utc>`. The signed
+    // canonical body uses `rfc3339()` (SecondsFormat::Secs); storing a
+    // `DateTime` here would re-serialize at chrono's default sub-second
+    // precision, so the stored record would no longer match the bytes that
+    // were signed and every selfSignature check would fail. Storing the exact
+    // signed string keeps stored-bytes == signed-bytes. (This mirrors
+    // `receipt.rs`, whose `startedAt`/`completedAt` are `String` for the same
+    // reason — the divergence here is what stalled settlement in 2026-06.)
+    pub attestedAt: String,
+    pub expiresAt: String,
 }
 
 /// Sensible defaults for a self-attested provider — what cocore
@@ -345,7 +353,6 @@ pub fn build(
         "secureEnclaveAvailable": inputs.secure_enclave_available,
         "authenticatedRootEnabled": inputs.authenticated_root_enabled,
         "rdmaDisabled": inputs.rdma_disabled,
-        "mdaCertChain": mda_chain_b64,
         "hardenedRuntime": inputs.hardened_runtime,
         "libraryValidation": inputs.library_validation,
         "getTaskAllow": inputs.get_task_allow,
@@ -358,6 +365,15 @@ pub fn build(
         "expiresAt": rfc3339(expires_at),
     });
     if let Value::Object(map) = &mut unsigned {
+        // Sign `mdaCertChain` only when non-empty, mirroring the stored
+        // record's `#[serde(skip_serializing_if = "Vec::is_empty")]`. An empty
+        // chain (the self-attested common case) is absent from BOTH the signed
+        // bytes and the stored record, so they stay byte-identical. Signing an
+        // empty `[]` that storage then dropped is exactly what made every
+        // self-attested attestation unverifiable in 2026-06.
+        if !mda_chain_b64.is_empty() {
+            map.insert("mdaCertChain".into(), json!(mda_chain_b64));
+        }
         if let Some(cd) = &inputs.cd_hash {
             map.insert("cdHash".into(), Value::String(cd.clone()));
         }
@@ -410,13 +426,15 @@ pub fn build(
         envScrubbed: inputs.env_scrubbed,
         tier,
         selfSignature: B64.encode(&sig),
-        attestedAt: attested_at,
-        expiresAt: expires_at,
+        // Store the exact seconds-precision strings that were signed (NOT the
+        // `DateTime`s), so stored-bytes == signed-bytes.
+        attestedAt: rfc3339(attested_at),
+        expiresAt: rfc3339(expires_at),
     })
 }
 
-fn rfc3339(t: DateTime<Utc>) -> Value {
-    Value::String(t.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
+fn rfc3339(t: DateTime<Utc>) -> String {
+    t.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
 }
 
 fn hash_serial(serial: &str, did: &str) -> String {
@@ -486,6 +504,85 @@ mod tests {
         // is irrelevant to the tier; it gates trustLevel only.)
         assert_eq!(rec.tier, "best-effort");
         assert!(!rec.inProcessBackend);
+    }
+
+    #[test]
+    fn stored_record_canonicalizes_to_the_signed_bytes() {
+        // Regression guard for the 2026-06 settlement stall. The record we
+        // WRITE to the PDS (serde of `AttestationRecord`) must canonicalize to
+        // the EXACT bytes we SIGNED. The stall had two causes, both reproduced
+        // here as a single invariant:
+        //   * a field signed but dropped on store (`mdaCertChain: []`), and
+        //   * timestamps signed at seconds precision but stored as `DateTime`
+        //     at sub-second precision.
+        // Either makes the stored record's canonical bytes differ from the
+        // signed bytes, so the enclave selfSignature no longer verifies against
+        // what a consumer reads back — and settlement silently rejects every
+        // receipt. Verify the STORED form cryptographically, the way the
+        // AppView/exchange does.
+        use base64::{engine::general_purpose::STANDARD as B64, Engine};
+        use p256::ecdsa::{signature::Verifier, Signature, VerifyingKey};
+        use p256::EncodedPoint;
+
+        let _g = identity_lock();
+        let signer = load_or_create_identity().unwrap();
+        // Self-attested common case: empty MDA chain, so `mdaCertChain` is
+        // absent from BOTH signed and stored forms.
+        let inputs = AttestationInputs {
+            provider_did: "did:plc:test".into(),
+            encryption_pub_key_b64: "abc".into(),
+            chip_name: "Apple M5 Max".into(),
+            hardware_model: "Mac17,6".into(),
+            serial_number: "STORE-EQ".into(),
+            os_version: "26.5.2".into(),
+            binary_path: std::path::PathBuf::from("/nonexistent"),
+            sip_enabled: true,
+            secure_boot_enabled: true,
+            secure_enclave_available: false,
+            authenticated_root_enabled: false,
+            rdma_disabled: true,
+            mda_cert_chain: vec![],
+            app_attest: None,
+            cd_hash: Some("ab".repeat(20)),
+            team_id: Some("4L45P7CP9M".into()),
+            hardened_runtime: true,
+            library_validation: false,
+            get_task_allow: false,
+            metallib_hash: None,
+            engine_lib_hash: None,
+            in_process_backend: false,
+            anti_debug: true,
+            core_dumps_disabled: true,
+            env_scrubbed: true,
+        };
+        let rec = build(inputs, &*signer).unwrap();
+
+        // Serialize exactly as written to the PDS, strip the signature, and
+        // canonicalize — this is precisely what a verifier reconstructs.
+        let mut stored: Value = serde_json::to_value(&rec).unwrap();
+        let map = stored.as_object_mut().unwrap();
+        let sig_der = B64
+            .decode(map.remove("selfSignature").unwrap().as_str().unwrap())
+            .unwrap();
+        // The empty self-attested chain must NOT be present in the stored form
+        // (and so must not be in the signed form either).
+        assert!(
+            !map.contains_key("mdaCertChain"),
+            "an empty mdaCertChain must be absent from the stored record"
+        );
+        let canonical = to_canonical_bytes(&stored).unwrap();
+
+        let pub_bytes = B64.decode(rec.publicKey.as_bytes()).unwrap();
+        let mut uncompressed = [0u8; 65];
+        uncompressed[0] = 0x04;
+        uncompressed[1..].copy_from_slice(&pub_bytes);
+        let vk = VerifyingKey::from_encoded_point(
+            &EncodedPoint::from_bytes(uncompressed).unwrap(),
+        )
+        .unwrap();
+        let sig = Signature::from_der(&sig_der).unwrap();
+        vk.verify(&canonical, &sig)
+            .expect("stored record must verify against the signed canonical bytes");
     }
 
     #[test]

--- a/provider/src/attestation.rs
+++ b/provider/src/attestation.rs
@@ -576,10 +576,8 @@ mod tests {
         let mut uncompressed = [0u8; 65];
         uncompressed[0] = 0x04;
         uncompressed[1..].copy_from_slice(&pub_bytes);
-        let vk = VerifyingKey::from_encoded_point(
-            &EncodedPoint::from_bytes(uncompressed).unwrap(),
-        )
-        .unwrap();
+        let vk = VerifyingKey::from_encoded_point(&EncodedPoint::from_bytes(uncompressed).unwrap())
+            .unwrap();
         let sig = Signature::from_der(&sig_der).unwrap();
         vk.verify(&canonical, &sig)
             .expect("stored record must verify against the signed canonical bytes");


### PR DESCRIPTION
## Summary

The 2026-06 settlement stall had a **second** root cause beyond the receipt `$type` regression fixed in #145. Even with receipt signatures verifying, every attestation failed `selfSignature` verification, so `verifyForChargeStrict` rejected **every** receipt with `attestation-selfsig-invalid` and **no settlements were ever written**. This is why settlements stayed frozen and `cocore.tokens` never moved after #145 deployed.

The provider signed a canonical attestation body that differed from the record it actually wrote to its PDS in two ways:

1. **`mdaCertChain`** — signed as `[]` but dropped from the stored record by serde's `skip_serializing_if = "Vec::is_empty"` (the self-attested common case). The stored record was missing a field the signature covered.
2. **timestamps** — signed at seconds precision (`SecondsFormat::Secs`) but stored as `DateTime<Utc>`, which serde re-serialized at chrono's default sub-second precision. The stored bytes no longer matched the signed bytes.

Either divergence shifts the canonical JSON and breaks the signature. This is the attestation analogue of the receipt `$type` bug, and the same class as the receipt `startedAt`/`completedAt` fields already being stored as seconds-precision `String`s — which is exactly why receipts verified and attestations did not.

## Changes

**Verifier — `packages/sdk/src/p256.ts`**
`verifyAttestationSignature` now tries the record **as-stored first**, then falls back to reconstructing the legacy signed body (restore `mdaCertChain: []` when absent, truncate timestamps to seconds). Already-published attestations can't be re-signed (the key is enclave-bound), so the verifier must reconstruct what was signed to drain the stranded backlog. The exact-as-stored attempt runs first, so this never weakens verification of a correctly-signed record.

**Provider — `provider/src/attestation.rs`**
Store exactly what is signed: `attestedAt`/`expiresAt` as seconds-precision `String`s (mirroring `receipt.rs`), and `mdaCertChain` signed only when non-empty (mirroring the stored `skip_serializing_if`). A new test cryptographically verifies the **stored** record's canonical bytes against the enclave signature, so any future signed-vs-stored divergence fails CI instead of silently stalling settlement.

## Verification

- New `verifyAttestationSignature` regression test (legacy signed form → stored form verifies; post-fix form verifies as-stored; tamper still fails). Self-contained, passing.
- New Rust `stored_record_canonicalizes_to_the_signed_bytes` test. Passing.
- **End-to-end against live records:** a stranded attestation now verifies, and `verifyForChargeStrict` on a fresh live receipt chain returns `ok: true` with zero findings.

## Follow-up

Once this deploys, the stranded receipt backlog can be drained via the `dev.cocore.admin.backfillSettlements` endpoint added in #145 (`clearRejected: true`), and `cocore.tokens` should resume moving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEbytgbQLfLLpHe3TP7Uo8)_