### PR TITLE
fix: bind confidential/attested routing to the serving machine

### DIFF
--- a/docs/adr/0002-model-identity-and-output-binding.md
+++ b/docs/adr/0002-model-identity-and-output-binding.md
@@ -1,0 +1,129 @@
+# ADR-0002: Model-identity binding and output-verification for receipts
+
+Status: proposed
+Date: 2026-07-01
+
+## Context
+
+A public exploit thread (Astra, 2026-07-01) demonstrated that co/core's
+trust boundaries were self-asserted by the provider and taken at face value
+by the backend. Four distinct issues were shown against a live
+`/verified/chat/completions` endpoint:
+
+1. **Attestation not bound to the serving machine.** An attested Mac and an
+   unattested Linux box registered under one DID; confidential/attested
+   requests routed to the unattested node ~80% of the time, which then read
+   the plaintext prompt and served whatever it liked.
+2. **Confidential prompts exfiltrated** to a public Bluesky account.
+3. **Model impersonation** — the provider self-asserts `model` in the
+   response/receipt; nothing binds returned tokens to the model that ran.
+4. **Junk-drain + self-credit** — the provider self-reports `tokens`,
+   derives `price` from them, and is both billed-against and credited on
+   that number, so it can charge the requester up to the authorized ceiling
+   for near-zero real work.
+
+Issues (1) and (2)'s live vector are fixed in the same change set as this
+ADR (machine-scoped verified allow-set; see
+`packages/console/src/lib/verified-standing.server.ts::resolveVerifiedProviderKeys`).
+Issue (4) is **partially** fixed there too: the receipt-vs-job validator now
+rejects `receipt.tokens.out > job.maxTokensOut`
+(`packages/sdk/src/validate.ts`, finding `tokens-over-job-ceiling`), bounding
+the token record to what the requester authorized.
+
+This ADR covers the two remaining problems that need a *design* change, not a
+one-line gate: **binding the returned output to the model that actually ran
+(issue 3)** and **the residual junk-for-authorized-amount half of issue 4**.
+Both are noted as gaps in ADR-0001 (Apple MDA / in-process inference
+milestones) and in the 2026-06 audit.
+
+## Problem statement
+
+The receipt commits to `model`, `inputCommitment`, `outputCommitment`,
+`tokens`, and an `enclaveSignature`. What it does **not** prove:
+
+- **Which model produced the output.** `model` is an opaque string the
+  provider writes. A provider can label a Gemma-4-26B response as any model
+  id, or return output from no model at all.
+- **That the output bytes are genuine model work.** `outputCommitment` is a
+  hash of whatever bytes the provider chose to return. A requester can
+  recompute it to detect *tampering in transit*, but nothing forces those
+  bytes to be real inference over the committed input under the committed
+  model.
+
+The economic consequence (issue 4 residual): under pre-authorization, the
+exchange settles any valid receipt against the requester's payment
+authorization up to `priceCeiling`. A provider that returns
+`maxTokensOut` worth of junk publishes a perfectly valid receipt and is
+credited for it. The token-ceiling gate stops *over-claiming*; it does not
+make junk detectable.
+
+## Options considered
+
+### A. Model-weights fingerprint in the attestation, strong-ref'd from the receipt
+The measured binary computes a fingerprint of the loaded model (e.g. a hash
+over the weights / manifest) and includes it in the signed attestation. The
+receipt already strong-refs an attestation; add a `modelFingerprint` (or
+reuse the attestation ref + a `model` allow-list the attestation carries) so
+`(model id -> fingerprint)` is attested, not self-asserted. A requester/AppView
+verifies the receipt's `model` maps to a fingerprint the attestation vouches
+for.
+
+- Pro: keeps the "receipt + lexicon + DID doc verifies offline" invariant.
+  No coordinator.
+- Con: only as strong as the attestation's measured-boundary. A provider
+  that runs the real weights but swaps the sampling/output still passes.
+  Requires the in-process (native) engine to be load-bearing (ADR-0001 M2).
+
+### B. Output-verification / dispute record
+Mint a `dev.cocore.compute.dispute` (or extend settlement) so a requester who
+decrypts the output and finds it inconsistent (empty, wrong language, doesn't
+follow the committed input) can publish a signed dispute that the exchange and
+future requesters weigh into provider standing. Settlement optionally holds a
+challenge window before crediting.
+
+- Pro: catches the junk case A can't (real weights, junk output). Federable.
+- Con: subjective ("is this output good?") unless paired with a
+  deterministic re-execution oracle; adds a settlement-latency window.
+
+### C. Deterministic re-execution oracle
+A verifier re-runs the inference (fixed seed, greedy decode) and checks the
+output matches. Strongest, but expensive, requires reproducible decoding
+across hardware, and reintroduces a privileged verifier — smells like a
+coordinator. Rejected as the default; may fit as an opt-in audit.
+
+## Recommendation (to ratify)
+
+- **Adopt A as the model-identity primitive** (lexicon-additive:
+  `modelFingerprint` on the attestation, verified in `validate.ts` /
+  `verify-provider.ts`), gated on the native in-process engine being the only
+  path that can reach the confidential tier — which the issue-1 fix already
+  enforces.
+- **Adopt B for the economic residual**, minimally: a challenge window +
+  signed dispute record feeding provider standing, so junk-for-authorized is
+  detectable and costly rather than free. Keep it federable (no privileged
+  verifier).
+- Defer C to an opt-in audit tool.
+
+Per CLAUDE.md, this is lexicon-first: land the `modelFingerprint` /
+`dispute` lexicon changes (with version bumps) in their own PR before any
+provider/consumer code assumes them. This ADR is the rationale that PR
+references.
+
+## Consequences
+
+- Requesters gain a cryptographic answer to "did the model I asked for
+  actually run?", not just "were the bytes tampered with in transit?".
+- The confidential tier's guarantee tightens from "verified hardware +
+  hardened runtime" to also "attested model identity".
+- Nothing here introduces a coordinator; all new state is
+  provider/requester-signed records under `dev.cocore.*`.
+
+## Status of the sibling fixes (this change set, not this ADR)
+
+- Machine-scoped verified allow-set — DONE
+  (`resolveVerifiedProviderKeys`, regression test in
+  `packages/console/src/lib/inference-dispatch.test.ts`).
+- `tokens.out <= job.maxTokensOut` enforcement — DONE
+  (`packages/sdk/src/validate.ts`, `tokens-over-job-ceiling`).
+- Confidential-tier badge/doc wording softened to a hardened-runtime posture
+  — DONE (`packages/console/src/components/TrustTierBadge.tsx`).

--- a/packages/console/src/components/TrustTierBadge.tsx
+++ b/packages/console/src/components/TrustTierBadge.tsx
@@ -11,7 +11,7 @@ import { Badge } from "@/design-system/badge";
 export type TrustTier = "best-effort" | "hardware-attested" | "attested-confidential";
 
 const CONFIDENTIAL_TITLE =
-  "Confidential tier — verified from this machine's signed, Apple-rooted attestation: genuine hardware bound to its signing key, a known-good measured build, hardened posture, and live code-attestation. Your prompt is sealed and served inside the measured binary, so the operator has no ordinary way to read it — a hardened-runtime posture, not a hardware enclave.";
+  "Confidential tier — verified from THIS machine's signed, Apple-rooted attestation: genuine hardware bound to its signing key, a known-good measured build, hardened posture, and live code-attestation. Your prompt is served inside the measured binary's in-process engine (no observable subprocess), so the operator has no ordinary path to the plaintext. This is a hardened-runtime posture, not a hardware enclave: the guarantee rests on macOS and the signed-binary supply chain being intact, and a compromised OS, an agent vulnerability, or a maliciously substituted signed build could still expose the prompt.";
 
 const HARDWARE_TITLE =
   "Hardware-attested — verified from this machine's signed, Apple-rooted attestation chain, bound to its signing key. Proven genuine Apple hardware (not a self-asserted claim).";

--- a/packages/console/src/lib/inference-dispatch.test.ts
+++ b/packages/console/src/lib/inference-dispatch.test.ts
@@ -106,11 +106,29 @@ describe("filterByAllowedDids", () => {
     assert.deepEqual(out, [m1]);
   });
 
-  test("a bare DID still matches every machine of that owner (friends/verified)", () => {
+  test("a bare DID still matches every machine of that owner (friends path)", () => {
+    // Friends routing is owner-granular by design: a friend vouches for the
+    // person, not a specific box. The verified/confidential path must NOT use
+    // bare DIDs (see the attestation-binding regression below).
     const m1 = { did: "did:plc:alice", machineId: "rkeyA" };
     const m2 = { did: "did:plc:alice", machineId: "rkeyB" };
     const out = filterByAllowedDids([m1, m2], new Set(["did:plc:alice"]));
     assert.deepEqual(out, [m1, m2]);
+  });
+
+  test("attestation binding: confidential standing never widens to an unattested sibling", () => {
+    // The exploit: an attested Mac and an unattested Linux box register under
+    // ONE DID. resolveVerifiedProviderKeys emits a composite key ONLY for the
+    // machine that actually passes the tier check (the Mac). Dispatch must then
+    // route confidential traffic to the Mac alone — the Linux box, which shares
+    // the DID, must be filtered out. A DID-scoped set (the old behavior) would
+    // have admitted BOTH, sending the confidential prompt to the unattested node.
+    const mac = { did: "did:plc:astra", machineId: "mac-rkey" };
+    const linux = { did: "did:plc:astra", machineId: "linux-rkey" };
+    const verifiedKeys = new Set(["did:plc:astra:mac-rkey"]);
+    assert.deepEqual(filterByAllowedDids([mac, linux], verifiedKeys), [mac]);
+    // Regression guard: the old bare-DID form would have leaked to Linux too.
+    assert.deepEqual(filterByAllowedDids([mac, linux], new Set(["did:plc:astra"])), [mac, linux]);
   });
 });
 

--- a/packages/console/src/lib/openai-routes.server.ts
+++ b/packages/console/src/lib/openai-routes.server.ts
@@ -48,7 +48,7 @@ import { verifyServiceAuth } from "@/lib/service-auth.server.ts";
 import { buildModelDirectory } from "@/lib/model-directory.server.ts";
 import {
   parseTrustFloor,
-  resolveVerifiedProviderDids,
+  resolveVerifiedProviderKeys,
   type TrustFloor,
 } from "@/lib/verified-standing.server.ts";
 
@@ -418,7 +418,9 @@ export async function handleVerifiedChatCompletions(request: Request): Promise<R
 
   let allowedProviderDids: Set<string>;
   try {
-    allowedProviderDids = await resolveVerifiedProviderDids(floor, parsed.model);
+    // Machine-scoped `${did}:${machineId}` keys — an owner's unattested
+    // machine never inherits an attested sibling's standing.
+    allowedProviderDids = await resolveVerifiedProviderKeys(floor, parsed.model);
   } catch (e) {
     return jsonError(
       502,

--- a/packages/console/src/lib/verified-standing.server.ts
+++ b/packages/console/src/lib/verified-standing.server.ts
@@ -156,11 +156,27 @@ export async function verifiedTierFor(row: AdvisorRow): Promise<VerifiedTier> {
   return row.confidentialEligible === true ? "attested-confidential" : "hardware-attested";
 }
 
-/** Set of provider DIDs whose VERIFIED tier meets `floor` (optionally for a
- *  given model). This is the proof-backed allow-set the verified completions
- *  path routes against — built the same way the friends path builds its set,
- *  but from cryptographic verification instead of friend records. */
-export async function resolveVerifiedProviderDids(
+/** Set of MACHINE keys (`${did}:${machineId}`) whose VERIFIED tier meets
+ *  `floor` (optionally for a given model). This is the proof-backed allow-set
+ *  the verified completions path routes against.
+ *
+ *  MUST be keyed per machine, not per owner DID. Tier is computed per row
+ *  (each row carries its own `attestationUri` + advisor-measured
+ *  `confidentialEligible`), but a DID can hold many machines: a genuinely
+ *  attested Mac and an unattested Linux box under the SAME DID. A DID-scoped
+ *  allow-set lets {@link filterByAllowedDids} widen from the attested machine
+ *  to every sibling under that DID — so an `attested-confidential` request
+ *  routes to the unattested node, which then reads the plaintext prompt and
+ *  serves whatever model it likes. The composite `${did}:${machineId}` key is
+ *  matched by {@link filterByAllowedDids} against the advisor row's
+ *  `(did, machineId)`, exactly like the pro-bono path
+ *  ({@link resolveProBonoProviderKeys}), so standing never leaks across an
+ *  owner's machines.
+ *
+ *  Fail closed: a row that passes the tier check but carries no `machineId`
+ *  can't be bound to a specific machine, so it is dropped rather than added as
+ *  a bare DID (which would re-open the widening hole). */
+export async function resolveVerifiedProviderKeys(
   floor: TrustFloor,
   model?: string,
 ): Promise<Set<string>> {
@@ -168,7 +184,7 @@ export async function resolveVerifiedProviderDids(
   if (!r.ok) throw new Error(`advisor /providers ${r.status}`);
   const rows = (await r.json()) as AdvisorRow[];
   const online = rows.filter((p) => p.attestedAt);
-  const dids = new Set<string>();
+  const keys = new Set<string>();
   await Promise.all(
     online.map(async (row) => {
       if (
@@ -179,9 +195,13 @@ export async function resolveVerifiedProviderDids(
       ) {
         return;
       }
+      // Can't machine-bind a row with no machineId → fail closed (drop it)
+      // rather than fall back to a DID-scoped key that would re-admit the
+      // owner's unattested siblings.
+      if (!row.machineId) return;
       const tier = await verifiedTierFor(row);
-      if (meetsFloor(tier, floor)) dids.add(row.did);
+      if (meetsFloor(tier, floor)) keys.add(`${row.did}:${row.machineId}`);
     }),
   );
-  return dids;
+  return keys;
 }

--- a/packages/sdk/src/validate.test.ts
+++ b/packages/sdk/src/validate.test.ts
@@ -4,6 +4,7 @@ import { webcrypto } from "node:crypto";
 
 import { canonicalize } from "./canonical.ts";
 import {
+  verifyForCharge,
   verifyForChargeStrict,
   verifyReceipt,
   verifyReceiptStrict,
@@ -401,6 +402,49 @@ test("verifyReceiptStrict: malformed publicKey surfaces signature-verify-error",
   // which is currently unreachable.
   assert.equal(r.ok, false);
   assert.ok(r.findings.some((f) => f.code === "signature-invalid"));
+});
+
+const chargeCtx = {
+  exchangeDid: "did:web:exchange.example",
+  settledReceipts: new Set<string>(),
+  now: () => new Date("2026-05-07T12:00:01Z"),
+};
+const chargeInputs = (receipt: ReceiptRecord, job: JobRecord) => ({
+  receipt,
+  receiptUri: "at://did:plc:p/receipt/1",
+  job,
+  jobOwnerDid: "did:plc:r",
+  authorization: fixtureAuth(),
+  authorizationUri: { uri: "at://did:plc:r/auth/1", cid: "bafycid" },
+});
+
+test("verifyForCharge: tokens.out over job.maxTokensOut is rejected (drain guard)", () => {
+  // The provider self-reports tokens and derives price from them; without this
+  // gate it could publish a receipt claiming far more output than the requester
+  // authorized (draining/crediting up to the price ceiling for near-zero work).
+  const r = verifyForCharge(
+    chargeCtx,
+    chargeInputs(
+      fixtureReceipt({ tokens: { in: 32, out: 5000 } }),
+      fixtureJob({ maxTokensOut: 256 }),
+    ),
+  );
+  assert.equal(r.ok, false);
+  assert.ok(
+    r.findings.some((f) => f.code === "tokens-over-job-ceiling"),
+    JSON.stringify(r.findings),
+  );
+});
+
+test("verifyForCharge: tokens.out within maxTokensOut passes the token gate", () => {
+  const r = verifyForCharge(
+    chargeCtx,
+    chargeInputs(
+      fixtureReceipt({ tokens: { in: 32, out: 128 } }),
+      fixtureJob({ maxTokensOut: 256 }),
+    ),
+  );
+  assert.equal(r.ok, true, JSON.stringify(r.findings));
 });
 
 test("verifyForChargeStrict: appends a sig check on top of verifyForCharge", async () => {

--- a/packages/sdk/src/validate.ts
+++ b/packages/sdk/src/validate.ts
@@ -307,6 +307,22 @@ export function verifyForCharge(ctx: PreChargeContext, inputs: PreChargeInputs):
       `receipt.price.amount ${receipt.price.amount} > authorization.ceiling ${authorization.ceiling.amount}`,
     );
   }
+  // The provider self-reports `tokens` and derives `price` from them, so an
+  // unenforced token count lets a provider bill the full authorized ceiling
+  // for near-zero real work while publishing an inflated token record. The
+  // job's `maxTokensOut` is the requester-authorized output ceiling (see
+  // dev.cocore.compute.job); a receipt claiming more than that is invalid.
+  // This bounds the token record to what the requester authorized; it does
+  // NOT prove the output is genuine model work — that needs output-commitment
+  // dispute (tracked separately). Pro-bono receipts carry tokens {0,0}, so
+  // they pass trivially.
+  if (receipt.tokens.out > job.maxTokensOut) {
+    err(
+      findings,
+      "tokens-over-job-ceiling",
+      `receipt.tokens.out ${receipt.tokens.out} > job.maxTokensOut ${job.maxTokensOut}`,
+    );
+  }
   checkProBonoInvariant(receipt, findings);
   if (
     job.acceptedExchanges &&


### PR DESCRIPTION
## Why

A security researcher ([@astrra.space](https://bsky.app/profile/astrra.space)) publicly demonstrated a **live exploit chain** against the `/verified/chat/completions` endpoint on 2026-07-01. The through-line: co/core's trust boundaries were self-asserted by the provider and taken at face value by the backend. This PR closes the core break and the cheap-to-enforce economic half, and files an ADR for the rest.

## The core break (P0)

Verified-tier eligibility was computed **per machine** but stored **per DID**. An owner registers a genuinely attested Mac **and** an unattested Linux box under **one DID**; `filterByAllowedDids` admits *any* machine sharing an allowed DID, and dispatch prefers the freshest heartbeat. Result: `min_trust: confidential` / `hardware-attested` requests were served by the unattested node (~80% in the researcher's demo), which then read the plaintext prompt, served whatever model it liked, and logged prompts to a public Bluesky PDS.

The attested Mac's row earned the whole DID its standing; the Linux box didn't even need its own attestation.

## What's in this PR

- **P0 — machine-scoped verified allow-set.** `resolveVerifiedProviderDids` → `resolveVerifiedProviderKeys` now emits `${did}:${machineId}` composite keys (the exact shape the pro-bono path already uses), so only the machine that actually passes the tier check is routable. **Fail closed** when a row has no `machineId`. Regression test reproduces the two-machines-one-DID scenario and guards against the old bare-DID leak.
- **P1 — token-drain gate.** `verifyForCharge` now rejects `receipt.tokens.out > job.maxTokensOut` (`tokens-over-job-ceiling`). Runs in the exchange via `verifyForChargeStrict`, so an over-claiming receipt is `rejected` and never settles/credits. Bounds over-claiming; does **not** yet prove the output is genuine model work.
- **P2 — doc honesty.** Confidential-tier badge copy softened to a hardened-runtime posture (depends on OS + signed-binary integrity), not an unbreakable seal.
- **ADR-0002** — model-identity binding + a dispute record for the residual "junk output billed at the full authorized ceiling, self-credited" gap. Lexicon-first, to ratify before touching records.

## Still open (by design, tracked in ADR-0002)

- **Model impersonation** — `model` is self-asserted; nothing binds returned tokens to the model that ran.
- **Junk-for-authorized-amount** — the price ceiling caps the max but doesn't require real work; needs an output-commitment dispute path.
- "Mint tokens via self-hosted OAuth" is a by-design federated grant, not a forge.

## Verification

- SDK + console targeted suites pass (52 tests); both packages typecheck clean; `format:check` clean.
- Generated `routeTree.gen.ts` deliberately excluded; pre-existing untracked `scripts/.publish-*.sh` left out of the commit.

> [!IMPORTANT]
> This is a publicly-demonstrated live exploit. The fix only takes effect once **console** redeploys — consider fast-tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)