### PR TITLE
security(pr2): SSRF guard, firehose size-cap + validation, body/read caps

### DIFF
--- a/packages/appview/src/api/read-router.ts
+++ b/packages/appview/src/api/read-router.ts
@@ -33,6 +33,13 @@ import type { Store } from "../store.ts";
 import { clampInt, parseIntOr } from "./query.ts";
 import { err, ok, searchParams } from "./http-app.ts";
 
+// modelActivity JSON-walks the 5000 most-recent receipt bodies on every hit and
+// is unauthenticated — a cheap way to force a full scan in a loop. Memoize the
+// result for a short TTL so a hot page (or an attacker) can't drive repeated
+// full scans. Override with COCORE_MODEL_ACTIVITY_TTL_MS.
+const MODEL_ACTIVITY_TTL_MS = Number(process.env["COCORE_MODEL_ACTIVITY_TTL_MS"] ?? 30_000);
+let modelActivityCache: { at: number; body: unknown } | null = null;
+
 // Lexicon `bytes` fields ship as base64 strings on the wire; decode them for
 // the schema-validation pass in verifyReceipt (the cryptographic verify runs
 // on the original string-bearing JSON so canonical bytes match what was signed).
@@ -110,7 +117,10 @@ export function buildReadRouter(store: Store): HttpRouter.HttpRouter<never, neve
       "/xrpc/dev.cocore.account.listFriendEdges",
       Effect.gen(function* () {
         const sp = yield* searchParams;
-        const limit = clampInt(sp.get("limit"), 5000, 1, 20000);
+        // Hard cap lowered 20000 -> 1000: an unauthenticated caller could pull
+        // 20k edge rows and serialize them per request as a memory-amplification
+        // lever. 1000 is ample for the friends UI; larger reads should paginate.
+        const limit = clampInt(sp.get("limit"), 1000, 1, 1000);
         const edges = store.listFriendEdges(limit);
         return ok({ edges, total: edges.length });
       }).pipe(Effect.withSpan("appview.listFriendEdges")),
@@ -217,6 +227,11 @@ export function buildReadRouter(store: Store): HttpRouter.HttpRouter<never, neve
     HttpRouter.get(
       "/xrpc/dev.cocore.compute.modelActivity",
       Effect.sync(() => {
+        // Serve a memoized result within the TTL to bound repeated full scans.
+        const cached = modelActivityCache;
+        if (cached && Date.now() - cached.at < MODEL_ACTIVITY_TTL_MS) {
+          return ok(cached.body);
+        }
         // Aggregate receipt activity per model + per time window (1h/24h/7d/
         // 30d), with per-provider counts, over the 5000 most-recent receipts.
         const now = Date.now();
@@ -282,7 +297,9 @@ export function buildReadRouter(store: Store): HttpRouter.HttpRouter<never, neve
             stats: s,
           })),
         }));
-        return ok({ generatedAt: new Date().toISOString(), models });
+        const body = { generatedAt: new Date().toISOString(), models };
+        modelActivityCache = { at: Date.now(), body };
+        return ok(body);
       }).pipe(Effect.withSpan("appview.modelActivity")),
     ),
     HttpRouter.get(

--- a/packages/appview/src/indexer/index.ts
+++ b/packages/appview/src/indexer/index.ts
@@ -13,6 +13,7 @@
 // was indexed.
 
 import type { Firehose, IndexedRecord } from "@cocore/sdk";
+import { ids, lexicons } from "@cocore/sdk/lex";
 import { Store } from "../store.ts";
 
 // Re-export the relay wire transport so consumers (e.g. the
@@ -35,6 +36,40 @@ function isCocoreCollection(collection: string): boolean {
   return collection.startsWith(COCORE_NAMESPACE_PREFIX);
 }
 
+// Firehose records are provider-signed, so the commit signature proves `repo`
+// is authentic — but it says NOTHING about the record body's shape or size. A
+// single validly-signed-but-hostile record (a 50 MB `model` string, a deeply
+// nested blob) would otherwise be stored verbatim and then walked by the
+// unauthenticated aggregation endpoints, DoS-ing every federated AppView at
+// once. Cap the serialized body and, for the collections we have a record
+// lexicon for, schema-validate before indexing.
+const MAX_RECORD_BYTES = Number(process.env["COCORE_MAX_RECORD_BYTES"] ?? 256 * 1024);
+
+// The size cap + object-shape check are ALWAYS enforced (they stop the concrete
+// memory-amplification DoS). Schema validation is warn-by-default: the indexer
+// has always stored loose records and the security-critical read path
+// (verifyReceipt) re-validates at serve time, so dropping lexicon-invalid
+// records is a behavior change gated behind an explicit flag. Set
+// COCORE_INDEX_STRICT_VALIDATION=1 to drop invalid records at ingest.
+const STRICT_INDEX_VALIDATION = process.env["COCORE_INDEX_STRICT_VALIDATION"] === "1";
+
+// Collections with a registered `record` lexicon in @cocore/sdk/lex, so we can
+// assertValidRecord them. Other dev.cocore.* collections (account.*, which are
+// not registered here, plus non-record query NSIDs) are size-capped + shape-
+// checked but not schema-validated. Keep in lockstep with the record lexicons.
+const VALIDATED_RECORD_COLLECTIONS = new Set<string>([
+  ids.DevCocoreComputeAttestation,
+  ids.DevCocoreComputeDispute,
+  ids.DevCocoreComputeExchangeAttestation,
+  ids.DevCocoreComputeExchangePolicy,
+  ids.DevCocoreComputeJob,
+  ids.DevCocoreComputePaymentAuthorization,
+  ids.DevCocoreComputeProvider,
+  ids.DevCocoreComputeReceipt,
+  ids.DevCocoreComputeSettlement,
+  ids.DevCocoreComputeTermsAcceptance,
+]);
+
 export interface FirehoseEvent {
   uri: string;
   cid: string;
@@ -52,9 +87,48 @@ export class Indexer {
     this.store = store;
   }
 
-  /** Process a single firehose event. Used by tests and by the wire layer. */
+  /** Process a single firehose event. Used by tests and by the wire layer.
+   *  Returns false (drops the record) for non-cocore collections, non-object
+   *  bodies, oversized bodies, and lexicon-invalid records. */
   ingest(ev: FirehoseEvent): boolean {
     if (!isCocoreCollection(ev.collection)) return false;
+
+    // Every cocore record is a JSON object; anything else is malformed.
+    if (typeof ev.record !== "object" || ev.record === null || Array.isArray(ev.record)) {
+      console.error(`indexer: dropping non-object ${ev.collection} record ${ev.uri}`);
+      return false;
+    }
+
+    // Size cap (all cocore collections) — bounds memory here and in the
+    // downstream aggregation scans that JSON-walk stored bodies.
+    const bytes = Buffer.byteLength(JSON.stringify(ev.record), "utf8");
+    if (bytes > MAX_RECORD_BYTES) {
+      console.error(
+        `indexer: dropping oversized ${ev.collection} record ${ev.uri} (${bytes}B > ${MAX_RECORD_BYTES}B)`,
+      );
+      return false;
+    }
+
+    // Schema-validate the collections we have a record lexicon for. Drop only
+    // under the strict flag; otherwise log and still index (see above).
+    if (VALIDATED_RECORD_COLLECTIONS.has(ev.collection)) {
+      try {
+        lexicons.assertValidRecord(ev.collection, {
+          $type: ev.collection,
+          ...(ev.record as Record<string, unknown>),
+        });
+      } catch (e) {
+        const msg = (e as Error).message;
+        if (STRICT_INDEX_VALIDATION) {
+          console.error(`indexer: dropping invalid ${ev.collection} record ${ev.uri}: ${msg}`);
+          return false;
+        }
+        console.warn(
+          `indexer: indexing lexicon-invalid ${ev.collection} record ${ev.uri} (strict mode off): ${msg}`,
+        );
+      }
+    }
+
     this.store.upsert({
       uri: ev.uri,
       cid: ev.cid,

--- a/packages/console/src/lib/openai-chat-completions.server.ts
+++ b/packages/console/src/lib/openai-chat-completions.server.ts
@@ -24,6 +24,7 @@ import type {
   DispatchEvent,
   ProviderCredit,
 } from "@/lib/inference-dispatch.server.ts";
+import { safeImageFetch } from "@/lib/safe-fetch.server.ts";
 
 /** A remote (http/https) image that still needs fetching before it can go
  *  into the sealed envelope. Produced by the sync `normalizeMessageContent`
@@ -453,12 +454,14 @@ async function resolveImages(messages: ChatMessage[]): Promise<EnvelopeMessage[]
         resolved.push(part);
         continue;
       }
-      // Remote image: fetch + inline.
-      const res = await fetch(part.url);
-      if (!res.ok) throw new Error(`failed to fetch image ${part.url}: ${res.status}`);
+      // Remote image: SSRF-guarded fetch + inline. `safeImageFetch` validates
+      // the URL (and every redirect hop) against private-range/scheme/port
+      // rules and returns an opaque error on any failure — do NOT echo the URL
+      // or upstream status back to the caller (that was an internal-scan oracle).
+      const res = await safeImageFetch(part.url);
       const mime = res.headers.get("content-type")?.split(";")[0]?.trim() || "image/jpeg";
       if (!mime.startsWith("image/")) {
-        throw new Error(`image url ${part.url} returned non-image content-type ${mime}`);
+        throw new Error("image url returned non-image content");
       }
       const buf = new Uint8Array(await res.arrayBuffer());
       imageBytes += buf.byteLength;

--- a/packages/console/src/lib/safe-fetch.server.ts
+++ b/packages/console/src/lib/safe-fetch.server.ts
@@ -39,8 +39,9 @@ const HOST_ALLOWLIST = (process.env["COCORE_IMAGE_FETCH_ALLOW_HOSTS"] ?? "")
   .filter((h) => h.length > 0);
 
 /** A deliberately opaque error — callers surface it verbatim so no upstream
- *  status, content-type, host, or reachability signal leaks to the requester. */
-export class ImageFetchError extends Error {
+ *  status, content-type, host, or reachability signal leaks to the requester.
+ *  Internal to this module (not exported): callers just see the generic message. */
+class ImageFetchError extends Error {
   constructor() {
     super("image fetch failed");
     this.name = "ImageFetchError";
@@ -93,7 +94,12 @@ function isBlockedIpv6(ip: string): boolean {
   const embedded = /(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/.exec(lower);
   if (embedded) return isBlockedIpv4(embedded[1]!);
   if (lower === "::" || lower === "::1") return true; // unspecified / loopback
-  if (lower.startsWith("fe8") || lower.startsWith("fe9") || lower.startsWith("fea") || lower.startsWith("feb")) {
+  if (
+    lower.startsWith("fe8") ||
+    lower.startsWith("fe9") ||
+    lower.startsWith("fea") ||
+    lower.startsWith("feb")
+  ) {
     return true; // fe80::/10 link-local
   }
   if (lower.startsWith("fc") || lower.startsWith("fd")) return true; // fc00::/7 ULA

--- a/packages/console/src/lib/safe-fetch.server.ts
+++ b/packages/console/src/lib/safe-fetch.server.ts
@@ -1,0 +1,183 @@
+// SSRF-hardened fetch for user-supplied URLs (currently: remote `image_url`s in
+// the OpenAI-compatible chat-completions proxy).
+//
+// The chat-completions body lets a caller point an `image_url` at ANY http(s)
+// URL, which the console then fetches from its own network position. Without a
+// guard that is a server-side request forgery primitive: a caller can reach
+// cloud metadata (169.254.169.254), loopback, and internal-only services, and
+// use response status / timing as an oracle. This module gates every such fetch:
+//
+//   * scheme must be http/https; port must be 80/443 (blocks odd internal ports)
+//   * the hostname is DNS-resolved and EVERY resolved IP must be public
+//     (loopback / private / link-local / ULA / CGNAT / multicast / reserved and
+//     IPv4-mapped/embedded forms are rejected)
+//   * redirects are followed manually and each hop is re-validated (a public URL
+//     can 302 to an internal one)
+//   * an AbortController bounds the wall-clock, and callers cap the body size
+//   * all failures collapse to a single generic Error — no URL/status/host is
+//     reflected back to the caller, so the oracle is closed
+//
+// Residual risk: DNS rebinding between our lookup and fetch's own connect. Full
+// mitigation needs pinning the validated IP for the socket; Node's fetch doesn't
+// expose that, so we accept the narrow TOCTOU and re-validate on every redirect.
+
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
+
+const DEFAULT_TIMEOUT_MS = Number(process.env["COCORE_IMAGE_FETCH_TIMEOUT_MS"] ?? 10_000);
+const MAX_REDIRECTS = 3;
+
+/** Remote (non-data:) image fetching can be disabled entirely — the envelope
+ *  already supports inline `data:` URIs, so an operator can require those. */
+const REMOTE_DISABLED = process.env["COCORE_IMAGE_FETCH_REMOTE_DISABLED"] === "1";
+
+/** Optional comma-separated hostname allowlist. When set, only these hosts
+ *  (exact, case-insensitive) may be fetched, in addition to the IP checks. */
+const HOST_ALLOWLIST = (process.env["COCORE_IMAGE_FETCH_ALLOW_HOSTS"] ?? "")
+  .split(",")
+  .map((h) => h.trim().toLowerCase())
+  .filter((h) => h.length > 0);
+
+/** A deliberately opaque error — callers surface it verbatim so no upstream
+ *  status, content-type, host, or reachability signal leaks to the requester. */
+export class ImageFetchError extends Error {
+  constructor() {
+    super("image fetch failed");
+    this.name = "ImageFetchError";
+  }
+}
+
+function ipv4ToInt(ip: string): number | null {
+  const parts = ip.split(".");
+  if (parts.length !== 4) return null;
+  let n = 0;
+  for (const p of parts) {
+    const o = Number(p);
+    if (!Number.isInteger(o) || o < 0 || o > 255 || !/^\d+$/.test(p)) return null;
+    n = n * 256 + o;
+  }
+  return n >>> 0;
+}
+
+function isBlockedIpv4(ip: string): boolean {
+  const n = ipv4ToInt(ip);
+  if (n === null) return true; // unparseable ⇒ treat as blocked
+  const inRange = (base: string, prefix: number): boolean => {
+    const b = ipv4ToInt(base)!;
+    const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;
+    return (n & mask) === (b & mask);
+  };
+  return (
+    inRange("0.0.0.0", 8) || // "this" network / unspecified
+    inRange("10.0.0.0", 8) || // private
+    inRange("100.64.0.0", 10) || // CGNAT
+    inRange("127.0.0.0", 8) || // loopback
+    inRange("169.254.0.0", 16) || // link-local (incl. 169.254.169.254 metadata)
+    inRange("172.16.0.0", 12) || // private
+    inRange("192.0.0.0", 24) || // IETF protocol assignments
+    inRange("192.0.2.0", 24) || // TEST-NET-1
+    inRange("192.88.99.0", 24) || // 6to4 relay anycast
+    inRange("192.168.0.0", 16) || // private
+    inRange("198.18.0.0", 15) || // benchmarking
+    inRange("198.51.100.0", 24) || // TEST-NET-2
+    inRange("203.0.113.0", 24) || // TEST-NET-3
+    inRange("224.0.0.0", 4) || // multicast
+    inRange("240.0.0.0", 4) // reserved / broadcast
+  );
+}
+
+function isBlockedIpv6(ip: string): boolean {
+  const lower = ip.toLowerCase().split("%")[0]!; // strip any zone id
+  // IPv4-mapped/embedded (::ffff:a.b.c.d, ::a.b.c.d, 64:ff9b::a.b.c.d) — pull
+  // out the trailing dotted-quad and apply the v4 rules.
+  const embedded = /(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/.exec(lower);
+  if (embedded) return isBlockedIpv4(embedded[1]!);
+  if (lower === "::" || lower === "::1") return true; // unspecified / loopback
+  if (lower.startsWith("fe8") || lower.startsWith("fe9") || lower.startsWith("fea") || lower.startsWith("feb")) {
+    return true; // fe80::/10 link-local
+  }
+  if (lower.startsWith("fc") || lower.startsWith("fd")) return true; // fc00::/7 ULA
+  if (lower.startsWith("ff")) return true; // ff00::/8 multicast
+  return false;
+}
+
+function isBlockedIp(ip: string): boolean {
+  const kind = isIP(ip);
+  if (kind === 4) return isBlockedIpv4(ip);
+  if (kind === 6) return isBlockedIpv6(ip);
+  return true; // not an IP literal ⇒ blocked
+}
+
+/** Validate scheme/port/host and confirm every resolved IP is public. Throws
+ *  {@link ImageFetchError} on any violation. */
+async function assertSafeUrl(raw: string): Promise<URL> {
+  let u: URL;
+  try {
+    u = new URL(raw);
+  } catch {
+    throw new ImageFetchError();
+  }
+  if (u.protocol !== "http:" && u.protocol !== "https:") throw new ImageFetchError();
+  if (u.port !== "" && u.port !== "80" && u.port !== "443") throw new ImageFetchError();
+
+  const host = u.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  if (HOST_ALLOWLIST.length > 0 && !HOST_ALLOWLIST.includes(host)) throw new ImageFetchError();
+
+  // If the host is an IP literal, check it directly; otherwise resolve all
+  // addresses and require every one to be public.
+  if (isIP(host)) {
+    if (isBlockedIp(host)) throw new ImageFetchError();
+    return u;
+  }
+  let addrs: { address: string }[];
+  try {
+    addrs = await lookup(host, { all: true });
+  } catch {
+    throw new ImageFetchError();
+  }
+  if (addrs.length === 0) throw new ImageFetchError();
+  for (const a of addrs) {
+    if (isBlockedIp(a.address)) throw new ImageFetchError();
+  }
+  return u;
+}
+
+/**
+ * SSRF-guarded GET for a user-supplied image URL. Validates the URL (and every
+ * redirect hop) against the private-range/scheme/port rules, bounds the
+ * wall-clock, and returns the final 2xx `Response`. The caller is responsible
+ * for content-type and body-size checks. Throws {@link ImageFetchError} — with
+ * no detail — on any failure.
+ */
+export async function safeImageFetch(rawUrl: string): Promise<Response> {
+  if (REMOTE_DISABLED) throw new ImageFetchError();
+
+  let current = rawUrl;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+  try {
+    for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+      const url = await assertSafeUrl(current);
+      const res = await fetch(url, {
+        redirect: "manual",
+        signal: controller.signal,
+        headers: { accept: "image/*" },
+      });
+      // Manual redirect handling: re-validate the target before following.
+      if (res.status >= 300 && res.status < 400) {
+        const loc = res.headers.get("location");
+        if (!loc) throw new ImageFetchError();
+        current = new URL(loc, url).toString();
+        continue;
+      }
+      if (!res.ok) throw new ImageFetchError();
+      return res;
+    }
+    throw new ImageFetchError(); // too many redirects
+  } catch (e) {
+    if (e instanceof ImageFetchError) throw e;
+    throw new ImageFetchError(); // network error / abort / anything ⇒ opaque
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/packages/o11y/src/http.ts
+++ b/packages/o11y/src/http.ts
@@ -27,20 +27,41 @@ export const searchParams = Effect.map(
   (req) => new URL(req.url, "http://localhost").searchParams,
 );
 
-/** Read + JSON-parse the request body. Empty body → `{}`. Fails catchably
- *  (not as a defect) with `Error("body must be JSON")` on malformed JSON. */
+/** Hard cap on a JSON request body. Bounds the in-memory buffer a single POST
+ *  can force before we parse it — without this, an unauthenticated route (e.g.
+ *  the bridge mirror) lets a caller push an arbitrarily large body into memory.
+ *  Override with COCORE_MAX_JSON_BODY_BYTES. */
+const MAX_JSON_BODY_BYTES = Number(process.env["COCORE_MAX_JSON_BODY_BYTES"] ?? 1024 * 1024);
+
+/** Read + JSON-parse the request body. Empty body → `{}`. Rejects a body whose
+ *  declared `content-length` or actual size exceeds {@link MAX_JSON_BODY_BYTES}
+ *  before parsing. Fails catchably (not as a defect) with
+ *  `Error("body must be JSON")` on malformed JSON (or `Error("body too large")`
+ *  on an oversized body). */
 export const jsonBody: Effect.Effect<unknown, Error, HttpServerRequest.HttpServerRequest> =
   HttpServerRequest.HttpServerRequest.pipe(
-    Effect.flatMap((req) => req.text),
-    Effect.flatMap((raw) =>
-      raw.trim().length === 0
+    Effect.flatMap((req) => {
+      const cl = req.headers["content-length"];
+      const declared = typeof cl === "string" ? Number(cl) : Number.NaN;
+      if (Number.isFinite(declared) && declared > MAX_JSON_BODY_BYTES) {
+        return Effect.fail(new Error("body too large"));
+      }
+      return req.text;
+    }),
+    Effect.flatMap((raw) => {
+      if (Buffer.byteLength(raw, "utf8") > MAX_JSON_BODY_BYTES) {
+        return Effect.fail(new Error("body too large"));
+      }
+      return raw.trim().length === 0
         ? Effect.succeed({} as unknown)
         : Effect.try({
             try: () => JSON.parse(raw) as unknown,
             catch: () => new Error("body must be JSON"),
-          }),
+          });
+    }),
+    Effect.catchAll((e) =>
+      Effect.fail(e instanceof Error && e.message === "body too large" ? e : new Error("body must be JSON")),
     ),
-    Effect.catchAll(() => Effect.fail(new Error("body must be JSON"))),
   );
 
 /** A request header value, or undefined. */

--- a/packages/o11y/src/http.ts
+++ b/packages/o11y/src/http.ts
@@ -60,7 +60,9 @@ export const jsonBody: Effect.Effect<unknown, Error, HttpServerRequest.HttpServe
           });
     }),
     Effect.catchAll((e) =>
-      Effect.fail(e instanceof Error && e.message === "body too large" ? e : new Error("body must be JSON")),
+      Effect.fail(
+        e instanceof Error && e.message === "body too large" ? e : new Error("body must be JSON"),
+      ),
     ),
   );
 


### PR DESCRIPTION
2 of 6 in the security remediation series. **Stacked on #158** (base = `security/pr1-edge-auth`); merge after PR-1.

## Findings addressed
- **H1 (High) — SSRF in the image proxy.** New `safe-fetch.server.ts` gates every user-supplied `image_url`: http/https + port 80/443 only, DNS-resolves the host and rejects any private/loopback/link-local/ULA/CGNAT/multicast/reserved IP (incl. IPv4-mapped v6), follows redirects manually and re-validates each hop, times out, and returns a single **opaque** error (closes the status/content-type oracle). `resolveImages()` routes through it.
- **H2 (High) — Firehose ingest validation + size cap.** Object-shape + serialized size cap (`COCORE_MAX_RECORD_BYTES`, 256 KiB) enforced **always** — this is the concrete DoS fix. Lexicon validation of registered `compute.*` records **warns-and-indexes by default** (the indexer has always stored loose records; `verifyReceipt` re-validates the security path at read time); `COCORE_INDEX_STRICT_VALIDATION=1` flips it to drop.
- **M5 — body cap.** `jsonBody` rejects oversized bodies (`COCORE_MAX_JSON_BODY_BYTES`, 1 MiB) before parsing.
- **M6 — read caps.** `listFriendEdges` cap 20000→1000; `modelActivity` memoized (`COCORE_MODEL_ACTIVITY_TTL_MS`, 30s).

## Deliberately deferred (follow-ups)
- Per-IP rate limiter on the read router (needs middleware plumbing + tests).
- Marking `listReceipts`/`listSettlements` results that filter on provider-chosen `requester`/`job.uri` as *unverified* (response-schema change; coordinate with consumers).

## Why validation is warn-mode, not drop
Existing unit/federation/replay tests ingest stub receipts (e.g. `{model,tokens}`) that aren't full lexicon-valid records; strict drop would break them and change indexing behavior. The size cap (the actual exploit) ships unconditionally. See commit body.

## Verification
`oxlint` clean on all changed files. `tsc`/tests via CI (couldn't run locally — offline env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)