### PR TITLE
fix: stop false "session expired" banner + make re-auth actually work

### DIFF
--- a/packages/console/src/routes/api/agent.status.ts
+++ b/packages/console/src/routes/api/agent.status.ts
@@ -17,6 +17,8 @@ import { runTraced } from "@/lib/o11y.server.ts";
 import { appviewListProvidersEffect } from "@/integrations/appview/appview.server.ts";
 import { sessionNeedsReauth } from "@/integrations/auth/atproto.server.ts";
 import { resolveBearerKey } from "@/lib/api-keys.server.ts";
+import { appviewSessionInfo } from "@/lib/appview-backed-session.server.ts";
+import { isAppviewForwardConfigured } from "@/lib/appview-pds-forward.server.ts";
 import { cocoreConfig } from "@/lib/cocore-config.ts";
 import { sumReceiptInSince } from "@/lib/earnings.ts";
 import { getBalance, listEvents } from "@/lib/exchange-balance.server.ts";
@@ -125,13 +127,29 @@ export const Route = createFileRoute("/api/agent/status")({
         const since = Date.now() - 24 * 60 * 60 * 1000;
 
         // "Does the agent need a fresh sign-in?" — a NON-refreshing read of
-        // the stored OAuth session (see sessionNeedsReauth). The old probe
-        // called restore(), which refreshes/rotates the single-use refresh
-        // token on every status poll; because the AppView is the designated
-        // refresher, that parallel rotation was cannibalizing the session it
-        // was meant to monitor and causing the recurring write 401s. This
-        // read only reports re-auth when the session is genuinely gone.
-        const needsReauth = sessionNeedsReauth(did as Did);
+        // the stored OAuth session. The old probe called restore(), which
+        // refreshes/rotates the single-use refresh token on every status poll;
+        // because the AppView is the designated refresher, that parallel
+        // rotation cannibalized the session it was meant to monitor.
+        //
+        // When AppView forwarding is configured, the AUTHORITATIVE session lives
+        // in the AppView (the console hands it off at login and never refreshes
+        // locally — see appview-backed-session.server.ts). The console's LOCAL
+        // store therefore goes stale/empty after handoff, so probing it reports
+        // a FALSE "session expired" even while the agent is actively publishing
+        // (Secure Mode / confidential live prove the session works). So prefer
+        // the AppView's authoritative, non-refreshing session-info and only
+        // report re-auth when it DEFINITIVELY says the session is gone
+        // (`checked && !present`) — never on a transient unreachable-AppView
+        // blip. Fall back to the local probe only in the legacy single-store
+        // deployment where forwarding isn't configured.
+        let needsReauth: boolean;
+        if (isAppviewForwardConfigured()) {
+          const info = await appviewSessionInfo(did);
+          needsReauth = info.checked ? !info.present : false;
+        } else {
+          needsReauth = sessionNeedsReauth(did as Did);
+        }
 
         // All three degrade gracefully so a single backend hiccup yields
         // partial data the menu can still render, not a 500.

--- a/provider-shell/Sources/CoCoreShell/WelcomeView.swift
+++ b/provider-shell/Sources/CoCoreShell/WelcomeView.swift
@@ -83,6 +83,14 @@ struct WelcomeView: View {
     }
 
     private var signedIn: Bool { state.session != nil }
+    /// The sign-in STEP needs action when there's no session OR the publish
+    /// session is dead (`needsReauth`). Without the `needsReauth` leg, a stale
+    /// session (`state.session != nil` but its refresh token is gone) rendered
+    /// the step as "Signed in ✓" with no way to re-authenticate — so clicking
+    /// "Sign in again" from the expired-session banner just reopened a wizard
+    /// that claimed you were already signed in. Only this step keys off it; the
+    /// later steps keep using `signedIn` (their own gating is unaffected).
+    private var needsSignIn: Bool { !signedIn || state.needsReauth }
     private var hasModels: Bool { !models.models.isEmpty }
     private var runtimeReady: Bool { venvInstalled }
     private var serving: Bool { state.serving }
@@ -187,11 +195,13 @@ struct WelcomeView: View {
     // MARK: step 1 — sign in
 
     private var stepSignIn: some View {
-        step(1, done: signedIn, active: !signedIn, title: "Sign in",
-             desc: signedIn
-                ? "Signed in as \(state.session?.handle ?? "your identity")."
-                : "Connect your ATProto identity to pair this machine.") {
-            if !signedIn {
+        step(1, done: !needsSignIn, active: needsSignIn, title: "Sign in",
+             desc: needsSignIn
+                ? (signedIn
+                    ? "Your co/core session expired — sign in again to keep publishing receipts."
+                    : "Connect your ATProto identity to pair this machine.")
+                : "Signed in as \(state.session?.handle ?? "your identity").") {
+            if needsSignIn {
                 VStack(alignment: .leading, spacing: 10) {
                     // Three-state so the click registers instantly with an
                     // honest label: idle → "Sign in", then the soft


### PR DESCRIPTION
The tray's **"Your co/core session expired — the agent can't publish records; receipts and Secure Mode are paused until you sign in again"** banner was showing in error, and its "Sign in again" button did nothing. Confirmed on a live machine that was fully signed in and serving (Secure Mode hardware-attested + confidential tier both active — which *require* a working publish session).

Two root causes:

## 1. False-positive `needsReauth` — server, deploys on merge
`/api/agent/status` computed `needsReauth` from `sessionNeedsReauth()`, which reads the **console's local** OAuth store. But with AppView forwarding configured (prod), the console hands the session off to the AppView at login and never refreshes locally (single-refresher design) — so its local store goes stale/empty and the probe reports "expired" while the agent is happily publishing.

Fix: when forwarding is configured, read `needsReauth` from the AppView's **authoritative, non-refreshing** `/internal/pds/session-info` (`appviewSessionInfo`), and only report re-auth on a definitive `checked && !present` — never on a transient unreachable-AppView blip. Falls back to the local probe only in the legacy single-store deployment.

## 2. Re-auth button dead-ended — tray, ships in the next release
`WelcomeView`'s sign-in step keyed only off `signedIn = state.session != nil`, so a stale session rendered "Signed in ✓" with no action — clicking "Sign in again" reopened a wizard that claimed you were already signed in. New `needsSignIn = !signedIn || state.needsReauth` drives just that step, so an expired session shows the real Sign-in button (`signIn()` re-pairs + refreshes). Other steps keep using `signedIn`.

## Verification
- `tsc` + format/lint/knip clean; `provider-shell` `swift build` clean.
- Fix #1 clears the banner for everyone as soon as the console (Client) deploys from main. Fix #2 reaches installed apps with the next tray release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)