### PR TITLE
feat(models): complete Qwen3.5 recommended family

### DIFF
--- a/packages/console/src/lib/recommended-models.ts
+++ b/packages/console/src/lib/recommended-models.ts
@@ -56,9 +56,19 @@ export const RECOMMENDED_MODELS: readonly RecommendedModel[] = [
     blurb: "Qwen3.5 9B — strong general-purpose; 16GB+ recommended",
   },
   {
+    id: "mlx-community/Qwen3.5-27B-4bit",
+    minRamGb: 24,
+    blurb: "Qwen3.5 27B — high-quality dense model; 24GB+",
+  },
+  {
     id: "mlx-community/Qwen3.6-27B-4bit",
     minRamGb: 24,
     blurb: "Qwen3.6 27B — frontier-class dense; 24GB+",
+  },
+  {
+    id: "mlx-community/Qwen3.5-35B-A3B-4bit",
+    minRamGb: 32,
+    blurb: "Qwen3.5 35B-A3B MoE — fast for its size; 32GB+",
   },
   {
     id: "mlx-community/Qwen3.6-35B-A3B-4bit",
@@ -74,6 +84,11 @@ export const RECOMMENDED_MODELS: readonly RecommendedModel[] = [
     id: "mlx-community/Qwen3.5-122B-A10B-4bit",
     minRamGb: 96,
     blurb: "Qwen3.5 122B-A10B MoE — flagship; 96GB+ Mac Studio/Ultra",
+  },
+  {
+    id: "mlx-community/Qwen3.5-397B-A17B-4bit",
+    minRamGb: 256,
+    blurb: "Qwen3.5 397B-A17B MoE — flagship; 256GB+ Ultra",
   },
 ];
 

--- a/provider-shell/Sources/CoCoreShell/ModelsView.swift
+++ b/provider-shell/Sources/CoCoreShell/ModelsView.swift
@@ -486,10 +486,13 @@ final class ModelManager: ObservableObject {
         // `language_model.*`) the text runtime can't load, so picking it always
         // failed provisioning. Keep this catalog to standard MLX text models.
         CatalogEntry(nsid: "mlx-community/Qwen3.5-9B-MLX-4bit", label: "Qwen 3.5 9B", minRamGB: 16, recommended: true, blurb: "Strong mid-size reasoning."),
+        CatalogEntry(nsid: "mlx-community/Qwen3.5-27B-4bit", label: "Qwen 3.5 27B", minRamGB: 24, recommended: true, blurb: "High-quality dense model."),
         CatalogEntry(nsid: "mlx-community/Qwen3.6-27B-4bit", label: "Qwen 3.6 27B", minRamGB: 24, recommended: true, blurb: "High-quality dense model."),
+        CatalogEntry(nsid: "mlx-community/Qwen3.5-35B-A3B-4bit", label: "Qwen 3.5 35B A3B", minRamGB: 32, recommended: true, blurb: "MoE — big quality at modest active cost."),
         CatalogEntry(nsid: "mlx-community/Qwen3.6-35B-A3B-4bit", label: "Qwen 3.6 35B A3B", minRamGB: 32, recommended: true, blurb: "MoE — big quality at modest active cost."),
         CatalogEntry(nsid: "mlx-community/Llama-4-Scout-17B-16E-Instruct-4bit", label: "Llama 4 Scout 17B", minRamGB: 64, recommended: true, blurb: "Meta's mixture-of-experts flagship."),
         CatalogEntry(nsid: "mlx-community/Qwen3.5-122B-A10B-4bit", label: "Qwen 3.5 122B A10B", minRamGB: 96, recommended: true, blurb: "Frontier-class MoE for big rigs."),
+        CatalogEntry(nsid: "mlx-community/Qwen3.5-397B-A17B-4bit", label: "Qwen 3.5 397B A17B", minRamGB: 256, recommended: true, blurb: "Flagship MoE for high-memory Ultras."),
         // Legacy choices — still serviceable, no longer the front-runners.
         CatalogEntry(nsid: "mlx-community/Qwen2.5-0.5B-Instruct-4bit", label: "Qwen 2.5 0.5B", minRamGB: 4, recommended: false, blurb: "Legacy tiny model."),
         CatalogEntry(nsid: "mlx-community/Qwen2.5-3B-Instruct-4bit", label: "Qwen 2.5 3B", minRamGB: 8, recommended: false, blurb: "Legacy small model."),

--- a/provider/src/pricing.rs
+++ b/provider/src/pricing.rs
@@ -34,6 +34,7 @@
 ///   * 27B 4-bit ≈ 14GB weights → wants 32GB+
 ///   * 70B 4-bit ≈ 36GB weights → wants 64GB+
 ///   * 122B 4-bit ≈ 65GB weights → wants 96GB+
+///   * 397B 4-bit ≈ 220GB weights → wants 256GB+
 pub struct ModelRate {
     pub model_id: &'static str,
     pub input_per_mtok: u64,
@@ -140,12 +141,32 @@ pub const RATES: &[ModelRate] = &[
         tool_call_parser: Some("hermes"),
     },
     ModelRate {
+        model_id: "mlx-community/Qwen3.5-27B-4bit",
+        input_per_mtok: 1_000_000,
+        output_per_mtok: 1_000_000,
+        currency: "CC",
+        min_ram_gb: 24,
+        description: "Qwen3.5 27B — high-quality dense model; 24GB+",
+        recommended: true,
+        tool_call_parser: Some("hermes"),
+    },
+    ModelRate {
         model_id: "mlx-community/Qwen3.6-27B-4bit",
         input_per_mtok: 1_000_000,
         output_per_mtok: 1_000_000,
         currency: "CC",
         min_ram_gb: 24,
         description: "Qwen3.6 27B — frontier-class dense; 24GB+",
+        recommended: true,
+        tool_call_parser: Some("hermes"),
+    },
+    ModelRate {
+        model_id: "mlx-community/Qwen3.5-35B-A3B-4bit",
+        input_per_mtok: 1_000_000,
+        output_per_mtok: 1_000_000,
+        currency: "CC",
+        min_ram_gb: 32,
+        description: "Qwen3.5 35B-A3B MoE — fast for its size; 32GB+",
         recommended: true,
         tool_call_parser: Some("hermes"),
     },
@@ -176,6 +197,16 @@ pub const RATES: &[ModelRate] = &[
         currency: "CC",
         min_ram_gb: 96,
         description: "Qwen3.5 122B-A10B MoE — flagship; 96GB+ Mac Studio/Ultra",
+        recommended: true,
+        tool_call_parser: Some("hermes"),
+    },
+    ModelRate {
+        model_id: "mlx-community/Qwen3.5-397B-A17B-4bit",
+        input_per_mtok: 1_000_000,
+        output_per_mtok: 1_000_000,
+        currency: "CC",
+        min_ram_gb: 256,
+        description: "Qwen3.5 397B-A17B MoE — flagship; 256GB+ Ultra",
         recommended: true,
         tool_call_parser: Some("hermes"),
     },
@@ -679,8 +710,21 @@ mod tests {
     #[test]
     fn recommended_set_is_the_rotation() {
         let rec: Vec<&str> = recommended_models().iter().map(|m| m.model_id).collect();
-        assert!(rec.contains(&"mlx-community/Qwen3.5-4B-MLX-4bit"));
-        assert!(rec.contains(&"mlx-community/Qwen3.5-122B-A10B-4bit"));
+        for model_id in [
+            "mlx-community/Qwen3.5-0.8B-MLX-4bit",
+            "mlx-community/Qwen3.5-2B-MLX-4bit",
+            "mlx-community/Qwen3.5-4B-MLX-4bit",
+            "mlx-community/Qwen3.5-9B-MLX-4bit",
+            "mlx-community/Qwen3.5-27B-4bit",
+            "mlx-community/Qwen3.5-35B-A3B-4bit",
+            "mlx-community/Qwen3.5-122B-A10B-4bit",
+            "mlx-community/Qwen3.5-397B-A17B-4bit",
+        ] {
+            assert!(
+                rec.contains(&model_id),
+                "missing recommended model {model_id}"
+            );
+        }
         // legacy + stub are NOT recommended
         assert!(!rec.contains(&"mlx-community/Qwen2.5-7B-Instruct-4bit"));
         assert!(!rec.contains(&"stub"));


### PR DESCRIPTION
Adds the Qwen3.5 family of models to the catalog. I don't have a Mac available to test on right now, but non-Mac-gated features pass their tests.