### PR TITLE
docs(security): calibrate confidential-tier claims to the actual posture

### DIFF
--- a/packages/console/src/components/TrustTierBadge.tsx
+++ b/packages/console/src/components/TrustTierBadge.tsx
@@ -11,7 +11,7 @@ import { Badge } from "@/design-system/badge";
 export type TrustTier = "best-effort" | "hardware-attested" | "attested-confidential";
 
 const CONFIDENTIAL_TITLE =
-  "Confidential tier — verified from this machine's signed, Apple-rooted attestation: genuine hardware bound to its signing key, a known-good measured build, hardened posture, and live code-attestation. Your prompt is sealed so the operator can't read it.";
+  "Confidential tier — verified from this machine's signed, Apple-rooted attestation: genuine hardware bound to its signing key, a known-good measured build, hardened posture, and live code-attestation. Your prompt is sealed and served inside the measured binary, so the operator has no ordinary way to read it — a hardened-runtime posture, not a hardware enclave.";
 
 const HARDWARE_TITLE =
   "Hardware-attested — verified from this machine's signed, Apple-rooted attestation chain, bound to its signing key. Proven genuine Apple hardware (not a self-asserted claim).";

--- a/packages/console/src/components/docs/security-page.tsx
+++ b/packages/console/src/components/docs/security-page.tsx
@@ -55,22 +55,25 @@ export function SecurityDocsPage() {
         </p>
 
         <h2 {...stylex.props(docsStyles.h2)}>
-          The Confidential tier — “the operator can&apos;t read the prompts”
+          The Confidential tier — sealing prompts from the machine&apos;s operator
         </h2>
         <p {...stylex.props(docsStyles.prose)}>
           This is the guarantee that matters to a <strong>requestor</strong>: when you send a prompt
-          to a confidential provider, the machine&apos;s own operator cannot read it. A best-effort
-          provider runs inference in a helper process the operator controls and could observe. A
-          confidential provider instead runs inference{" "}
+          to a confidential provider, the machine&apos;s own operator has{" "}
+          <em>no ordinary, supported way</em> to read it. A best-effort provider runs inference in a
+          helper process the operator controls and can freely observe. A confidential provider
+          instead runs inference{" "}
           <strong>entirely inside the measured, signed co/core agent</strong> — the in-process
-          engine, with no subprocess and no IPC to tap — so the plaintext never leaves the attested
-          binary. There is no observation surface for the operator to use.
+          engine, with no subprocess and no IPC to tap — so the plaintext stays inside the attested
+          binary, under a hardened runtime with library validation and anti-debugging. The operator&apos;s
+          everyday tools for looking inside a running program — reading another process&apos;s memory,
+          attaching a debugger, swapping in a logging build — don&apos;t reach it.
         </p>
         <p {...stylex.props(docsStyles.prose)}>
           “Operator” here means the person running the provider machine. If you&apos;re an operator
-          reading this in the app: confidential means that <em>you</em> can&apos;t read what
-          requestors send you — and that&apos;s the point. It&apos;s what lets requestors trust your
-          machine with sensitive work.
+          reading this in the app: confidential means that <em>you</em> have no ordinary way to read
+          what requestors send you — and that&apos;s the point. It&apos;s what lets requestors trust
+          your machine with sensitive work.
         </p>
         <p {...stylex.props(docsStyles.prose)}>
           How it&apos;s proven, so a requestor doesn&apos;t have to take the operator&apos;s word
@@ -81,14 +84,40 @@ export function SecurityDocsPage() {
           advertise the <strong>attested-confidential</strong> tier.
         </p>
 
+        <h2 {...stylex.props(docsStyles.h2)}>What the confidential tier is — and isn&apos;t</h2>
+        <p {...stylex.props(docsStyles.prose)}>
+          Be precise about the <em>kind</em> of guarantee this is, because it&apos;s easy to overstate.
+          The confidential tier is <strong>not</strong> a hardware trusted-execution environment (TEE)
+          in the sense of Intel SGX, AMD SEV-SNP, or AWS Nitro Enclaves. Apple&apos;s Secure Enclave
+          protects the device&apos;s signing keys and produces the attestation, but it does{" "}
+          <strong>not</strong> run the model — your prompt and the model weights execute in ordinary
+          macOS user space and on the GPU, like any other app.
+        </p>
+        <p {...stylex.props(docsStyles.prose)}>
+          What seals them from the operator is the <strong>verified platform-security posture</strong>,
+          not memory isolation in silicon: code signing, System Integrity Protection, the hardened
+          runtime, library validation, anti-debugging, disabled core dumps, and the absence of any
+          subprocess or IPC to tap. Under that posture the operator has no <em>ordinary</em> path to
+          the plaintext — but the guarantee still rests on the OS and the signed-binary supply chain
+          being intact. A vulnerability in macOS or in the agent, or a maliciously substituted signed
+          build, could still expose plaintext. So the honest claim is a raised bar, not an absolute:
+          confidential moves the trust from <em>“trust the machine&apos;s operator”</em> to{" "}
+          <em>“trust Apple&apos;s platform security and co/core&apos;s measured, signed build”</em> —
+          a meaningful shift, but a different and shallower one than a hardware enclave that isolates
+          memory from the host itself. If you need that stronger property, a hardware-TEE provider is
+          the right tool; the confidential tier is the strongest guarantee reachable on stock Apple
+          hardware without one.
+        </p>
+
         <h2 {...stylex.props(docsStyles.h2)}>Why they&apos;re independent</h2>
         <p {...stylex.props(docsStyles.prose)}>
           <strong>Neither</strong> — fast best-effort serving: a real-enough machine whose operator
           can read prompts. <strong>Secure Mode only</strong> — proven genuine hardware, but
           inference still runs where the operator can read it. <strong>Confidential only</strong> —
-          the operator can&apos;t read prompts, but you&apos;re trusting the code-identity proof
-          without an Apple hardware-root attestation of the silicon. <strong>Both</strong> — genuine
-          attested hardware <em>and</em> a sealed, operator-blind inference path.
+          the operator has no ordinary way to read prompts, but you&apos;re trusting the code-identity
+          proof without an Apple hardware-root attestation of the silicon. <strong>Both</strong> —
+          genuine attested hardware <em>and</em> a sealed inference path the operator can&apos;t
+          ordinarily read.
         </p>
 
         <h2 {...stylex.props(docsStyles.h2)}>The model constraint for operators</h2>

--- a/packages/console/src/components/docs/security-page.tsx
+++ b/packages/console/src/components/docs/security-page.tsx
@@ -62,12 +62,12 @@ export function SecurityDocsPage() {
           to a confidential provider, the machine&apos;s own operator has{" "}
           <em>no ordinary, supported way</em> to read it. A best-effort provider runs inference in a
           helper process the operator controls and can freely observe. A confidential provider
-          instead runs inference{" "}
-          <strong>entirely inside the measured, signed co/core agent</strong> — the in-process
-          engine, with no subprocess and no IPC to tap — so the plaintext stays inside the attested
-          binary, under a hardened runtime with library validation and anti-debugging. The operator&apos;s
-          everyday tools for looking inside a running program — reading another process&apos;s memory,
-          attaching a debugger, swapping in a logging build — don&apos;t reach it.
+          instead runs inference <strong>entirely inside the measured, signed co/core agent</strong>{" "}
+          — the in-process engine, with no subprocess and no IPC to tap — so the plaintext stays
+          inside the attested binary, under a hardened runtime with library validation and
+          anti-debugging. The operator&apos;s everyday tools for looking inside a running program —
+          reading another process&apos;s memory, attaching a debugger, swapping in a logging build —
+          don&apos;t reach it.
         </p>
         <p {...stylex.props(docsStyles.prose)}>
           “Operator” here means the person running the provider machine. If you&apos;re an operator
@@ -86,27 +86,28 @@ export function SecurityDocsPage() {
 
         <h2 {...stylex.props(docsStyles.h2)}>What the confidential tier is — and isn&apos;t</h2>
         <p {...stylex.props(docsStyles.prose)}>
-          Be precise about the <em>kind</em> of guarantee this is, because it&apos;s easy to overstate.
-          The confidential tier is <strong>not</strong> a hardware trusted-execution environment (TEE)
-          in the sense of Intel SGX, AMD SEV-SNP, or AWS Nitro Enclaves. Apple&apos;s Secure Enclave
-          protects the device&apos;s signing keys and produces the attestation, but it does{" "}
-          <strong>not</strong> run the model — your prompt and the model weights execute in ordinary
-          macOS user space and on the GPU, like any other app.
+          Be precise about the <em>kind</em> of guarantee this is, because it&apos;s easy to
+          overstate. The confidential tier is <strong>not</strong> a hardware trusted-execution
+          environment (TEE) in the sense of Intel SGX, AMD SEV-SNP, or AWS Nitro Enclaves.
+          Apple&apos;s Secure Enclave protects the device&apos;s signing keys and produces the
+          attestation, but it does <strong>not</strong> run the model — your prompt and the model
+          weights execute in ordinary macOS user space and on the GPU, like any other app.
         </p>
         <p {...stylex.props(docsStyles.prose)}>
-          What seals them from the operator is the <strong>verified platform-security posture</strong>,
-          not memory isolation in silicon: code signing, System Integrity Protection, the hardened
-          runtime, library validation, anti-debugging, disabled core dumps, and the absence of any
-          subprocess or IPC to tap. Under that posture the operator has no <em>ordinary</em> path to
-          the plaintext — but the guarantee still rests on the OS and the signed-binary supply chain
-          being intact. A vulnerability in macOS or in the agent, or a maliciously substituted signed
-          build, could still expose plaintext. So the honest claim is a raised bar, not an absolute:
-          confidential moves the trust from <em>“trust the machine&apos;s operator”</em> to{" "}
-          <em>“trust Apple&apos;s platform security and co/core&apos;s measured, signed build”</em> —
-          a meaningful shift, but a different and shallower one than a hardware enclave that isolates
-          memory from the host itself. If you need that stronger property, a hardware-TEE provider is
-          the right tool; the confidential tier is the strongest guarantee reachable on stock Apple
-          hardware without one.
+          What seals them from the operator is the{" "}
+          <strong>verified platform-security posture</strong>, not memory isolation in silicon: code
+          signing, System Integrity Protection, the hardened runtime, library validation,
+          anti-debugging, disabled core dumps, and the absence of any subprocess or IPC to tap.
+          Under that posture the operator has no <em>ordinary</em> path to the plaintext — but the
+          guarantee still rests on the OS and the signed-binary supply chain being intact. A
+          vulnerability in macOS or in the agent, or a maliciously substituted signed build, could
+          still expose plaintext. So the honest claim is a raised bar, not an absolute: confidential
+          moves the trust from <em>“trust the machine&apos;s operator”</em> to{" "}
+          <em>“trust Apple&apos;s platform security and co/core&apos;s measured, signed build”</em>{" "}
+          — a meaningful shift, but a different and shallower one than a hardware enclave that
+          isolates memory from the host itself. If you need that stronger property, a hardware-TEE
+          provider is the right tool; the confidential tier is the strongest guarantee reachable on
+          stock Apple hardware without one.
         </p>
 
         <h2 {...stylex.props(docsStyles.h2)}>Why they&apos;re independent</h2>
@@ -114,10 +115,10 @@ export function SecurityDocsPage() {
           <strong>Neither</strong> — fast best-effort serving: a real-enough machine whose operator
           can read prompts. <strong>Secure Mode only</strong> — proven genuine hardware, but
           inference still runs where the operator can read it. <strong>Confidential only</strong> —
-          the operator has no ordinary way to read prompts, but you&apos;re trusting the code-identity
-          proof without an Apple hardware-root attestation of the silicon. <strong>Both</strong> —
-          genuine attested hardware <em>and</em> a sealed inference path the operator can&apos;t
-          ordinarily read.
+          the operator has no ordinary way to read prompts, but you&apos;re trusting the
+          code-identity proof without an Apple hardware-root attestation of the silicon.{" "}
+          <strong>Both</strong> — genuine attested hardware <em>and</em> a sealed inference path the
+          operator can&apos;t ordinarily read.
         </p>
 
         <h2 {...stylex.props(docsStyles.h2)}>The model constraint for operators</h2>

--- a/packages/console/src/components/machines/MachineDetail.tsx
+++ b/packages/console/src/components/machines/MachineDetail.tsx
@@ -533,7 +533,7 @@ export function MachineDetail({ rkey }: { rkey: string }) {
             <dt {...stylex.props(styles.kvDt)}>Confidential tier</dt>
             <dd {...stylex.props(styles.kvDd)}>
               {m.tier === "attested-confidential"
-                ? "🔒 Confidential — the operator cannot read your prompts"
+                ? "🔒 Confidential — sealed so the operator has no ordinary way to read your prompts"
                 : m.desiredTier === "attested-confidential"
                   ? "Upgrade pending — opted in; finishing on the next serve"
                   : "Best-effort — fast, but the operator can read prompts"}
@@ -573,9 +573,9 @@ export function MachineDetail({ rkey }: { rkey: string }) {
             ) : (
               <>
                 <LabelText variant="secondary">
-                  Optional: upgrade this machine to the confidential tier so the operator can&apos;t
-                  read prompts. It won&apos;t change how this machine serves today — you can turn it
-                  off anytime.
+                  Optional: upgrade this machine to the confidential tier so the operator has no
+                  ordinary way to read prompts. It won&apos;t change how this machine serves today —
+                  you can turn it off anytime.
                 </LabelText>
                 <Button
                   variant="primary"

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -17,7 +17,8 @@ export interface StrongRef {
 
 export type TrustLevel = "self-attested" | "hardware-attested";
 /** Confidentiality tier — whether the prompt was provably handled only inside
- *  a measured, signed binary the owner cannot read. Distinct from TrustLevel.
+ *  a measured, signed binary, under a hardened posture the owner has no ordinary
+ *  way to read (a software seal, not a hardware enclave). Distinct from TrustLevel.
  *  A verifier MUST recompute this from evidence (see {@link verifyProviderForSeal})
  *  and never trust a self-asserted value. */
 export type Tier = "attested-confidential" | "best-effort";

--- a/provider-shell/Sources/CoCoreShell/MenuBarController.swift
+++ b/provider-shell/Sources/CoCoreShell/MenuBarController.swift
@@ -498,7 +498,7 @@ final class MenuBarController {
                 let alert = NSAlert()
                 alert.messageText = "Enable confidential serving?"
                 alert.informativeText =
-                    "Inference will run entirely inside the measured, signed agent, so this machine's operator can't read prompts.\n\nThe confidential engine serves Qwen2 / Llama / Gemma / Phi models — an incompatible model (e.g. a Qwen3 model) will show a fault, so pick a compatible one under Models. The agent will restart to switch over."
+                    "Inference will run entirely inside the measured, signed agent, under a hardened runtime with no subprocess to tap — so this machine's operator has no ordinary way to read prompts. (It's a software-sealed posture, not a hardware enclave.)\n\nThe confidential engine serves Qwen2 / Llama / Gemma / Phi models — an incompatible model (e.g. a Qwen3 model) will show a fault, so pick a compatible one under Models. The agent will restart to switch over."
                 alert.addButton(withTitle: "Enable")
                 alert.addButton(withTitle: "Cancel")
                 guard alert.runModal() == .alertFirstButtonReturn else { return }

--- a/provider-shell/Sources/CoCoreShell/StatusView.swift
+++ b/provider-shell/Sources/CoCoreShell/StatusView.swift
@@ -155,7 +155,7 @@ struct StatusRows: View {
             switch state.confidentialPhase {
             case .active:
                 secureCaption(
-                    "Requests run sealed inside the measured, signed agent, so not even you — this Mac's operator — can read what requestors send or receive. That unreadable-by-the-operator guarantee is what requestors get.",
+                    "Requests run sealed inside the measured, signed agent, under a hardened runtime with no subprocess to tap — so you, this Mac's operator, have no ordinary way to read what requestors send or receive. That's the guarantee requestors get. (It's a software-sealed posture, not a hardware enclave: it holds as long as macOS and the signed build aren't compromised.)",
                     .secondary)
             case .applying(let reason):
                 // The interstitial that fixes "I have to toggle until it takes":
@@ -166,7 +166,7 @@ struct StatusRows: View {
                     .orange)
             case .off:
                 secureCaption(
-                    "Requests run in a local helper process that you, this Mac's operator, could read — fine for non-sensitive work. Enable confidential to seal them so requestors get a no-snooping guarantee. The confidential engine serves Qwen2 / Qwen3 / Llama / Gemma / Phi-class models.",
+                    "Requests run in a local helper process that you, this Mac's operator, could read — fine for non-sensitive work. Enable confidential to seal them inside the measured agent so you have no ordinary way to read them. The confidential engine serves Qwen2 / Qwen3 / Llama / Gemma / Phi-class models.",
                     .secondary)
             }
             if let setConfidential = onSetConfidential {


### PR DESCRIPTION
## Why

A review thread flagged the security copy as overclaiming. The console docs and several UI surfaces asserted the confidential tier as an **absolute** — "There is no observation surface for the operator to use", "the operator cannot read it", "not even you can read what requestors send" — while `packages/console/src/lib/terms-content.ts` already states the honest version (these mitigations "do **not** guarantee that the operator cannot read prompts"). The marketing/UI surfaces and the terms were inconsistent.

The thread's technical critique is correct:

- The confidential tier is **not** a hardware TEE (SGX / SEV-SNP / Nitro Enclaves). Apple's Secure Enclave protects signing keys and produces the attestation, but it does **not** run the model.
- The prompt and model weights execute in ordinary macOS user space / on the GPU.
- What seals them is the **verified platform-security posture** (in-process measured binary, hardened runtime, library validation, SIP, anti-debugging, disabled core dumps, no subprocess/IPC) — which removes the operator's *ordinary* observation paths, but still rests on the OS and the signed-binary supply chain being intact.

## What changed

Copy only — no behavior change.

- **`docs/security` page** (`security-page.tsx`): softened the absolute claims to "no ordinary, supported way to read"; replaced "There is no observation surface…" with a concrete description of what the posture does and doesn't block; **added a new section, "What the confidential tier is — and isn't,"** that names the TEE distinction and the residual trust assumptions.
- **`TrustTierBadge.tsx`**, **`MachineDetail.tsx`**: tooltip/label calibration ("no ordinary way to read", "a hardened-runtime posture, not a hardware enclave").
- **`packages/sdk/src/types.ts`**: `Tier` doc comment calibrated.
- **provider-shell** (`StatusView.swift`, `MenuBarController.swift`): confidential captions and the enable-confidential confirm dialog calibrated, with a "software-sealed posture, not a hardware enclave" note.

## Out of scope (separate finding)

The thread also reports the attestation **doesn't complete** — Secure Mode stuck "Securing…" and Confidential stuck "Applying…" for ~24h, with the message *"This Mac isn't connected to the co/core network yet."* That string is emitted by `agent.status.ts` / `agent-status.ts` when the machine has **no advisor rows** — i.e. the agent's `serve` loop never connected to the advisor/matchmaker, so confidential can never be verified. That's a runtime/connectivity issue that needs the actual machine to diagnose; it's not addressable in a copy review. Flagging it here so it isn't lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHapRMzbVPXnA8wdZQ8eya)_