### PR TITLE
fix(installer): stop PlistBuddy error text leaking into LaunchAgent plist

### DIFF
--- a/scripts/install-from-tarball.sh
+++ b/scripts/install-from-tarball.sh
@@ -29,7 +29,21 @@ readonly LABEL="dev.cocore.provider"
 # pair + LaunchAgent on the SAME stack the app targets, instead of pairing a
 # PR/dev build against prod. An explicit COCORE_CONSOLE / COCORE_ADVISOR env
 # still wins.
-_baked() { /usr/libexec/PlistBuddy -c "Print :$1" "$STAGE/cocore.app/Contents/Info.plist" 2>/dev/null || true; }
+# CLI-only tarballs ship no cocore.app, and PlistBuddy reports a missing
+# *file* on stdout ("File Doesn't Exist, Will Create: …"), which a bare
+# capture would take as the baked value and sed into the LaunchAgent
+# plist (issue #157). Require the plist to exist and the value to look
+# like a URL before trusting it; otherwise emit nothing so the prod
+# defaults below win.
+_baked() {
+  local plist="$STAGE/cocore.app/Contents/Info.plist" v
+  [[ -f "$plist" ]] || return 0
+  v="$(/usr/libexec/PlistBuddy -c "Print :$1" "$plist" 2>/dev/null)" || return 0
+  case "$v" in
+    http://*|https://*|ws://*|wss://*) printf '%s\n' "$v" ;;
+  esac
+  return 0
+}
 COCORE_CONSOLE="${COCORE_CONSOLE:-$(_baked CocoreConsoleURL)}"
 COCORE_CONSOLE="${COCORE_CONSOLE:-https://console.cocore.dev}"
 COCORE_ADVISOR="${COCORE_ADVISOR:-$(_baked CocoreAdvisorURL)}"


### PR DESCRIPTION
Fixes #157

## Root cause

`install-from-tarball.sh` reads baked console/advisor URLs from the bundled menu-bar app's `Info.plist` via:

```sh
_baked() { /usr/libexec/PlistBuddy -c "Print :$1" "$STAGE/cocore.app/Contents/Info.plist" 2>/dev/null || true; }
```

CLI-only tarballs ship no `cocore.app`, and when the target file is missing PlistBuddy prints `File Doesn't Exist, Will Create: <path>` to **stdout**, not stderr. The `2>/dev/null || true` suppresses only stderr and the exit code, so the command substitution captured the error message as the "URL". Being non-empty, it shadowed the `${COCORE_ADVISOR:-wss://advisor.cocore.dev/v1/agent}` prod fallback and got sed'd into the LaunchAgent plist as `COCORE_ADVISOR` / `COCORE_CONSOLE` — producing the reported reconnect loop:

```
refusing to connect to advisor over insecure transport: "File Doesn't Exist, Will Create: …/cocore.app/Contents/Info.plist"
```

Other PlistBuddy call sites (`build-mac-app.sh`, `provider/src/models_cli.rs`) are unaffected — they discard stdout or check exit status.

## Fix

`_baked()` now:
1. returns empty when the app's `Info.plist` doesn't exist, and
2. only accepts values that look like a URL (`http(s)://` / `ws(s)://`), so any future PlistBuddy stdout noise also falls through to the prod defaults instead of poisoning the plist.

## Verification

Tested the function against four scenarios:
- no app bundle (the issue's case) → prod defaults
- app bundle with baked PR URLs → honored
- app bundle present, keys absent (plain release) → prod defaults
- non-URL garbage value in the plist → prod defaults

`bash -n` passes.

Machines already affected just need to re-run the installer — the bad values live only in `~/Library/LaunchAgents/dev.cocore.provider.plist`, which a reinstall rewrites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)