### PR TITLE
security(pr3): gate advisor /jobs + /control behind internal bearer; bound advisor state

### DIFF
--- a/infra/advisor/src/connection.ts
+++ b/infra/advisor/src/connection.ts
@@ -37,6 +37,11 @@ import type { SessionManager } from "./sessions.ts";
 // re-challenge refreshes it. A cdHash change (new build) invalidates the cache
 // — that machine must re-prove. TTL caps how long a proof is honored unrefreshed.
 const CODE_ATTEST_TTL_MS = 11 * 60_000;
+// Hard cap on cache entries. This map is keyed by attacker-influenceable
+// (did, machineId) and was previously only ever written, never swept — a
+// registration flood could grow it without bound. `rememberCodeAttest` prunes
+// expired entries and evicts oldest-first once the cap is reached.
+const CODE_ATTEST_MAX_ENTRIES = 10_000;
 const codeAttestCache = new Map<string, { cdHash: string; at: number }>();
 const codeAttestKey = (did: string, machineId: string): string => `${did} ${machineId}`;
 function cachedCodeAttestFresh(
@@ -56,6 +61,18 @@ function rememberCodeAttest(
   now: number,
 ): void {
   if (!cdHash) return;
+  // Bound the map before inserting: drop expired entries, then evict
+  // oldest-first (Map preserves insertion order) until under the cap.
+  if (codeAttestCache.size >= CODE_ATTEST_MAX_ENTRIES) {
+    for (const [k, v] of codeAttestCache) {
+      if (now - v.at >= CODE_ATTEST_TTL_MS) codeAttestCache.delete(k);
+    }
+    while (codeAttestCache.size >= CODE_ATTEST_MAX_ENTRIES) {
+      const oldest = codeAttestCache.keys().next().value;
+      if (oldest === undefined) break;
+      codeAttestCache.delete(oldest);
+    }
+  }
   codeAttestCache.set(codeAttestKey(did, machineId), { cdHash, at: now });
 }
 

--- a/infra/advisor/src/jobs.ts
+++ b/infra/advisor/src/jobs.ts
@@ -208,8 +208,9 @@ function parseJobBody(input: unknown, generateId: () => string): ParsedJob | Par
   };
 }
 
-/** Hard cap on a request body. `/jobs` is public (it's how requesters
- *  dispatch), so an unbounded read is a trivial memory-exhaustion DoS. A
+/** Hard cap on a request body. `/jobs` is gated by the internal bearer (called
+ *  by the console/appview server, not end requesters), but an unbounded read is
+ *  still a memory-exhaustion DoS from a key holder or a misconfig. A
  *  text prompt + metadata is well under 1 MiB, but a multimodal
  *  (messages-v1) request inlines base64 images inside the sealed envelope,
  *  which is then sent as a JSON number array (~4-7 bytes on the wire per

--- a/infra/advisor/src/main.ts
+++ b/infra/advisor/src/main.ts
@@ -105,9 +105,7 @@ const CONFIG = Effect.runSync(
     internalApiKey: Config.string("COCORE_INTERNAL_API_KEY").pipe(Config.option),
     // Backstop bound on total concurrent WS connections (registry + per-conn
     // state grow with connections; without a cap a flood can exhaust memory).
-    maxConnections: Config.integer("COCORE_ADVISOR_MAX_CONNECTIONS").pipe(
-      Config.withDefault(2000),
-    ),
+    maxConnections: Config.integer("COCORE_ADVISOR_MAX_CONNECTIONS").pipe(Config.withDefault(2000)),
   }),
 );
 

--- a/infra/advisor/src/main.ts
+++ b/infra/advisor/src/main.ts
@@ -17,7 +17,7 @@
 // Both are lost on restart — providers reconnect automatically;
 // in-flight requesters retry.
 
-import { randomUUID } from "node:crypto";
+import { randomUUID, timingSafeEqual } from "node:crypto";
 import { createServer } from "node:http";
 import { join } from "node:path";
 
@@ -26,7 +26,7 @@ import { Config, Effect, Metric, Option } from "effect";
 import { WebSocketServer } from "ws";
 
 import { makeRuntime, record } from "@cocore/o11y";
-import { err, jsonBody, makeNodeHandler, ok } from "@cocore/o11y/http";
+import { err, header, jsonBody, makeNodeHandler, ok } from "@cocore/o11y/http";
 
 import { loadApnsConfig } from "./apns.ts";
 import { handleConnection } from "./connection.ts";
@@ -98,11 +98,49 @@ const CONFIG = Effect.runSync(
     latencyPersistIntervalMs: Config.integer("COCORE_ADVISOR_LATENCY_PERSIST_INTERVAL_MS").pipe(
       Config.withDefault(30_000),
     ),
+    // Shared internal bearer gating the mutating HTTP routes (/jobs, /control).
+    // These are called only by the console/appview SERVER (which vouches for the
+    // requester via its own session), not by end requesters — so a shared secret
+    // + private network is the right boundary, matching the services bridge.
+    internalApiKey: Config.string("COCORE_INTERNAL_API_KEY").pipe(Config.option),
+    // Backstop bound on total concurrent WS connections (registry + per-conn
+    // state grow with connections; without a cap a flood can exhaust memory).
+    maxConnections: Config.integer("COCORE_ADVISOR_MAX_CONNECTIONS").pipe(
+      Config.withDefault(2000),
+    ),
   }),
 );
 
 const PORT = CONFIG.port;
+const INTERNAL_API_KEY = CONFIG.internalApiKey;
+const MAX_CONNECTIONS = CONFIG.maxConnections;
 const HEARTBEAT_TIMEOUT_MS = CONFIG.heartbeatTimeoutMs;
+
+/** Constant-time bearer check against the shared internal key. Fails closed
+ *  when the key is unset (the mutating routes become unreachable rather than
+ *  open) — the same posture as the services bridge. */
+function authOk(hdr: string | string[] | undefined): boolean {
+  if (Option.isNone(INTERNAL_API_KEY)) return false;
+  const key = INTERNAL_API_KEY.value;
+  if (typeof hdr !== "string") return false;
+  const m = /^Bearer\s+(.+)$/.exec(hdr);
+  if (!m) return false;
+  const presented = m[1] ?? "";
+  if (presented.length !== key.length) return false;
+  return timingSafeEqual(Buffer.from(presented), Buffer.from(key));
+}
+
+/** Wrap a route Effect so it first requires a valid internal bearer. The
+ *  `header` read adds the HttpServerRequest requirement (already present on the
+ *  wrapped routes), so the composed type stays a valid HttpRouter handler. */
+function requireInternalAuth<A, E, R>(route: Effect.Effect<A, E, R>) {
+  return Effect.gen(function* () {
+    if (!authOk(yield* header("authorization"))) {
+      return err(401, { error: "unauthorized" });
+    }
+    return yield* route;
+  });
+}
 const SWEEP_INTERVAL_MS = CONFIG.sweepIntervalMs;
 const RECHALLENGE_INTERVAL_MS = CONFIG.rechallengeIntervalMs;
 /** How long the advisor waits for the provider to answer a
@@ -379,22 +417,27 @@ async function main(): Promise<void> {
         ),
       ).pipe(Effect.withSpan("advisor.verified-providers")),
     ),
-    HttpRouter.post("/control", controlRoute(registry).pipe(Effect.withSpan("advisor.control"))),
+    HttpRouter.post(
+      "/control",
+      requireInternalAuth(controlRoute(registry)).pipe(Effect.withSpan("advisor.control")),
+    ),
     HttpRouter.post(
       "/jobs",
-      jobsRoute({
-        registry,
-        sessions,
-        generateId: () => randomUUID(),
-        attestationMaxAgeMs: ATTESTATION_MAX_AGE_MS,
-        preflightTimeoutMs: PREFLIGHT_TIMEOUT_MS,
-        onDispatched: (ms) => {
-          ack.record(ms);
-          // Mirror the ack sample into a histogram for OTLP export (the /ack
-          // route keeps serving the rolling in-memory window).
-          record(runtime, Metric.update(ackMs, ms));
-        },
-      }),
+      requireInternalAuth(
+        jobsRoute({
+          registry,
+          sessions,
+          generateId: () => randomUUID(),
+          attestationMaxAgeMs: ATTESTATION_MAX_AGE_MS,
+          preflightTimeoutMs: PREFLIGHT_TIMEOUT_MS,
+          onDispatched: (ms) => {
+            ack.record(ms);
+            // Mirror the ack sample into a histogram for OTLP export (the /ack
+            // route keeps serving the rolling in-memory window).
+            record(runtime, Metric.update(ackMs, ms));
+          },
+        }),
+      ),
     ),
   );
 
@@ -422,8 +465,19 @@ async function main(): Promise<void> {
   // The `ws` library stays the transport; the connection's setup logic runs
   // as an Effect on the o11y runtime under an `advisor.ws.connection` span
   // (analogous to NodeHttpServer driving the HttpRouter above).
-  wss.on("connection", (socket, req) =>
-    record(
+  wss.on("connection", (socket, req) => {
+    // Backstop against a connection flood: once we're over the cap, refuse new
+    // sockets (1013 = "try again later") instead of letting registry / per-conn
+    // state grow unbounded. wss.clients already includes this socket.
+    if (wss.clients.size > MAX_CONNECTIONS) {
+      try {
+        socket.close(1013, "advisor at capacity");
+      } catch {
+        /* already closing */
+      }
+      return;
+    }
+    return record(
       runtime,
       Effect.sync(() =>
         handleConnection(socket, req, registry, sessions, {
@@ -435,8 +489,8 @@ async function main(): Promise<void> {
           apns: apnsConfig,
         }),
       ).pipe(Effect.withSpan("advisor.ws.connection")),
-    ),
-  );
+    );
+  });
 
   // --- Janitor: evict machines we haven't heard from ------------
   const sweeper = setInterval(() => {

--- a/packages/appview/src/inference/dispatch.ts
+++ b/packages/appview/src/inference/dispatch.ts
@@ -693,9 +693,14 @@ export async function* runDispatch(
     // 4. POST advisor /jobs, pinned to this candidate. `inputFormat` tells the
     //    provider how to read the opened bytes (raw prompt vs messages-v1
     //    envelope); omitted for the text path.
+    const advisorKey = process.env["COCORE_INTERNAL_API_KEY"];
     const req = await fetch(`${deps.advisorUrl}/jobs`, {
       method: "POST",
-      headers: { "content-type": "application/json", accept: "text/event-stream" },
+      headers: {
+        "content-type": "application/json",
+        accept: "text/event-stream",
+        ...(advisorKey ? { authorization: `Bearer ${advisorKey}` } : {}),
+      },
       body: JSON.stringify({
         jobUri: submitted.job.ref.uri,
         jobCid: submitted.job.ref.cid,

--- a/packages/console/src/components/machines/machines.functions.ts
+++ b/packages/console/src/components/machines/machines.functions.ts
@@ -26,7 +26,7 @@ import {
   appviewGetReceiptsEffect,
   appviewListProvidersEffect,
 } from "@/integrations/appview/appview.server.ts";
-import { cocoreConfig } from "@/lib/cocore-config.ts";
+import { cocoreConfig, internalAuthHeaders } from "@/lib/cocore-config.ts";
 import { resolveActorsForDids } from "@/lib/friends.server.ts";
 import { fetchAttestationPubkeys } from "@/lib/machine-attribution.server.ts";
 import {
@@ -366,7 +366,7 @@ async function nudgeAdvisorControl(did: string): Promise<void> {
   try {
     await fetch(`${cocoreConfig().advisorUrl}/control`, {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: { "content-type": "application/json", ...internalAuthHeaders() },
       body: JSON.stringify({ did }),
       signal: AbortSignal.timeout(5_000),
     });
@@ -385,7 +385,7 @@ async function requestSelfRight(did: string, machineId: string): Promise<{ deliv
   try {
     const resp = await fetch(`${cocoreConfig().advisorUrl}/control`, {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: { "content-type": "application/json", ...internalAuthHeaders() },
       body: JSON.stringify({ did, machineId, action: "self-right" }),
       signal: AbortSignal.timeout(5_000),
     });

--- a/packages/console/src/lib/cocore-config.ts
+++ b/packages/console/src/lib/cocore-config.ts
@@ -37,6 +37,14 @@ export function bridgeHeaders(): Record<string, string> {
   };
 }
 
+/** The `Authorization` header for the advisor's internal routes (/jobs,
+ *  /control), or `{}` when no key is configured. Spread into a fetch's headers
+ *  alongside content-type/accept. */
+export function internalAuthHeaders(): Record<string, string> {
+  const key = process.env["COCORE_INTERNAL_API_KEY"] ?? "";
+  return key ? { authorization: `Bearer ${key}` } : {};
+}
+
 export function cocoreConfig(): CocoreConfig {
   return {
     bridgeUrl: process.env["COCORE_BRIDGE_URL"] ?? "http://localhost:8080",

--- a/packages/console/src/lib/inference-dispatch.server.ts
+++ b/packages/console/src/lib/inference-dispatch.server.ts
@@ -28,7 +28,7 @@ import {
   AppviewForwardTransport,
   isAppviewForwardConfigured,
 } from "@/lib/appview-pds-forward.server.ts";
-import { cocoreConfig } from "@/lib/cocore-config.ts";
+import { cocoreConfig, internalAuthHeaders } from "@/lib/cocore-config.ts";
 import { runTraced } from "@/lib/o11y.server.ts";
 import { PdsPublishTransport } from "@/lib/pds-publish.server.ts";
 import { appviewGetProfileEffect } from "@/integrations/appview/appview.server.ts";
@@ -855,7 +855,11 @@ export async function* runDispatch(input: DispatchInputs): AsyncGenerator<Dispat
     //    advisors/providers keep treating the payload as text.
     const req = await fetch(`${config.advisorUrl}/jobs`, {
       method: "POST",
-      headers: { "content-type": "application/json", accept: "text/event-stream" },
+      headers: {
+        "content-type": "application/json",
+        accept: "text/event-stream",
+        ...internalAuthHeaders(),
+      },
       body: JSON.stringify({
         jobUri: submitted.job.ref.uri,
         jobCid: submitted.job.ref.cid,


### PR DESCRIPTION
3 of 6+ in the security series. **Stacked on #159** (base = `security/pr2-input-validation`).

## Findings addressed
- **H3 / H1 (High) — unauthenticated advisor dispatch/control.** `/jobs` and `/control` had no auth; anyone reachable could spend the provider fleet's compute for free, forge `requesterDid`, and nudge/recover any provider's machines. **Revised from the plan:** these routes are called by the console/appview **server** (not end requesters — see `inference-dispatch.server.ts:856`, `dispatch.ts:697`, `machines.functions.ts`), so per the follow-up decision they're gated with the **shared internal bearer** (constant-time `authOk`, fail-closed when unset), matching the bridge/`/internal` pattern — not per-requester service-auth. All server callers attach the key (`internalAuthHeaders()` / env).
- **M7 / M1-infra — unbounded advisor state.** Global WS connection cap (`COCORE_ADVISOR_MAX_CONNECTIONS`, 2000) + `codeAttestCache` now prunes/evicts (10k cap) instead of growing forever.

## Deferred to its own PR
- **C2 register-frame signing** (Rust provider signs + advisor verifies + key→DID binding, grace-period). Split out per decision — it's a cross-language change that needs the provider `cargo` CI + cross-lang fixture. Note: the session-frame half of the advisor spoofing risk (**C3**) already shipped in #158.

## Deploy note
The advisor now needs `COCORE_INTERNAL_API_KEY` set (shared with console/appview). Unset ⇒ `/jobs` + `/control` fail closed (401) and dispatch stops.

## Verification
`oxlint` clean. `jobs.test.ts` exercises `jobsRoute` directly (auth is a mount-level wrapper), so unaffected. `tsc`/tests via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)