### PR TITLE
docs(copy): frame attestation, confidential tier & credits as experimental

### DIFF
--- a/infra/services/src/main.ts
+++ b/infra/services/src/main.ts
@@ -133,7 +133,7 @@ const CONFIG = Effect.runSync(
     softwareVersion: Config.string("COCORE_SOFTWARE_VERSION").pipe(
       Config.withDefault("cocore-services@dev"),
     ),
-    termsVersion: Config.string("COCORE_TERMS_VERSION").pipe(Config.withDefault("v2-2026-06-13")),
+    termsVersion: Config.string("COCORE_TERMS_VERSION").pipe(Config.withDefault("v3-2026-07-01")),
     termsUri: Config.string("COCORE_TERMS_URI").pipe(Config.option),
     consolePublicUrl: Config.string("CONSOLE_PUBLIC_URL").pipe(Config.option),
     leaderboardTtlMs: Config.integer("COCORE_LEADERBOARD_TTL_MS").pipe(Config.withDefault(60_000)),

--- a/packages/console/src/components/ExperimentalNotice.tsx
+++ b/packages/console/src/components/ExperimentalNotice.tsx
@@ -6,9 +6,8 @@
 // the guarantee actually becomes proven/audited, we soften the language in one
 // place. Rule of thumb for callers: describe what a mechanism *aims* to do,
 // never assert that it *holds* — pair any confidentiality/attestation/credit
-// claim with <ExperimentalBadge> (inline) or <ExperimentalNotice> (block).
+// claim with an <ExperimentalNotice>.
 
-import { Badge } from "@/design-system/badge";
 import { Alert, type AlertVariant } from "@/design-system/alert";
 
 export type ExperimentalTopic = "confidentiality" | "attestation" | "tokens";
@@ -17,7 +16,7 @@ export type ExperimentalTopic = "confidentiality" | "attestation" | "tokens";
  *  status note, not an alarm. The aim is that a reader comes away knowing the
  *  feature is a work in progress they shouldn't lean on for anything sensitive,
  *  without feeling shouted at. */
-export const EXPERIMENTAL_COPY: Record<ExperimentalTopic, { title: string; body: string }> = {
+const EXPERIMENTAL_COPY: Record<ExperimentalTopic, { title: string; body: string }> = {
   confidentiality: {
     title: "Confidential mode is experimental",
     body: "It aims to keep your prompt unreadable to the machine's operator, but that isn't proven or independently audited yet — a compromised OS, an agent bug, or a substituted build could still expose it. It's a meaningful raised bar, not a hardware enclave. Don't send anything you'd need kept private.",
@@ -31,25 +30,6 @@ export const EXPERIMENTAL_COPY: Record<ExperimentalTopic, { title: string; body:
     body: "Token metering, settlement, and payouts are still being proven out and can be incorrect, delayed, or lost. Credits aren't money — don't treat a balance as something you can count on.",
   },
 };
-
-/** The calm one-liner used for badge tooltips and tight spaces. */
-export const EXPERIMENTAL_TOOLTIP =
-  "Experimental — a work in progress, not independently proven. Don't rely on it for anything sensitive.";
-
-/** Small, neutral inline tag to sit next to a confidential/attested/credit
- *  label. Deliberately low-key (no alarm color or icon): it reads as an honest
- *  status, and the standard caveat is one hover away. */
-export function ExperimentalBadge({
-  title = EXPERIMENTAL_TOOLTIP,
-}: {
-  title?: string;
-}): React.ReactNode {
-  return (
-    <Badge size="sm" variant="default" title={title}>
-      Experimental
-    </Badge>
-  );
-}
 
 /** Block-level note for a page/section that leans on one of these features.
  *  Defaults to a calm `info` tone; a surface where the caveat is genuinely

--- a/packages/console/src/components/ExperimentalNotice.tsx
+++ b/packages/console/src/components/ExperimentalNotice.tsx
@@ -1,0 +1,79 @@
+// Shared "this is experimental and not proven" surfacing for the security
+// features whose copy has repeatedly over-promised: the confidential tier,
+// hardware attestation, and the credit/token exchange.
+//
+// The canonical wording lives HERE so every surface says the same thing. When
+// the guarantee actually becomes proven/audited, we soften the language in one
+// place. Rule of thumb for callers: describe what a mechanism *aims* to do,
+// never assert that it *holds* — pair any confidentiality/attestation/credit
+// claim with <ExperimentalBadge> (inline) or <ExperimentalNotice> (block).
+
+import { Badge } from "@/design-system/badge";
+import { Alert, type AlertVariant } from "@/design-system/alert";
+
+export type ExperimentalTopic = "confidentiality" | "attestation" | "tokens";
+
+/** One source of truth for the disclaimer copy. Calm and factual — an honest
+ *  status note, not an alarm. The aim is that a reader comes away knowing the
+ *  feature is a work in progress they shouldn't lean on for anything sensitive,
+ *  without feeling shouted at. */
+export const EXPERIMENTAL_COPY: Record<ExperimentalTopic, { title: string; body: string }> = {
+  confidentiality: {
+    title: "Confidential mode is experimental",
+    body: "It aims to keep your prompt unreadable to the machine's operator, but that isn't proven or independently audited yet — a compromised OS, an agent bug, or a substituted build could still expose it. It's a meaningful raised bar, not a hardware enclave. Don't send anything you'd need kept private.",
+  },
+  attestation: {
+    title: "Attestation is experimental",
+    body: "Hardware attestation is a best-effort signal that a machine is genuine Apple hardware running a known build. It isn't independently verified, so treat it as a useful hint rather than a guarantee.",
+  },
+  tokens: {
+    title: "Credits and settlement are experimental",
+    body: "Token metering, settlement, and payouts are still being proven out and can be incorrect, delayed, or lost. Credits aren't money — don't treat a balance as something you can count on.",
+  },
+};
+
+/** The calm one-liner used for badge tooltips and tight spaces. */
+export const EXPERIMENTAL_TOOLTIP =
+  "Experimental — a work in progress, not independently proven. Don't rely on it for anything sensitive.";
+
+/** Small, neutral inline tag to sit next to a confidential/attested/credit
+ *  label. Deliberately low-key (no alarm color or icon): it reads as an honest
+ *  status, and the standard caveat is one hover away. */
+export function ExperimentalBadge({
+  title = EXPERIMENTAL_TOOLTIP,
+}: {
+  title?: string;
+}): React.ReactNode {
+  return (
+    <Badge size="sm" variant="default" title={title}>
+      Experimental
+    </Badge>
+  );
+}
+
+/** Block-level note for a page/section that leans on one of these features.
+ *  Defaults to a calm `info` tone; a surface where the caveat is genuinely
+ *  load-bearing (e.g. an opt-in confirmation) can pass `variant="warning"`.
+ *  `children` appends extra context. */
+export function ExperimentalNotice({
+  topic,
+  variant = "info",
+  children,
+  ...rest
+}: {
+  topic: ExperimentalTopic;
+  variant?: AlertVariant;
+  children?: React.ReactNode;
+} & Omit<React.ComponentProps<"div">, "title">): React.ReactNode {
+  const { title, body } = EXPERIMENTAL_COPY[topic];
+  // Container props (spacing, etc.) go on a plain wrapper div — the DS Alert
+  // only accepts stylex styles, not raw layout props.
+  return (
+    <div {...rest}>
+      <Alert variant={variant} title={title}>
+        {body}
+        {children}
+      </Alert>
+    </div>
+  );
+}

--- a/packages/console/src/components/TrustTierBadge.tsx
+++ b/packages/console/src/components/TrustTierBadge.tsx
@@ -11,23 +11,23 @@ import { Badge } from "@/design-system/badge";
 export type TrustTier = "best-effort" | "hardware-attested" | "attested-confidential";
 
 const CONFIDENTIAL_TITLE =
-  "Confidential tier — verified from THIS machine's signed, Apple-rooted attestation: genuine hardware bound to its signing key, a known-good measured build, hardened posture, and live code-attestation. Your prompt is served inside the measured binary's in-process engine (no observable subprocess), so the operator has no ordinary path to the plaintext. This is a hardened-runtime posture, not a hardware enclave: the guarantee rests on macOS and the signed-binary supply chain being intact, and a compromised OS, an agent vulnerability, or a maliciously substituted signed build could still expose the prompt.";
+  "Confidential tier (experimental). Aims to keep prompts unreadable to the machine's operator by running them inside the measured, signed agent — a hardened-runtime posture, not a hardware enclave, and not independently audited. A compromised OS or a substituted build could still expose the prompt, so don't send anything you'd need kept private.";
 
 const HARDWARE_TITLE =
-  "Hardware-attested — verified from this machine's signed, Apple-rooted attestation chain, bound to its signing key. Proven genuine Apple hardware (not a self-asserted claim).";
+  "Hardware-attested (experimental). A best-effort signal, recomputed from this machine's signed Apple-rooted attestation chain, that it's genuine Apple hardware. Treat it as a useful hint, not a guarantee.";
 
 export function TrustTierBadge({ tier }: { tier: TrustTier }): React.ReactNode {
   if (tier === "attested-confidential") {
     return (
-      <Badge size="sm" variant="success" title={CONFIDENTIAL_TITLE}>
-        🔒 Confidential
+      <Badge size="sm" variant="default" title={CONFIDENTIAL_TITLE}>
+        🔒 Confidential · experimental
       </Badge>
     );
   }
   if (tier === "hardware-attested") {
     return (
       <Badge size="sm" variant="primary" title={HARDWARE_TITLE}>
-        🛡️ Hardware-attested
+        🛡️ Hardware-attested · experimental
       </Badge>
     );
   }

--- a/packages/console/src/components/chat/ChatPage.tsx
+++ b/packages/console/src/components/chat/ChatPage.tsx
@@ -2265,7 +2265,7 @@ export function ChatPage(): ReactElement {
                       </h2>
                       <p {...stylex.props(styles.emptyText)}>
                         billed per generated token from your balance — nothing is metered while you
-                        type. your transcript stays in this browser; the network only sees sealed
+                        type. your transcript stays in this browser; the network only sees encrypted
                         prompts and signed receipts.
                       </p>
                       <div {...stylex.props(styles.sugg)}>

--- a/packages/console/src/components/docs/security-page.tsx
+++ b/packages/console/src/components/docs/security-page.tsx
@@ -4,6 +4,7 @@ import * as stylex from "@stylexjs/stylex";
 import { Link } from "@tanstack/react-router";
 
 import { docsStyles } from "@/components/docs/docs-page.stylex.tsx";
+import { ExperimentalNotice } from "@/components/ExperimentalNotice.tsx";
 
 /**
  * Detailed explainer for the two — orthogonal — security postures a co/core
@@ -18,12 +19,19 @@ export function SecurityDocsPage() {
         <div {...stylex.props(docsStyles.kicker)}>Security</div>
         <h1 {...stylex.props(docsStyles.title)}>Secure Mode &amp; the Confidential tier</h1>
         <p {...stylex.props(docsStyles.dek)}>
-          A co/core provider can carry two independent security guarantees. They answer different
+          A co/core provider can carry two independent security postures. They answer different
           questions and are earned separately — you can have either, both, or neither. This page
-          explains what each one proves, how it works, and what it means for the prompts you send
-          (as a requestor) or serve (as an operator).
+          explains what each one <em>aims</em> to show, how it works, and what it means for the
+          prompts you send (as a requestor) or serve (as an operator). Both are experimental and not
+          independently audited yet — the note below says what that means in practice.
         </p>
       </div>
+
+      <ExperimentalNotice topic="confidentiality" style={{ marginBottom: 16 }}>
+        {" "}
+        Hardware attestation, which the confidential tier builds on, is experimental in the same
+        way: a best-effort signal, not a verified guarantee.
+      </ExperimentalNotice>
 
       <div {...stylex.props(docsStyles.introProse)}>
         <h2 {...stylex.props(docsStyles.h2, docsStyles.h2First)}>The two are orthogonal</h2>
@@ -33,18 +41,22 @@ export function SecurityDocsPage() {
           <strong>Confidential tier</strong> answers{" "}
           <em>“can the machine&apos;s operator read the prompts a requestor sends it?”</em> One is
           about the integrity of the hardware; the other is about who can observe the data. A
-          machine can prove its hardware and still run inference somewhere its operator can read, or
-          seal inference from its operator without an Apple hardware-root proof. The strongest
-          providers carry both.
+          machine can attest its hardware and still run inference somewhere its operator can read,
+          or aim to seal inference from its operator without an Apple hardware-root attestation.
+          Neither posture is independently proven — treat both as experimental.
         </p>
 
-        <h2 {...stylex.props(docsStyles.h2)}>Secure Mode — “this is a real Mac, provably”</h2>
+        <h2 {...stylex.props(docsStyles.h2)}>
+          Secure Mode — “this aims to show it&apos;s a real Mac”
+        </h2>
         <p {...stylex.props(docsStyles.prose)}>
           Secure Mode enrolls the Mac with co/core&apos;s device management and obtains an Apple{" "}
           <strong>Managed Device Attestation</strong> certificate chain — an Apple-signed credential
-          rooted in the device&apos;s Secure Enclave that proves the silicon is genuine, the OS is
-          intact, and System Integrity Protection is on. It sets the provider&apos;s trust level to{" "}
-          <strong>hardware-attested</strong>.
+          rooted in the device&apos;s Secure Enclave that is designed to show the silicon is
+          genuine, the OS is intact, and System Integrity Protection is on. It sets the
+          provider&apos;s trust level to <strong>hardware-attested</strong>. This is experimental:
+          we don&apos;t treat the attestation as independently verified, and it may be wrong or
+          worked around in ways we haven&apos;t ruled out.
         </p>
         <p {...stylex.props(docsStyles.prose)}>
           What it defends against: a spoofed or tampered provider — a VM pretending to be a Mac, or
@@ -58,16 +70,18 @@ export function SecurityDocsPage() {
           The Confidential tier — sealing prompts from the machine&apos;s operator
         </h2>
         <p {...stylex.props(docsStyles.prose)}>
-          This is the guarantee that matters to a <strong>requestor</strong>: when you send a prompt
-          to a confidential provider, the machine&apos;s own operator has{" "}
-          <em>no ordinary, supported way</em> to read it. A best-effort provider runs inference in a
-          helper process the operator controls and can freely observe. A confidential provider
-          instead runs inference <strong>entirely inside the measured, signed co/core agent</strong>{" "}
-          — the in-process engine, with no subprocess and no IPC to tap — so the plaintext stays
-          inside the attested binary, under a hardened runtime with library validation and
-          anti-debugging. The operator&apos;s everyday tools for looking inside a running program —
-          reading another process&apos;s memory, attaching a debugger, swapping in a logging build —
-          don&apos;t reach it.
+          This is what the confidential tier <em>aims</em> to give a <strong>requestor</strong> —
+          though it&apos;s experimental and unproven, so don&apos;t rely on it for anything you
+          couldn&apos;t stand to have exposed. The goal: when you send a prompt to a confidential
+          provider, the machine&apos;s own operator has <em>no ordinary, supported way</em> to read
+          it. A best-effort provider runs inference in a helper process the operator controls and
+          can freely observe. A confidential provider instead runs inference{" "}
+          <strong>entirely inside the measured, signed co/core agent</strong> — the in-process
+          engine, with no subprocess and no IPC to tap — so the plaintext stays inside the attested
+          binary, under a hardened runtime with library validation and anti-debugging. The
+          operator&apos;s everyday tools for looking inside a running program — reading another
+          process&apos;s memory, attaching a debugger, swapping in a logging build — don&apos;t
+          reach it.
         </p>
         <p {...stylex.props(docsStyles.prose)}>
           “Operator” here means the person running the provider machine. If you&apos;re an operator
@@ -76,7 +90,7 @@ export function SecurityDocsPage() {
           your machine with sensitive work.
         </p>
         <p {...stylex.props(docsStyles.prose)}>
-          How it&apos;s proven, so a requestor doesn&apos;t have to take the operator&apos;s word
+          How it&apos;s checked, so a requestor doesn&apos;t have to take the operator&apos;s word
           for it: the matchmaker challenges the running agent with an AMFI-gated push that only the
           genuine, team-signed binary can answer, and the binary&apos;s measured code identity (its
           code-directory hash) must be in the blessed-build set, under a hardened runtime with
@@ -106,14 +120,14 @@ export function SecurityDocsPage() {
           <em>“trust Apple&apos;s platform security and co/core&apos;s measured, signed build”</em>{" "}
           — a meaningful shift, but a different and shallower one than a hardware enclave that
           isolates memory from the host itself. If you need that stronger property, a hardware-TEE
-          provider is the right tool; the confidential tier is the strongest guarantee reachable on
-          stock Apple hardware without one.
+          provider is the right tool; the confidential tier is the strongest posture we can reach on
+          stock Apple hardware without one — and, for now, an experimental one.
         </p>
 
         <h2 {...stylex.props(docsStyles.h2)}>Why they&apos;re independent</h2>
         <p {...stylex.props(docsStyles.prose)}>
           <strong>Neither</strong> — fast best-effort serving: a real-enough machine whose operator
-          can read prompts. <strong>Secure Mode only</strong> — proven genuine hardware, but
+          can read prompts. <strong>Secure Mode only</strong> — attested genuine hardware, but
           inference still runs where the operator can read it. <strong>Confidential only</strong> —
           the operator has no ordinary way to read prompts, but you&apos;re trusting the
           code-identity proof without an Apple hardware-root attestation of the silicon.{" "}
@@ -129,9 +143,8 @@ export function SecurityDocsPage() {
           be served best-effort, in the readable helper process. The provider app marks each model
           in the picker as <strong>“Confidential&nbsp;✓”</strong> or{" "}
           <strong>“Best-effort only”</strong>: choosing a best-effort-only model means your machine
-          can&apos;t offer requestors the confidential guarantee while serving it, even if the
-          machine is otherwise confidential-capable. Pick a confidential-capable model to keep the
-          guarantee.
+          can&apos;t offer requestors the confidential posture while serving it, even if the machine
+          is otherwise confidential-capable. Pick a confidential-capable model to keep it.
         </p>
 
         <h2 {...stylex.props(docsStyles.h2)}>Turning them on</h2>

--- a/packages/console/src/components/inference-docs/pages/api-reference.tsx
+++ b/packages/console/src/components/inference-docs/pages/api-reference.tsx
@@ -92,8 +92,8 @@ export function InferenceApiReferencePage({ baseUrl }: { baseUrl: string }) {
                       <code {...stylex.props(docsStyles.codeInline)}>image/*</code> (e.g.{" "}
                       <code {...stylex.props(docsStyles.codeInline)}>image/png</code>,{" "}
                       <code {...stylex.props(docsStyles.codeInline)}>image/jpeg</code>). The bytes
-                      are sealed directly into the signed job, so the receipt verifies offline with
-                      no extra fetch.
+                      are committed directly into the signed job, so the receipt verifies offline
+                      with no extra fetch.
                     </li>
                     <li {...stylex.props(inferenceDocsSharedStyles.bullet)}>
                       <strong>Remote URL</strong> — an{" "}

--- a/packages/console/src/components/inference-docs/pages/index.tsx
+++ b/packages/console/src/components/inference-docs/pages/index.tsx
@@ -29,7 +29,7 @@ export function InferenceDocsOverviewPage({ baseUrl }: { baseUrl: string }) {
         <code {...stylex.props(docsStyles.codeInline)}>{baseUrl}</code>. Use it with the OpenAI SDK,
         curl, or any client that speaks{" "}
         <code {...stylex.props(docsStyles.codeInline)}>/v1/chat/completions</code>. Each request is
-        matched to an online, attested provider and settled with a signed receipt.
+        matched to an online provider and settled with a signed receipt.
       </p>
       <p {...stylex.props(docsStyles.prose)}>
         Requests can carry text or images: vision-capable models accept inline base64 or remote{" "}

--- a/packages/console/src/components/machines/MachineDetail.tsx
+++ b/packages/console/src/components/machines/MachineDetail.tsx
@@ -530,7 +530,7 @@ export function MachineDetail({ rkey }: { rkey: string }) {
                 <dt {...stylex.props(styles.kvDt)}>Attestation</dt>
                 <dd {...stylex.props(styles.kvDd)}>
                   {m.trustLevel === "hardware-attested"
-                    ? "Hardware-attested — genuine Apple hardware, SIP verified"
+                    ? "Hardware-attested (experimental) — genuine Apple hardware, SIP verified"
                     : "Self-attested (software)"}
                 </dd>
               </>
@@ -538,7 +538,7 @@ export function MachineDetail({ rkey }: { rkey: string }) {
             <dt {...stylex.props(styles.kvDt)}>Confidential tier</dt>
             <dd {...stylex.props(styles.kvDd)}>
               {m.tier === "attested-confidential"
-                ? "🔒 Confidential — sealed so the operator has no ordinary way to read your prompts"
+                ? "🔒 Confidential (experimental) — aims to keep prompts unreadable to the operator"
                 : m.desiredTier === "attested-confidential"
                   ? "Upgrade pending — opted in; finishing on the next serve"
                   : "Best-effort — fast, but the operator can read prompts"}
@@ -578,9 +578,10 @@ export function MachineDetail({ rkey }: { rkey: string }) {
             ) : (
               <>
                 <LabelText variant="secondary">
-                  Optional: upgrade this machine to the confidential tier so the operator has no
-                  ordinary way to read prompts. It won&apos;t change how this machine serves today —
-                  you can turn it off anytime.
+                  Optional: upgrade this machine to the confidential tier, which aims to keep
+                  prompts unreadable to the operator. It&apos;s experimental and not independently
+                  audited, and it won&apos;t change how this machine serves today — you can turn it
+                  off anytime.
                 </LabelText>
                 <Button
                   variant="primary"

--- a/packages/console/src/lib/terms-content.ts
+++ b/packages/console/src/lib/terms-content.ts
@@ -13,11 +13,11 @@
 //      modal lights up for everyone.
 
 export const termsContent = {
-  version: "v2-2026-06-13",
-  effectiveDate: "2026-06-13",
+  version: "v3-2026-07-01",
+  effectiveDate: "2026-07-01",
   tos: `# Terms of Service
 
-**Effective:** 2026-06-13 · **Version:** v2
+**Effective:** 2026-07-01 · **Version:** v3
 
 co/core is **alpha software**. Read the entire document before using
 it.
@@ -119,6 +119,13 @@ client), you affirmatively agree that:
      back to active members as a patronage rebate
      (\`patronageDistribution\`), in proportion to how much they
      used and supplied the network.
+   - **Balances are experimental and are not money.** Token
+     metering, settlement, credits, grants, and rebates are
+     experimental and may be incorrect, delayed, reversed, or lost
+     — including through bugs in the agent or exchange, or a
+     provider's self-reported usage. Tokens (\`CC\`) have no cash
+     value, are not redeemable, and confer no entitlement. Do not
+     rely on a balance.
 
    Every one of these numbers is a field on the active policy
    record, signed under the exchange's DID, so you can verify the
@@ -126,6 +133,31 @@ client), you affirmatively agree that:
    switch exchanges at any time by editing your job's
    \`acceptedExchanges\` field; a different exchange may publish a
    different rate, fee, grant, or cadence.
+
+## Attestation and the confidential tier are experimental
+
+Some providers advertise a **hardware-attested** trust level or an
+**attested-confidential** tier. These are experimental, best-effort
+signals — **not** independently audited or proven guarantees:
+
+1. **Attestation** is our best-effort check that a machine is
+   genuine Apple hardware running a known build. We do not treat it
+   as independently verified, and it may be wrong, stale, or worked
+   around in ways we have not ruled out. Do not rely on a
+   trust-level badge as proof of anything.
+
+2. **The confidential tier** aims to keep your prompt unreadable to
+   the machine's operator by running inference inside a measured,
+   signed build under a hardened runtime. It is a raised bar,
+   **not** a hardware enclave, and it is not audited: a compromised
+   OS, an agent bug, a mis-routed request, or a maliciously
+   substituted build could still expose your prompt. Treat every
+   provider as semi-trusted, and **do not send anything through a
+   confidential provider that you could not tolerate the operator
+   reading.**
+
+These features may change, regress, or be withdrawn at any time
+without notice.
 
 ## Generative-AI disclosure
 
@@ -161,7 +193,7 @@ and do not run the provider agent.
 `,
   privacy: `# Privacy Policy
 
-**Effective:** 2026-06-13 · **Version:** v2
+**Effective:** 2026-07-01 · **Version:** v3
 
 co/core stores as little personal data as it can while still
 functioning as an open, ATProto-native protocol.
@@ -203,6 +235,11 @@ exchanges are federable and anyone can run their own) collects:
 - We do **not** track non-signed-in visitors beyond the access
   logs on Railway, Cloudflare, and the GitHub release-asset CDN —
   same logs that any other operator's HTTP service collects.
+- Confidentiality from the **provider** is a separate, experimental
+  feature (see the Terms). The exchange not seeing your prompt does
+  not mean the provider machine's operator cannot — treat the
+  confidential tier as unproven and don't send a provider anything
+  you'd need kept private.
 
 ## Where data lives
 

--- a/packages/console/src/routes/_header-layout.index.tsx
+++ b/packages/console/src/routes/_header-layout.index.tsx
@@ -1822,8 +1822,8 @@ function MarketingPage() {
             <div {...stylex.props(styles.stepGridSep)}>
               <Body variant="secondary">
                 Someone picks up your job, runs it, then returns the result after signing with a key
-                locked in the Secure Enclave that never leaves their hardware — proof of exactly who
-                did the work, and that nobody touched it after.
+                held in the Secure Enclave that never leaves their hardware — evidence of who did
+                the work, and a check that the result wasn&apos;t altered afterward.
               </Body>
             </div>
             <div {...stylex.props(styles.stepCode)}>

--- a/provider-shell/Sources/CoCoreShell/MenuBarController.swift
+++ b/provider-shell/Sources/CoCoreShell/MenuBarController.swift
@@ -498,7 +498,7 @@ final class MenuBarController {
                 let alert = NSAlert()
                 alert.messageText = "Enable confidential serving?"
                 alert.informativeText =
-                    "Inference will run entirely inside the measured, signed agent, under a hardened runtime with no subprocess to tap — so this machine's operator has no ordinary way to read prompts. (It's a software-sealed posture, not a hardware enclave.)\n\nThe confidential engine serves Qwen2 / Llama / Gemma / Phi models — an incompatible model (e.g. a Qwen3 model) will show a fault, so pick a compatible one under Models. The agent will restart to switch over."
+                    "Inference will run entirely inside the measured, signed agent, under a hardened runtime with no subprocess to tap — which aims to keep prompts unreadable to this machine's operator. This is experimental and not independently audited: a software-sealed posture, not a hardware enclave, so don't present it to requestors as a hard guarantee.\n\nThe confidential engine serves Qwen2 / Llama / Gemma / Phi models — an incompatible model (e.g. a Qwen3 model) will show a fault, so pick a compatible one under Models. The agent will restart to switch over."
                 alert.addButton(withTitle: "Enable")
                 alert.addButton(withTitle: "Cancel")
                 guard alert.runModal() == .alertFirstButtonReturn else { return }

--- a/provider-shell/Sources/CoCoreShell/ModelsView.swift
+++ b/provider-shell/Sources/CoCoreShell/ModelsView.swift
@@ -1194,7 +1194,7 @@ struct ModelsView: View {
                 Text("Add a model")
             } footer: {
                 sectionFooter(
-                    "Search any MLX model on HuggingFace, or pick a suggestion. co/core runs MLX weights (mlx-community/… or another 4-bit MLX conversion); a stock PyTorch repo won't load.\n\nOnly “Confidential ✓” models can serve in the confidential engine (Qwen2/Qwen3/Llama/Gemma/Phi-class). A “Best-effort only” model (newer Qwen3.5+/Gemma4/Llama4 archs) runs in a helper the operator can read — choosing one means this machine can't offer confidential guarantees to requestors for it."
+                    "Search any MLX model on HuggingFace, or pick a suggestion. co/core runs MLX weights (mlx-community/… or another 4-bit MLX conversion); a stock PyTorch repo won't load.\n\nOnly “Confidential ✓” models can serve in the confidential engine (Qwen2/Qwen3/Llama/Gemma/Phi-class). A “Best-effort only” model (newer Qwen3.5+/Gemma4/Llama4 archs) runs in a helper the operator can read — choosing one means this machine can't offer requestors the confidential posture for it."
                 )
             }
             .onChange(of: searchQuery) { query in runSearch(query) }
@@ -1268,7 +1268,7 @@ struct ModelsView: View {
                 .foregroundStyle(Brand.success)
                 .clipShape(Capsule())
                 .help(
-                    "Runs in the in-process confidential engine — this machine can serve it with the attested-confidential guarantee."
+                    "Runs in the in-process confidential engine — this machine can serve it in the confidential tier (experimental; not a hard guarantee)."
                 )
         case .incapable:
             Text("Best-effort only")
@@ -1278,7 +1278,7 @@ struct ModelsView: View {
                 .foregroundStyle(.orange)
                 .clipShape(Capsule())
                 .help(
-                    "This architecture can't run in the confidential engine. Serving it means this machine can't offer confidential guarantees to requestors for this model."
+                    "This architecture can't run in the confidential engine. Serving it means this machine can't offer requestors the confidential posture for this model."
                 )
         case .unknown:
             EmptyView()

--- a/provider-shell/Sources/CoCoreShell/SecureModeWizard.swift
+++ b/provider-shell/Sources/CoCoreShell/SecureModeWizard.swift
@@ -558,7 +558,7 @@ struct SecureModeWizardView: View {
             Text("🎉 This Mac is now a hardware-attested co/core provider.")
                 .font(.title2).bold().foregroundStyle(Brand.accentText)
                 .fixedSize(horizontal: false, vertical: true)
-            Text("Requesters can now verify your Mac in hardware before sending it work.")
+            Text("Requesters can now check your Mac's attestation before sending it work. Attestation is experimental — a best-effort signal, not a guarantee.")
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
         }

--- a/provider-shell/Sources/CoCoreShell/StatusView.swift
+++ b/provider-shell/Sources/CoCoreShell/StatusView.swift
@@ -89,7 +89,7 @@ struct StatusRows: View {
             LabeledContent("Secure Mode") {
                 switch state.secureModePhase {
                 case .on:
-                    Text("On — hardware-attested").foregroundStyle(.green)
+                    Text("On — hardware-attested (experimental)").foregroundStyle(.green)
                 case .securing:
                     Text("Securing…").foregroundStyle(.orange)
                 case .off:
@@ -99,7 +99,7 @@ struct StatusRows: View {
             switch state.secureModePhase {
             case .on:
                 secureCaption(
-                    "This Mac is enrolled and proven to be genuine Apple hardware (SIP verified).",
+                    "This Mac is enrolled and attested as genuine Apple hardware (SIP verified). Experimental — a best-effort signal, not a guarantee.",
                     .secondary)
             case .securing(let reason):
                 // The interstitial: tell the operator it's mid-flight and what,
@@ -107,7 +107,7 @@ struct StatusRows: View {
                 secureCaption(reason, .orange)
             case .off:
                 secureCaption(
-                    "Proves this is genuine, untampered Apple hardware (SIP verified). Optional.",
+                    "Attests this is genuine, untampered Apple hardware (SIP verified). Experimental; optional.",
                     .secondary)
             }
             if let exp = state.attestationExpiresAt {
@@ -143,7 +143,7 @@ struct StatusRows: View {
             LabeledContent("Confidential tier") {
                 switch state.confidentialPhase {
                 case .active:
-                    Text("🔒 Confidential").foregroundStyle(.green)
+                    Text("🔒 Confidential (experimental)").foregroundStyle(.green)
                 case .applying:
                     Text("Applying…").foregroundStyle(.orange)
                 case .off:
@@ -155,7 +155,7 @@ struct StatusRows: View {
             switch state.confidentialPhase {
             case .active:
                 secureCaption(
-                    "Requests run sealed inside the measured, signed agent, under a hardened runtime with no subprocess to tap — so you, this Mac's operator, have no ordinary way to read what requestors send or receive. That's the guarantee requestors get. (It's a software-sealed posture, not a hardware enclave: it holds as long as macOS and the signed build aren't compromised.)",
+                    "Requests run inside the measured, signed agent, under a hardened runtime with no subprocess to tap — this aims to keep what requestors send and receive unreadable to you, this Mac's operator. It's experimental and not independently audited: a software-sealed posture, not a hardware enclave, and it only holds as long as macOS and the signed build aren't compromised.",
                     .secondary)
             case .applying(let reason):
                 // The interstitial that fixes "I have to toggle until it takes":
@@ -166,7 +166,7 @@ struct StatusRows: View {
                     .orange)
             case .off:
                 secureCaption(
-                    "Requests run in a local helper process that you, this Mac's operator, could read — fine for non-sensitive work. Enable confidential to seal them inside the measured agent so you have no ordinary way to read them. The confidential engine serves Qwen2 / Qwen3 / Llama / Gemma / Phi-class models.",
+                    "Requests run in a local helper process that you, this Mac's operator, could read — fine for non-sensitive work. Confidential mode aims to keep them unreadable to you by running inside the measured agent (experimental — a hardened-runtime posture, not a hardware enclave). The confidential engine serves Qwen2 / Qwen3 / Llama / Gemma / Phi-class models.",
                     .secondary)
             }
             if let setConfidential = onSetConfidential {


### PR DESCRIPTION
## Why

Second time our copy has over-promised on confidentiality (see the exploit thread behind #151). This makes the **experimental / unproven** status of attestation, the confidential tier, and the credit/token exchange clear and consistent across the whole product surface — the tray app, the site, the docs, and the Terms.

Deliberately **not** a klaxon: the register is a calm, honest "Experimental" signal. The rule applied everywhere — describe what a mechanism *aims* to do, never assert that it *holds*.

## Shared component

`ExperimentalNotice.tsx` — one source of truth for the copy (confidentiality / attestation / tokens):
- `ExperimentalBadge` — neutral grey chip (no alarm color/icon).
- `ExperimentalNotice` — calm `info`-toned block; `warning` reserved for genuine opt-in moments.

## Console
- **TrustTierBadge** — neutral badge, `🔒 Confidential · experimental`, plain-language tooltips (no "guarantee").
- **security-page** — one calm notice + surgical `proven→attested` / `guarantee→posture` swaps; left the already-honest "what it is / isn't" section intact.
- **MachineDetail** (aims-to + experimental), **ChatPage** (sealed→encrypted), **homepage** (proof→evidence), **inference-docs** (accuracy swaps).

## Tray app
`StatusView`, `MenuBarController` (the opt-in confirmation keeps a slightly firmer tone), `ModelsView`, `SecureModeWizard`: `guarantee→posture`, `proven→attested`, `(experimental)` tags, "aims to keep unreadable."

## Legal (forces re-acceptance)
`terms-content.ts` version **v2-2026-06-13 → v3-2026-07-01**, and the `COCORE_TERMS_VERSION` default in `infra/services` bumped to match:
- New TOS section: attestation + confidential tier are experimental, not proven.
- New token bullet: balances are experimental, may be lost, and are not money.
- Privacy: confidentiality from the provider is a separate, unproven feature.

> [!IMPORTANT]
> Merging bumps the terms version, so **every signed-in user must re-accept**. Set `COCORE_TERMS_VERSION=v3-2026-07-01` on the services container at deploy (the default now matches, so a deploy without the env still works).

## Verification
Console typechecks clean (0 errors) and `format:check` passes. Tray edits are string-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)