### PR TITLE
fix(console): recognize no-mda-chain as a hardware-attestation blocker

### DIFF
--- a/packages/console/src/lib/verified-standing.server.ts
+++ b/packages/console/src/lib/verified-standing.server.ts
@@ -61,12 +61,13 @@ interface AdvisorRow {
 // fails (self-signature, the Apple MDA chain, or its binding to the signing
 // key). If NONE are present, genuine-Apple-hardware-bound-to-the-signing-key
 // holds — i.e. at least hardware-attested.
-const HARDWARE_BLOCKER_CODES = new Set([
+export const HARDWARE_BLOCKER_CODES = new Set([
   "attestation-signature-invalid",
   "mda-invalid",
   "mda-unbound",
   "mda-no-binding-material",
   "no-hardware-attestation",
+  "no-mda-chain",
 ]);
 
 // offline proof (hardware-attested?) keyed by attestation CID — immutable.

--- a/packages/console/src/lib/verified-standing.server.ts
+++ b/packages/console/src/lib/verified-standing.server.ts
@@ -66,7 +66,6 @@ export const HARDWARE_BLOCKER_CODES = new Set([
   "mda-invalid",
   "mda-unbound",
   "mda-no-binding-material",
-  "no-hardware-attestation",
   "no-mda-chain",
 ]);
 

--- a/packages/console/src/lib/verified-standing.test.ts
+++ b/packages/console/src/lib/verified-standing.test.ts
@@ -3,9 +3,14 @@
 // by the SDK's own verifier tests; here we pin the floor semantics: a
 // hardware-attested floor accepts EITHER verified tier, confidential is strict.
 
+import { generateKeyPairSync, sign as nodeSign } from "node:crypto";
 import { describe, expect, it } from "vitest";
 
-import { meetsFloor, parseTrustFloor } from "./verified-standing.server.ts";
+import { canonicalize } from "@cocore/sdk/canonical";
+import type { AttestationRecord } from "@cocore/sdk/types";
+import { verifyProviderForSeal } from "@cocore/sdk/verify-provider";
+
+import { HARDWARE_BLOCKER_CODES, meetsFloor, parseTrustFloor } from "./verified-standing.server.ts";
 
 describe("parseTrustFloor", () => {
   it("maps the accepted aliases", () => {
@@ -35,5 +40,61 @@ describe("meetsFloor", () => {
     expect(meetsFloor("attested-confidential", "attested-confidential")).toBe(true);
     expect(meetsFloor("hardware-attested", "attested-confidential")).toBe(false);
     expect(meetsFloor("best-effort", "attested-confidential")).toBe(false);
+  });
+});
+
+// Regression: HARDWARE_BLOCKER_CODES is matched against the SDK verifier's
+// finding codes by NAME. If the two drift (as they did when this set listed
+// "no-hardware-attestation" but the SDK emits "no-mda-chain"), a self-attested
+// record with no MDA chain and no App Attest — e.g. every Linux provider,
+// which has no Apple attestation framework to call — passes through
+// unblocked and offlineHardwareTier() wrongly reports "hardware-attested".
+describe("HARDWARE_BLOCKER_CODES tracks the SDK's actual finding codes", () => {
+  it("flags a self-attested record with no MDA chain and no App Attest", async () => {
+    const { publicKey, privateKey } = generateKeyPairSync("ec", { namedCurve: "P-256" });
+    const jwk = publicKey.export({ format: "jwk" }) as { x: string; y: string };
+    const pubB64 = Buffer.concat([
+      Buffer.from(jwk.x, "base64url"),
+      Buffer.from(jwk.y, "base64url"),
+    ]).toString("base64");
+    const sign = (msg: Uint8Array): string =>
+      nodeSign("SHA256", Buffer.from(msg), privateKey).toString("base64");
+
+    const unsigned: Omit<AttestationRecord, "selfSignature"> = {
+      publicKey: pubB64,
+      encryptionPubKey: "ZW5jcnlwdGlvbktleQ==",
+      chipName: "generic-linux",
+      hardwareModel: "linux",
+      serialNumberHash: "0".repeat(64),
+      osVersion: "Linux 6.12",
+      binaryHash: "1".repeat(64),
+      cdHash: "a".repeat(40),
+      teamId: "TEAM123456",
+      hardenedRuntime: false,
+      libraryValidation: false,
+      getTaskAllow: true,
+      inProcessBackend: true,
+      antiDebug: false,
+      coreDumpsDisabled: false,
+      envScrubbed: false,
+      sipEnabled: false,
+      secureBootEnabled: false,
+      secureEnclaveAvailable: false,
+      authenticatedRootEnabled: false,
+      attestedAt: "2026-06-19T00:00:00Z",
+      expiresAt: "2026-06-20T00:00:00Z",
+    };
+    const attestation: AttestationRecord = {
+      ...unsigned,
+      selfSignature: sign(new TextEncoder().encode(canonicalize(unsigned))),
+    };
+
+    const result = await verifyProviderForSeal(attestation, undefined, {
+      now: () => new Date("2026-06-19T12:00:00Z"),
+    });
+
+    const codes = result.findings.map((f) => f.code);
+    expect(codes).toContain("no-mda-chain");
+    expect(codes.some((c) => HARDWARE_BLOCKER_CODES.has(c))).toBe(true);
   });
 });


### PR DESCRIPTION
HARDWARE_BLOCKER_CODES checked for "no-hardware-attestation", a code the SDK verifier never emits. For attestations with no MDA chain and no App Attest object — the case for every self-attested provider, including all Linux hosts, which have no Apple attestation framework at all — the SDK actually emits "no-mda-chain". The name mismatch let those attestations fall through offlineHardwareTier() unblocked, so the console showed "Hardware-attested" for machines that never proved any hardware.