### PR TITLE
security(pr1): authenticate bridge mutations, advisor session ownership, wipe env-guard

### DIFF
--- a/infra/advisor/src/connection.ts
+++ b/infra/advisor/src/connection.ts
@@ -302,6 +302,21 @@ export function handleConnection(
     void onMessage(msg);
   });
 
+  // A session-targeting frame (chunk/keepalive/complete) is honored only from
+  // the exact socket the session was dispatched to. An unregistered socket, or
+  // one registered as a different provider/machine, cannot inject into or
+  // complete a session it doesn't own.
+  const ownsSession = (sessionId: string): boolean => {
+    const owner = sessions.ownerOf(sessionId);
+    return (
+      !!owner &&
+      !!registeredDid &&
+      !!registeredMachineId &&
+      owner.providerDid === registeredDid &&
+      owner.providerMachineId === registeredMachineId
+    );
+  };
+
   const onMessage = async (msg: AdvisorMessage): Promise<void> => {
     switch (msg.type) {
       case "register": {
@@ -445,9 +460,7 @@ export function handleConnection(
         return;
       }
       case "inference_chunk": {
-        if (!sessions.has(msg.session_id)) {
-          return;
-        }
+        if (!ownsSession(msg.session_id)) return;
         sessions.write(msg.session_id, {
           type: "chunk",
           sessionId: msg.session_id,
@@ -461,12 +474,16 @@ export function handleConnection(
         // "Still generating" — reset the session idle timer so a slow-but-
         // alive job (long prefill / slow decode) isn't killed as silent.
         // Not relayed to the requester; doesn't count as a token.
-        if (sessions.has(msg.session_id)) {
+        if (ownsSession(msg.session_id)) {
           sessions.keepalive(msg.session_id);
         }
         return;
       }
       case "inference_complete": {
+        // Only the provider a session was dispatched to may complete it —
+        // otherwise any connected provider could forge another session's
+        // completion (bogus receipt_uri / token counts, premature close).
+        if (!ownsSession(msg.session_id)) return;
         // A completion proves this machine isn't silently dropping work —
         // record it so the silent-failure detector clears, bad standing is
         // restored, and the dispatch counter has a denominator.

--- a/infra/advisor/src/sessions.ts
+++ b/infra/advisor/src/sessions.ts
@@ -146,6 +146,17 @@ export class SessionManager {
     return this.bySessionId.has(sessionId);
   }
 
+  /** The provider (DID + machine) a session was dispatched to, or undefined
+   *  if there's no such session. The WS handler uses this to reject
+   *  `inference_*` frames from any socket other than the one the job was
+   *  actually sent to — without it, any connected provider could inject
+   *  chunks into, or forge the completion of, another provider's session. */
+  ownerOf(sessionId: string): { providerDid: string; providerMachineId: string } | undefined {
+    const e = this.bySessionId.get(sessionId);
+    if (!e) return undefined;
+    return { providerDid: e.providerDid, providerMachineId: e.providerMachineId };
+  }
+
   size(): number {
     return this.bySessionId.size;
   }

--- a/infra/mock-provider/src/main.ts
+++ b/infra/mock-provider/src/main.ts
@@ -20,7 +20,12 @@ let attCount = 0;
 async function publish(rec: IndexedRecord): Promise<void> {
   const res = await fetch(`${BRIDGE}/xrpc/dev.cocore.bridge.publish`, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: {
+      "content-type": "application/json",
+      ...(process.env["COCORE_INTERNAL_API_KEY"]
+        ? { authorization: `Bearer ${process.env["COCORE_INTERNAL_API_KEY"]}` }
+        : {}),
+    },
     body: JSON.stringify(rec),
   });
   if (!res.ok) {

--- a/infra/seed-dev-stack.ts
+++ b/infra/seed-dev-stack.ts
@@ -58,7 +58,12 @@ function encodeInt(b: Uint8Array): number[] {
 async function publish(bridge: string, record: Record<string, unknown>): Promise<void> {
   const res = await fetch(`${bridge}/xrpc/dev.cocore.bridge.publish`, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: {
+      "content-type": "application/json",
+      ...(process.env["COCORE_INTERNAL_API_KEY"]
+        ? { authorization: `Bearer ${process.env["COCORE_INTERNAL_API_KEY"]}` }
+        : {}),
+    },
     body: JSON.stringify(record),
   });
   if (!res.ok) throw new Error(`publish ${record["uri"]}: ${res.status} ${await res.text()}`);

--- a/infra/services/src/main.ts
+++ b/infra/services/src/main.ts
@@ -602,8 +602,13 @@ async function main() {
   const appview = buildAppviewSplit(store, {
     accountStore,
     appviewDid: APPVIEW_DID,
-    // The bridge runs in this same process; mirror PDS writes to it.
+    // The bridge runs in this same process; mirror PDS writes to it. The
+    // bridge's mutating routes now require the internal key, so hand the
+    // AppView the same token to authenticate its best-effort mirror POSTs.
     bridgeUrl: BRIDGE_URL,
+    bridgeAuthToken: Option.isSome(INTERNAL_API_KEY)
+      ? Redacted.value(INTERNAL_API_KEY.value)
+      : undefined,
     internalSecret: Option.isSome(INTERNAL_SECRET)
       ? Redacted.value(INTERNAL_SECRET.value)
       : undefined,
@@ -670,6 +675,7 @@ async function main() {
     HttpRouter.post(
       "/xrpc/dev.cocore.bridge.publish",
       Effect.gen(function* () {
+        if (!authOk(yield* header("authorization"))) return err(401, { error: "unauthorized" });
         const parsed = yield* Effect.either(jsonBody);
         if (parsed._tag === "Left") return err(400, { error: "body must be JSON" });
         const body = parsed.right as IndexedRecord;
@@ -727,6 +733,7 @@ async function main() {
     HttpRouter.post(
       "/xrpc/dev.cocore.bridge.unpublish",
       Effect.gen(function* () {
+        if (!authOk(yield* header("authorization"))) return err(401, { error: "unauthorized" });
         const parsed = yield* Effect.either(jsonBody);
         if (parsed._tag === "Left") return err(400, { error: "body must be JSON" });
         const body = parsed.right as { uri?: string };
@@ -738,6 +745,7 @@ async function main() {
     HttpRouter.post(
       "/xrpc/dev.cocore.bridge.purge",
       Effect.gen(function* () {
+        if (!authOk(yield* header("authorization"))) return err(401, { error: "unauthorized" });
         const parsed = yield* Effect.either(jsonBody);
         if (parsed._tag === "Left") return err(400, { error: "body must be JSON" });
         const body = parsed.right as { did?: string };
@@ -957,6 +965,23 @@ async function main() {
           return err(403, {
             error: "wipe disabled; set COCORE_ALLOW_WIPE=1 on the services container",
           });
+        }
+        // Railway copies production env vars (incl. COCORE_INTERNAL_API_KEY)
+        // into forked preview environments. Refuse to run a destructive wipe in
+        // any non-production Railway env unless explicitly overridden, so an
+        // inherited key can't wipe from a preview origin. Locales without
+        // RAILWAY_ENVIRONMENT_NAME (bare-node / docker dev) are unaffected.
+        {
+          const railwayEnv = process.env["RAILWAY_ENVIRONMENT_NAME"];
+          if (
+            railwayEnv &&
+            railwayEnv !== "production" &&
+            process.env["COCORE_ALLOW_WIPE_NONPROD"] !== "1"
+          ) {
+            return err(403, {
+              error: `wipe blocked in non-production Railway env '${railwayEnv}'; set COCORE_ALLOW_WIPE_NONPROD=1 to override`,
+            });
+          }
         }
         try {
           const counts: Record<string, number> = {};

--- a/packages/appview/src/api/server.ts
+++ b/packages/appview/src/api/server.ts
@@ -43,6 +43,10 @@ export interface BuildServerOptions {
   appviewDid?: string;
   /** Bridge base URL for the best-effort cache mirror on PDS writes. */
   bridgeUrl?: string;
+  /** Internal API key the bridge's mutating routes now require. Threaded into
+   *  the PDS-write + inference mirror paths so their best-effort bridge POSTs
+   *  carry the Bearer the gate expects. */
+  bridgeAuthToken?: string;
   /** Shared secret the console presents to hand off a freshly minted
    *  OAuth session (`POST /internal/oauth-session`). When unset, the
    *  handoff endpoints are not registered. */
@@ -228,7 +232,12 @@ function buildAppviewRouters(
   // PDS-write executor + its `/api/pds/*` alias (a paired agent's apiBase
   // points at this AppView and appends `/api/pds/...`).
   if (opts.accountStore && oauth) {
-    const pctx = { accounts: opts.accountStore, oauth, bridgeUrl: opts.bridgeUrl };
+    const pctx = {
+      accounts: opts.accountStore,
+      oauth,
+      bridgeUrl: opts.bridgeUrl,
+      bridgeAuthToken: opts.bridgeAuthToken,
+    };
     const pds = buildPdsRouter(pctx);
     routers.push(pds, pds.pipe(HttpRouter.prefixAll("/api")));
     // Deprecated legacy alias: agents still on the pre-cutover
@@ -274,6 +283,7 @@ function buildAppviewRouters(
         advisorUrl: opts.advisorUrl,
         exchangeDid: opts.exchangeDid ?? "did:web:exchange.local",
         bridgeUrl: opts.bridgeUrl,
+        bridgeAuthToken: opts.bridgeAuthToken,
       }),
     );
     console.error("appview: inference.dispatch endpoint enabled");
@@ -357,6 +367,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     accountStore,
     appviewDid,
     bridgeUrl: process.env["COCORE_BRIDGE_URL"],
+    bridgeAuthToken: process.env["COCORE_INTERNAL_API_KEY"],
     internalSecret: process.env["COCORE_INTERNAL_SECRET"],
   });
   createServer(handler).listen(port, () => {

--- a/packages/appview/src/inference/routes.ts
+++ b/packages/appview/src/inference/routes.ts
@@ -53,6 +53,9 @@ export interface InferenceContext {
   /** Bridge base URL for the best-effort AppView-cache mirror on the job
    *  write. When unset, writes still land on the PDS and firehose catches up. */
   bridgeUrl?: string;
+  /** Internal API key the bridge's mutating routes now require. Attached as a
+   *  Bearer to the best-effort mirror POST; unset ⇒ unauthenticated mirror. */
+  bridgeAuthToken?: string;
 }
 
 interface DispatchBody {
@@ -226,6 +229,7 @@ function parseDispatch(body: DispatchBody): ParsedDispatch | string {
 function sessionTransport(
   session: RestoredSession,
   bridgeUrl: string | undefined,
+  bridgeAuthToken?: string,
 ): RecordTransport {
   return {
     async publish<T extends Record<string, unknown>>(args: {
@@ -253,7 +257,10 @@ function sessionTransport(
         const rkey = out.uri.split("/").pop() ?? "";
         void fetch(`${bridgeUrl.replace(/\/$/, "")}/xrpc/dev.cocore.bridge.publish`, {
           method: "POST",
-          headers: { "content-type": "application/json" },
+          headers: {
+            "content-type": "application/json",
+            ...(bridgeAuthToken ? { authorization: `Bearer ${bridgeAuthToken}` } : {}),
+          },
           body: JSON.stringify({
             uri: out.uri,
             cid: out.cid,
@@ -333,7 +340,7 @@ export function buildInferenceRouter(ctx: InferenceContext): HttpRouter.HttpRout
           {
             advisorUrl: ctx.advisorUrl,
             exchangeDid: ctx.exchangeDid,
-            transport: sessionTransport(session, ctx.bridgeUrl),
+            transport: sessionTransport(session, ctx.bridgeUrl, ctx.bridgeAuthToken),
             getProfile: storeProfileFetcher(ctx.store),
           },
         );

--- a/packages/appview/src/pds/write.ts
+++ b/packages/appview/src/pds/write.ts
@@ -50,6 +50,10 @@ export interface PdsWriteContext {
   /** Bridge base URL for the best-effort AppView-cache mirror. When unset,
    *  writes still land on the PDS and the firehose catches up. */
   bridgeUrl?: string;
+  /** Internal API key the bridge's mutating routes now require. Attached as a
+   *  Bearer to the best-effort mirror POSTs; when unset the mirror is sent
+   *  unauthenticated (dev/local bridges without the gate). */
+  bridgeAuthToken?: string;
 }
 
 // ---- small helpers --------------------------------------------------
@@ -83,11 +87,15 @@ function mirrorPublish(
     repo: string;
     record: Record<string, unknown>;
   },
+  token?: string,
 ): void {
   if (!bridgeUrl) return;
   void fetch(`${bridgeUrl.replace(/\/$/, "")}/xrpc/dev.cocore.bridge.publish`, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: {
+      "content-type": "application/json",
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+    },
     body: JSON.stringify({
       uri: args.uri,
       cid: args.cid,
@@ -101,11 +109,14 @@ function mirrorPublish(
   });
 }
 
-function mirrorUnpublish(bridgeUrl: string | undefined, uri: string): void {
+function mirrorUnpublish(bridgeUrl: string | undefined, uri: string, token?: string): void {
   if (!bridgeUrl) return;
   void fetch(`${bridgeUrl.replace(/\/$/, "")}/xrpc/dev.cocore.bridge.unpublish`, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: {
+      "content-type": "application/json",
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+    },
     body: JSON.stringify({ uri }),
   }).catch(() => {
     /* swallowed — firehose catches up */
@@ -247,13 +258,17 @@ async function doCreate(
     cid: string;
     commit?: { cid: string; rev: string };
   };
-  mirrorPublish(ctx.bridgeUrl, {
-    uri: out.uri,
-    cid: out.cid,
-    collection: a.collection,
-    repo: did,
-    record: a.record,
-  });
+  mirrorPublish(
+    ctx.bridgeUrl,
+    {
+      uri: out.uri,
+      cid: out.cid,
+      collection: a.collection,
+      repo: did,
+      record: a.record,
+    },
+    ctx.bridgeAuthToken,
+  );
   return ok({ uri: out.uri, cid: out.cid, commit: out.commit });
 }
 
@@ -288,13 +303,17 @@ async function doPut(
     });
   }
   const out = (await r.json()) as { uri: string; cid: string };
-  mirrorPublish(ctx.bridgeUrl, {
-    uri: out.uri,
-    cid: out.cid,
-    collection: a.collection,
-    repo: did,
-    record: a.record,
-  });
+  mirrorPublish(
+    ctx.bridgeUrl,
+    {
+      uri: out.uri,
+      cid: out.cid,
+      collection: a.collection,
+      repo: did,
+      record: a.record,
+    },
+    ctx.bridgeAuthToken,
+  );
   return ok({ uri: out.uri, cid: out.cid });
 }
 
@@ -325,7 +344,7 @@ async function doDelete(
     const text = await r.text().catch(() => "");
     // Already-gone collapses to success so the agent's dedup loop moves on.
     if (r.status === 404 || /not.*locate|InvalidSwap|not.*found/i.test(text)) {
-      mirrorUnpublish(ctx.bridgeUrl, uri);
+      mirrorUnpublish(ctx.bridgeUrl, uri, ctx.bridgeAuthToken);
       return ok({ uri, alreadyGone: true });
     }
     return err(r.status >= 500 ? 502 : r.status, {
@@ -333,7 +352,7 @@ async function doDelete(
       message: `deleteRecord ${a.collection}: ${text.slice(0, 300)}`,
     });
   }
-  mirrorUnpublish(ctx.bridgeUrl, uri);
+  mirrorUnpublish(ctx.bridgeUrl, uri, ctx.bridgeAuthToken);
   return ok({ uri });
 }
 

--- a/packages/console/src/lib/account-profile.server.ts
+++ b/packages/console/src/lib/account-profile.server.ts
@@ -28,7 +28,7 @@ import type { OAuthSession } from "@atcute/oauth-node-client";
 import { runTraced } from "@/lib/o11y.server.ts";
 
 import { fetchBlueskyPublicProfileFieldsEffect } from "@/lib/bluesky-public-profile.server.ts";
-import { cocoreConfig } from "@/lib/cocore-config.ts";
+import { bridgeHeaders, cocoreConfig } from "@/lib/cocore-config.ts";
 
 const COLLECTION = "dev.cocore.account.profile";
 const RKEY = "self";
@@ -48,7 +48,7 @@ function mirrorProfileToBridge(
   if (!bridgeUrl) return;
   void fetch(`${bridgeUrl}/xrpc/dev.cocore.bridge.publish`, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: bridgeHeaders(),
     body: JSON.stringify({
       uri,
       cid,

--- a/packages/console/src/lib/cocore-config.ts
+++ b/packages/console/src/lib/cocore-config.ts
@@ -27,6 +27,16 @@ export interface CocoreConfig {
   internalApiKey: string;
 }
 
+/** Headers for a best-effort mirror POST to the services bridge. Includes the
+ *  internal API key the bridge's mutating routes now require. */
+export function bridgeHeaders(): Record<string, string> {
+  const key = process.env["COCORE_INTERNAL_API_KEY"] ?? "";
+  return {
+    "content-type": "application/json",
+    ...(key ? { authorization: `Bearer ${key}` } : {}),
+  };
+}
+
 export function cocoreConfig(): CocoreConfig {
   return {
     bridgeUrl: process.env["COCORE_BRIDGE_URL"] ?? "http://localhost:8080",

--- a/packages/console/src/lib/friends.server.ts
+++ b/packages/console/src/lib/friends.server.ts
@@ -24,7 +24,7 @@
 
 import type { OAuthSession } from "@atcute/oauth-node-client";
 
-import { cocoreConfig } from "@/lib/cocore-config.ts";
+import { bridgeHeaders, cocoreConfig } from "@/lib/cocore-config.ts";
 
 const FRIEND_COLLECTION = "dev.cocore.account.friend";
 
@@ -44,7 +44,7 @@ function mirrorFriendToBridge(args: {
   if (!bridgeUrl) return;
   void fetch(`${bridgeUrl}/xrpc/dev.cocore.bridge.publish`, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: bridgeHeaders(),
     body: JSON.stringify({
       uri: args.uri,
       cid: args.cid,
@@ -63,7 +63,7 @@ function mirrorFriendDeleteToBridge(uri: string): void {
   if (!bridgeUrl) return;
   void fetch(`${bridgeUrl}/xrpc/dev.cocore.bridge.unpublish`, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: bridgeHeaders(),
     body: JSON.stringify({ uri }),
   }).catch(() => {});
 }

--- a/packages/console/src/lib/pds-publish.server.ts
+++ b/packages/console/src/lib/pds-publish.server.ts
@@ -16,6 +16,8 @@ import type { OAuthSession } from "@atcute/oauth-node-client";
 
 import type { PublishedRecord, RecordTransport } from "@cocore/sdk/publish";
 
+import { bridgeHeaders } from "@/lib/cocore-config.ts";
+
 interface CreateRecordResponse {
   uri: string;
   cid: string;
@@ -65,7 +67,7 @@ export class PdsPublishTransport implements RecordTransport {
     if (this.bridgeUrl) {
       void fetch(`${this.bridgeUrl}/xrpc/dev.cocore.bridge.publish`, {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: bridgeHeaders(),
         body: JSON.stringify({
           uri: out.uri,
           cid: out.cid,

--- a/packages/console/src/lib/pds-write.server.ts
+++ b/packages/console/src/lib/pds-write.server.ts
@@ -25,7 +25,7 @@ import {
 } from "@/integrations/auth/atproto.server.ts";
 import { resolveBearerKey } from "@/lib/api-keys.server.ts";
 import { forwardPdsWrite, isAppviewForwardConfigured } from "@/lib/appview-pds-forward.server.ts";
-import { cocoreConfig } from "@/lib/cocore-config.ts";
+import { bridgeHeaders, cocoreConfig } from "@/lib/cocore-config.ts";
 
 /** Collection NSIDs these endpoints will write to a user's PDS. We allow
  *  the full `dev.cocore.*` namespace (compute.* receipts/jobs/etc. AND
@@ -56,7 +56,7 @@ function mirrorToBridge(args: {
   if (!bridgeUrl) return;
   void fetch(`${bridgeUrl}/xrpc/dev.cocore.bridge.publish`, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: bridgeHeaders(),
     body: JSON.stringify({
       uri: args.uri,
       cid: args.cid,
@@ -75,7 +75,7 @@ function mirrorDeleteToBridge(uri: string): void {
   if (!bridgeUrl) return;
   void fetch(`${bridgeUrl}/xrpc/dev.cocore.bridge.unpublish`, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: bridgeHeaders(),
     body: JSON.stringify({ uri }),
   }).catch(() => {
     // swallowed — AppView eventually catches up via firehose

--- a/packages/console/src/lib/provider-record-pds.server.ts
+++ b/packages/console/src/lib/provider-record-pds.server.ts
@@ -1,6 +1,6 @@
 import type { OAuthSession } from "@atcute/oauth-node-client";
 
-import { cocoreConfig } from "@/lib/cocore-config.ts";
+import { bridgeHeaders, cocoreConfig } from "@/lib/cocore-config.ts";
 import {
   type CasRecordStore,
   isRecordNotFound,
@@ -17,7 +17,7 @@ function mirrorDeleteToBridge(uri: string): void {
   if (!bridgeUrl) return;
   void fetch(`${bridgeUrl}/xrpc/dev.cocore.bridge.unpublish`, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: bridgeHeaders(),
     body: JSON.stringify({ uri }),
   }).catch(() => {
     // swallowed — the AppView will eventually catch up via firehose
@@ -44,7 +44,7 @@ function mirrorPutToBridge(args: {
   const uri = `at://${args.did}/${PROVIDER_COLLECTION}/${args.rkey}`;
   void fetch(`${bridgeUrl}/xrpc/dev.cocore.bridge.publish`, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: bridgeHeaders(),
     body: JSON.stringify({
       uri,
       cid: args.cid,

--- a/packages/console/src/lib/wipe-my-data.server.ts
+++ b/packages/console/src/lib/wipe-my-data.server.ts
@@ -29,7 +29,7 @@ import type { OAuthSession } from "@atcute/oauth-node-client";
 
 import { deleteConsoleUserPrefsForDid } from "@/lib/console-user-prefs.server.ts";
 import { consoleDb } from "@/lib/console-db.server.ts";
-import { cocoreConfig } from "@/lib/cocore-config.ts";
+import { bridgeHeaders, cocoreConfig } from "@/lib/cocore-config.ts";
 
 // Every `dev.cocore.compute.*` collection the user might have written
 // to. Keep this in lockstep with `lexicons/dev/cocore/compute/*` — a
@@ -111,7 +111,7 @@ async function purgeAppview(did: string): Promise<number> {
   try {
     const r = await fetch(`${bridgeUrl}/xrpc/dev.cocore.bridge.purge`, {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: bridgeHeaders(),
       body: JSON.stringify({ did }),
     });
     if (!r.ok) return 0;

--- a/packages/console/src/routes/api/internal/wipe-everything.ts
+++ b/packages/console/src/routes/api/internal/wipe-everything.ts
@@ -156,6 +156,28 @@ export const Route = createFileRoute("/api/internal/wipe-everything")({
             403,
           );
         }
+        // Railway forks preview environments from production and copies its
+        // variables (including COCORE_INTERNAL_API_KEY). This endpoint deletes
+        // every signed-in user's dev.cocore.* records off their real PDS, so
+        // refuse to run in any non-production Railway env unless explicitly
+        // overridden — an inherited key must not be able to wipe from a preview
+        // origin. Environments without RAILWAY_ENVIRONMENT_NAME (local dev) are
+        // unaffected.
+        {
+          const railwayEnv = process.env["RAILWAY_ENVIRONMENT_NAME"];
+          if (
+            railwayEnv &&
+            railwayEnv !== "production" &&
+            process.env["COCORE_ALLOW_WIPE_NONPROD"] !== "1"
+          ) {
+            return jsonResponse(
+              {
+                error: `wipe blocked in non-production Railway env '${railwayEnv}'; set COCORE_ALLOW_WIPE_NONPROD=1 to override`,
+              },
+              403,
+            );
+          }
+        }
 
         // 1. Walk every stored OAuth session and wipe that DID's PDS.
         //    Run BEFORE truncating oauth_sessions so we still have the

--- a/packages/sdk/src/publish.ts
+++ b/packages/sdk/src/publish.ts
@@ -42,13 +42,17 @@ export interface RecordTransport {
 }
 
 /** Bridge transport. Targets the in-process firehose used by
- *  `infra/services` and the local docker stack. The bridge does not
- *  authenticate writes — caller passes the requester's DID directly. */
+ *  `infra/services` and the local docker stack. The caller passes the
+ *  requester's DID directly. The dev bridge's mutating routes now require the
+ *  internal API key, so pass `token` (COCORE_INTERNAL_API_KEY) to attach it as
+ *  a Bearer; omit it only for a bridge deployed without the gate. */
 export class BridgeRecordTransport implements RecordTransport {
   private readonly endpoint: string;
+  private readonly token: string | undefined;
 
-  constructor(opts: { endpoint: string }) {
+  constructor(opts: { endpoint: string; token?: string }) {
     this.endpoint = opts.endpoint.replace(/\/$/, "");
+    this.token = opts.token;
   }
 
   async publish<T extends Record<string, unknown>>(args: {
@@ -69,7 +73,10 @@ export class BridgeRecordTransport implements RecordTransport {
     };
     const res = await fetch(`${this.endpoint}/xrpc/dev.cocore.bridge.publish`, {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: {
+        "content-type": "application/json",
+        ...(this.token ? { authorization: `Bearer ${this.token}` } : {}),
+      },
       body: JSON.stringify(body),
     });
     if (!res.ok) {


### PR DESCRIPTION
First of a 6-PR security remediation series from the adversarial audit. **Stacked** — merge in order (pr1 → pr6); each subsequent PR is based on the previous branch.

## Findings addressed
- **C1 (Critical)** — `dev.cocore.bridge.publish/unpublish/purge` were unauthenticated on the public bridge port. Anyone reachable could `purge` all records for any DID, `unpublish` any record, or `publish` forged records. Now gated behind the internal bearer (`authOk`), and all ~11 internal mirror callers (console/appview/sdk/seed/mock-provider) thread `COCORE_INTERNAL_API_KEY`.
- **C3 (Critical)** — advisor `inference_chunk/keepalive/complete` were routed by `session_id` with no sender check. Now honored only from the socket the session was dispatched to (`SessionManager.ownerOf` + `ownsSession`).
- **H6 (code half)** — `admin.wipe` / `wipe-everything` now refuse to run in a non-production Railway env unless `COCORE_ALLOW_WIPE_NONPROD=1`.

## Deploy note
Every service process (services, console, appview, dev mock-provider/seed) must have `COCORE_INTERNAL_API_KEY` set for index mirroring to authenticate; where unset, mirror POSTs 401 and the firehose backfills.

## Verification
`oxlint` clean on all changed files. Could not run `tsc`/tests locally (offline env) — relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)