### PR TITLE
fix: patch the field failures surfaced by the 2026-07-03 bug-report triage

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,4 +1,4 @@
 {
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
-  "ignorePatterns": ["**/routeTree.gen.ts", "**/openapi.yaml"]
+  "ignorePatterns": ["**/*.gen.ts", "**/openapi.yaml"]
 }

--- a/packages/sdk/src/oauth-scope.ts
+++ b/packages/sdk/src/oauth-scope.ts
@@ -25,6 +25,12 @@
 // verify the caller's DID for:
 //   * dev.cocore.devicePair.confirm — approve a device-pairing
 //   * dev.cocore.inference.dispatch — forward an inference dispatch
+//   * dev.cocore.compute.register  — the agent's DID-bound advisor
+//     registration (the agent posts /api/pds/getServiceAuth with this lxm;
+//     without the grant every agent falls back to registering with the
+//     advisor unauthenticated — seen fleet-wide as `ScopeMissingError` in
+//     agent logs, e.g. ticket br_23e56917 — which blocks ever enforcing
+//     DID-auth at the advisor).
 // `aud: "*"` keeps the grant environment-agnostic (this static list can't
 // name a per-env AppView DID); the console only ever targets the AppView.
 //
@@ -57,7 +63,11 @@ export const oauthScopes = [
     action: ["create", "update", "delete"],
   }),
   atprotoScope.rpc({
-    lxm: ["dev.cocore.devicePair.confirm", "dev.cocore.inference.dispatch"],
+    lxm: [
+      "dev.cocore.devicePair.confirm",
+      "dev.cocore.inference.dispatch",
+      "dev.cocore.compute.register",
+    ],
     aud: "*",
   }),
 ];

--- a/packages/sdk/src/types.gen.ts
+++ b/packages/sdk/src/types.gen.ts
@@ -163,11 +163,9 @@ export interface JobRecord {
   expiresAt: string;
   createdAt: string;
   outputSchema?: { name?: string; strict?: boolean; schema?: Record<string, unknown> };
-  tools?: {
-    type: "function";
-    function: { name: string; description?: string; parameters?: Record<string, unknown> };
-  }[];
+  tools?: { type: "function"; function: { name: string; description?: string; parameters?: Record<string, unknown> } }[];
   toolChoice?: "auto" | "none" | "required";
+  toolChoiceFunction?: string;
 }
 
 export interface PaymentAuthorizationRecord {
@@ -208,6 +206,8 @@ export interface ProviderRecord {
   payoutsEnabled?: boolean;
   binaryVersion?: string;
   engineFault?: { code: string; message: string; models?: string[]; at: string };
+  attestationFault?: { code: string; message: string; at: string };
+  toolCalls?: boolean;
   shareLocation?: boolean;
   region?: string;
   regionSource?: string;

--- a/provider-shell/Sources/CoCoreShell/AgentSupervisor.swift
+++ b/provider-shell/Sources/CoCoreShell/AgentSupervisor.swift
@@ -151,7 +151,14 @@ final class AgentSupervisor {
         let p = Process()
         p.executableURL = bin
         p.arguments = ["agent", "diag"]
-        p.environment = ["HOME": NSHomeDirectory()]
+        // Inherit the full environment and only pin HOME. Replacing the env
+        // wholesale (the old `["HOME": ...]`) dropped PATH, so the diag's
+        // system-profile probes (`sysctl`, `ioreg` — both under /usr/sbin,
+        // which execvp's fallback path lacks) all failed and every uploaded
+        // bundle reported chip "unknown" / 0 GB RAM (ticket br_23e56917).
+        var env = ProcessInfo.processInfo.environment
+        env["HOME"] = NSHomeDirectory()
+        p.environment = env
         let pipe = Pipe()
         p.standardOutput = pipe
         p.standardError = FileHandle.nullDevice
@@ -179,8 +186,8 @@ final class AgentSupervisor {
     func sendBugReport(note: String? = nil) async -> String? {
         guard let bundle = Self.generateBugReportBundle() else { return nil }
         // Target session.apiBase — the service that paired us holds our bearer
-        // key. (Follow-up: the AppView should serve /api/agent/bug-report too,
-        // so device-pair'd agents can upload; today only the console does.)
+        // key (both the console and the AppView serve /api/agent/bug-report;
+        // each resolves the keys it minted).
         guard let session = SessionStore.load(),
               let apiKey = session.apiKey,
               let base = session.apiBase,

--- a/provider-shell/Sources/CoCoreShell/SecureModeWizard.swift
+++ b/provider-shell/Sources/CoCoreShell/SecureModeWizard.swift
@@ -119,13 +119,21 @@ enum EnrollmentProbe {
     static func isEnrolled() -> Bool {
         let (status, out) = run("/usr/bin/profiles", ["status", "-type", "enrollment"])
         guard status == 0 else { return false }
-        let lower = out.lowercased()
-        // "Enrolled via DEP: No" / "MDM enrollment: Yes (...)" — treat any
-        // affirmative MDM-enrollment line as enrolled.
-        if lower.contains("mdm enrollment: yes") { return true }
-        // TODO: confirm exact phrasing on the target macOS; fall back to a
-        // looser match so a wording change doesn't silently block the flow.
-        if lower.contains("enrolled") && !lower.contains("not enrolled") { return true }
+        // Parse the "MDM enrollment:" line specifically (case-insensitive).
+        // The previous looser fallback (`contains("enrolled") && !contains("not
+        // enrolled")`) matched the "Enrolled via DEP: No" line that `profiles
+        // status` prints on EVERY Mac — so this probe returned true even on
+        // never-enrolled machines, and the Secure Mode UI told those users
+        // "Re-attesting in the background…" instead of "Finish enrollment"
+        // (ticket br_23e56917). Must stay in agreement with the agent's check
+        // (provider/src/mda_loader.rs `mdm_enrolled`), which drives the actual
+        // attestation flow.
+        for line in out.lowercased().split(separator: "\n") {
+            let l = line.trimmingCharacters(in: .whitespaces)
+            if l.hasPrefix("mdm enrollment:") {
+                return l.contains("yes")
+            }
+        }
         return false
     }
 

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -205,6 +205,14 @@ async fn main() -> Result<()> {
     // field failure names itself instead of vanishing with the unified log.
     cocore_provider::diagnostics::install_panic_hook();
 
+    // Rust ignores SIGPIPE, so `println!` to a closed pipe (`cocore pause |
+    // head -1`) PANICS on EPIPE — a field bundle captured exactly that crash
+    // in `cmd_set_active` (ticket br_4bc92a25). Restore the Unix default so a
+    // closed pipe ends the CLI quietly, like every other command-line tool.
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    }
+
     let cli = Cli::parse();
     init_tracing(&cli.log);
 
@@ -2808,6 +2816,38 @@ fn build_engines(
             models: all_unserved,
             at: chrono::Utc::now(),
         }
+    } else if !failed.is_empty() && is_python_env_broken(last_err.as_deref()) {
+        // The venv exists but its packages don't import — the subprocess dies
+        // at import time, before touching the model. The generic "not in MLX
+        // format" message below would be actively wrong (the model was never
+        // even looked at) and sends the operator down a model-picking rabbit
+        // hole when the fix is to re-provision the Python environment. The
+        // installer's bootstrap re-runs idempotently and now pins known-good
+        // dependency versions, so re-running it repairs this in place.
+        tracing::warn!(
+            models = ?failed,
+            last_error = %last_err.as_deref().unwrap_or("(none captured)"),
+            "python environment is broken (engine dies at import); serving stub only"
+        );
+        EngineFault {
+            code: "python-env-broken".to_string(),
+            message: format!(
+                "The Python inference environment at {} is broken: the engine \
+                 process crashes while importing its libraries, before your \
+                 model(s) [{}] are even read — the models themselves are fine. \
+                 This usually means a dependency version mismatch inside the \
+                 environment. The machine is online but only serving the no-op \
+                 `stub` engine, so it won't be matched to real inference jobs. \
+                 Fix: re-run the installer to repair the environment in place — \
+                 `curl -fsSL https://cocore.dev/agent | sh` — then start serving \
+                 again. If it keeps failing, DM @cocore.dev on Bluesky with your \
+                 machine label and we'll help.",
+                venv_python.display(),
+                failed.join(", "),
+            ),
+            models: all_unserved,
+            at: chrono::Utc::now(),
+        }
     } else if !failed.is_empty() && is_socket_path_too_long(last_err.as_deref()) {
         // The engine couldn't open its local Unix-domain socket because the
         // assembled path overflowed the OS `sun_path` limit (a long $HOME +
@@ -2999,6 +3039,26 @@ const ENGINE_START_MAX_ATTEMPTS: u32 = 3;
 /// download to make progress.
 const ENGINE_START_BACKOFF: std::time::Duration = std::time::Duration::from_secs(8);
 
+/// Whether an engine-start error is the "the Python environment itself is
+/// broken" failure — the wrapper (`cocore_inference_server.py`) dying at
+/// IMPORT time, before any model or socket work. This is deterministic: no
+/// amount of retrying or model-picking helps, only re-provisioning the venv.
+/// Seen in the field when an unconstrained dependency resolve pulled
+/// transformers 5.13.0, whose stricter `AutoTokenizer.register` broke
+/// mlx-lm's import (`AttributeError: 'str' object has no attribute
+/// '__module__'`). Detected from the captured startup stderr, which is
+/// content-safe (library tracebacks only — no request has been served yet).
+fn is_python_env_broken(last_err: Option<&str>) -> bool {
+    let Some(e) = last_err else { return false };
+    let import_traceback = e.contains("Traceback")
+        && (e.contains("import vllm_mlx") || e.contains("ModuleNotFoundError"));
+    // The specific transformers-5.13 / mlx-lm incompatibility, matched
+    // exactly so it classifies even if a future wrapper reorders imports.
+    let transformers_register_break =
+        e.contains("'str' object has no attribute '__module__'");
+    import_traceback || transformers_register_break
+}
+
 /// Whether an engine-start error is the "this VLM's image config is broken"
 /// failure — the multimodal loader (mlx_vlm) choking on an incomplete
 /// `vision_config`. Detected from the captured subprocess stderr, which the
@@ -3082,6 +3142,16 @@ fn start_engine_with_recovery(
                     Ok(()) => return Ok(engine),
                     Err(e) => {
                         let err = format!("{e:#}");
+                        // An import-time crash of the wrapper is deterministic —
+                        // the venv's packages are broken, and the same spawn will
+                        // fail identically every time. Retrying (and then
+                        // retrying the NEXT model) just burns minutes before the
+                        // operator sees the fault; bail to classification now.
+                        if is_python_env_broken(Some(&err)) {
+                            tracing::warn!(model = %model, attempt, error = %err,
+                                "inference subprocess died at import (broken python env); not retrying");
+                            return Err(EngineStartFailure::Failed(err));
+                        }
                         tracing::warn!(model = %model, attempt, error = %err, "inference subprocess failed to start; will retry");
                         last_err = Some(err);
                     }
@@ -3284,6 +3354,39 @@ mod vision_fault_tests {
             "ModuleNotFoundError: vllm_mlx"
         )));
         assert!(!is_vision_config_failure(None));
+    }
+
+    use super::is_python_env_broken;
+
+    #[test]
+    fn detects_transformers_513_import_break() {
+        // The exact field signature from ticket br_23e56917 (transformers
+        // 5.13.0 vs mlx-lm's string-key AutoTokenizer.register).
+        let err = "inference subprocess for mlx-community/Qwen3.5-122B-A10B-4bit exited during startup with exit status: 1\n\
+                   [stderr] Traceback (most recent call last):\n\
+                   [stderr]   File \"/Users/u/.cocore/cocore_inference_server.py\", line 97, in <module>\n\
+                   [stderr]     import vllm_mlx.server as srv  # noqa: E402\n\
+                   [stderr] AttributeError: 'str' object has no attribute '__module__'. Did you mean: '__mod__'?";
+        assert!(is_python_env_broken(Some(err)));
+    }
+
+    #[test]
+    fn detects_missing_module_at_import() {
+        let err = "exited during startup with exit status: 1\n\
+                   [stderr] Traceback (most recent call last):\n\
+                   [stderr] ModuleNotFoundError: No module named 'vllm_mlx'";
+        assert!(is_python_env_broken(Some(err)));
+    }
+
+    #[test]
+    fn env_broken_ignores_model_load_failures_and_none() {
+        // A traceback from MODEL loading (post-import) must not classify as a
+        // broken env — the imports succeeded, so the env is fine.
+        assert!(!is_python_env_broken(Some(
+            "Traceback (most recent call last):\n  File \"utils.py\" ...\nOSError: out of memory loading weights"
+        )));
+        assert!(!is_python_env_broken(Some("never became ready")));
+        assert!(!is_python_env_broken(None));
     }
 
     use super::{is_multimodal_weight_map_failure, is_socket_path_too_long};

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -3054,8 +3054,7 @@ fn is_python_env_broken(last_err: Option<&str>) -> bool {
         && (e.contains("import vllm_mlx") || e.contains("ModuleNotFoundError"));
     // The specific transformers-5.13 / mlx-lm incompatibility, matched
     // exactly so it classifies even if a future wrapper reorders imports.
-    let transformers_register_break =
-        e.contains("'str' object has no attribute '__module__'");
+    let transformers_register_break = e.contains("'str' object has no attribute '__module__'");
     import_traceback || transformers_register_break
 }
 
@@ -3520,7 +3519,6 @@ mod active_gate_tests {
 
 #[cfg(test)]
 mod offline_marker_tests {
-    use super::*;
     use cocore_provider::pds::{ProviderRecord, TrustLevel};
 
     /// A provider record as the AGENT builds it in-memory: the

--- a/provider/src/mda_loader.rs
+++ b/provider/src/mda_loader.rs
@@ -418,6 +418,13 @@ pub fn any_explicit_mda_env() -> bool {
 /// attestation refresh). Always fail-soft.
 pub fn acquire_auto(console_base: &str, api_key: &str, public_key_b64: &str) -> Vec<Vec<u8>> {
     if !mdm_enrolled() {
+        // Log the skip: this is the ONLY signal in a diagnostic bundle that
+        // explains a machine stuck self-attested while its owner believes
+        // Secure Mode is applying. A silent return here cost a full triage
+        // round-trip on ticket br_23e56917.
+        tracing::info!(
+            "MDA auto: this Mac is not MDM-enrolled (per `profiles status`); staying self-attested"
+        );
         return Vec::new();
     }
     let Some(serial) = device_serial() else {
@@ -491,11 +498,16 @@ fn chain_binds_key(chain: &[Vec<u8>], public_key_b64: &str) -> bool {
 /// Is this Mac currently MDM-enrolled? Reads `profiles status -type enrollment`
 /// ("MDM enrollment: Yes"). Any failure / non-macOS → false (skip option-B).
 pub fn mdm_enrolled() -> bool {
-    run_capture("profiles", &["status", "-type", "enrollment"])
+    // Case-insensitive on purpose: `profiles status` phrasing has shifted
+    // capitalization across macOS releases, and a silent parse miss here reads
+    // as "not enrolled" and quietly disables the whole MDA flow. Must stay in
+    // agreement with the tray's probe (SecureModeWizard.swift
+    // `EnrollmentProbe.isEnrolled`), which drives the Secure Mode UI copy.
+    run_capture("/usr/bin/profiles", &["status", "-type", "enrollment"])
         .map(|out| {
             out.lines().any(|l| {
-                let l = l.trim();
-                l.starts_with("MDM enrollment:") && l.contains("Yes")
+                let l = l.trim().to_lowercase();
+                l.starts_with("mdm enrollment:") && l.contains("yes")
             })
         })
         .unwrap_or(false)
@@ -524,7 +536,9 @@ pub fn device_hardware_uuid() -> Option<String> {
 
 /// Pull a string property off the IOPlatformExpertDevice node via `ioreg`.
 fn ioreg_value(key: &str) -> Option<String> {
-    let out = run_capture("ioreg", &["-rd1", "-c", "IOPlatformExpertDevice"])?;
+    // /usr/sbin isn't on execvp's fallback path — absolute path so this probe
+    // works however the agent was spawned (see system_profile.rs).
+    let out = run_capture("/usr/sbin/ioreg", &["-rd1", "-c", "IOPlatformExpertDevice"])?;
     for line in out.lines() {
         if line.contains(&format!("\"{key}\"")) {
             // line looks like:  "IOPlatformUUID" = "376AF848-..."

--- a/provider/src/system_profile.rs
+++ b/provider/src/system_profile.rs
@@ -79,8 +79,18 @@ pub fn collect() -> SystemProfile {
     }
 }
 
+// Absolute paths for the probe binaries: `sysctl`, `system_profiler`, and
+// `ioreg` live under /usr/sbin, which execvp's FALLBACK path (used when a
+// parent spawns us with no PATH at all) does not include. The tray shelled
+// `cocore agent diag` with a stripped env for a while, and every probe here
+// silently returned None — bundles reported chip "unknown" / 0 GB RAM
+// (ticket br_23e56917). These paths are stable on every macOS.
 fn sysctl(key: &str) -> Option<String> {
-    let out = Command::new("sysctl").arg("-n").arg(key).output().ok()?;
+    let out = Command::new("/usr/sbin/sysctl")
+        .arg("-n")
+        .arg(key)
+        .output()
+        .ok()?;
     if !out.status.success() {
         return None;
     }
@@ -100,7 +110,7 @@ fn parse_gpu_cores() -> Option<u32> {
     // `system_profiler -json SPDisplaysDataType` returns an array of
     // GPU entries. Apple Silicon integrated GPUs carry an
     // `sppci_cores` field; we take the first one we find.
-    let out = Command::new("system_profiler")
+    let out = Command::new("/usr/sbin/system_profiler")
         .arg("-json")
         .arg("SPDisplaysDataType")
         .output()
@@ -121,7 +131,7 @@ fn parse_gpu_cores() -> Option<u32> {
 }
 
 fn sw_vers_product_version() -> Option<String> {
-    let out = Command::new("sw_vers")
+    let out = Command::new("/usr/bin/sw_vers")
         .arg("-productVersion")
         .output()
         .ok()?;

--- a/scripts/bootstrap-python-venv.sh
+++ b/scripts/bootstrap-python-venv.sh
@@ -35,6 +35,7 @@
 #   0  success
 #   2  uv install failed
 #   3  pip install vllm-mlx failed
+#   4  venv verification failed (packages installed but don't import)
 
 set -euo pipefail
 
@@ -118,8 +119,16 @@ install_packages() {
   # HF_HUB_ENABLE_HF_TRANSFER when the package is importable.
   # uv pip install needs the venv activated; we pass --python pointing
   # at the venv's interpreter to make it scope to that venv.
+  #
+  # transformers is CONSTRAINED, not floated: transformers 5.13.0 broke
+  # mlx-lm's tokenizer registration (`AutoTokenizer.register("NewlineTokenizer",
+  # ...)` with a string key → `AttributeError: 'str' object has no attribute
+  # '__module__'` at import), which kills every engine spawn on a fresh
+  # install. Because this script re-runs idempotently, the constraint also
+  # REPAIRS an already-broken venv by downgrading it. Lift the ceiling once
+  # mlx-lm registers its tokenizer with a real config class upstream.
   if ! "$COCORE_UV" pip install --python "$COCORE_PYTHON_VENV/bin/python" \
-        "$pkg" mlx-lm uvicorn hf_transfer >&2; then
+        "$pkg" mlx-lm uvicorn hf_transfer "transformers<5.13" >&2; then
     err "uv pip install $pkg failed"
     exit 3
   fi
@@ -136,8 +145,17 @@ verify() {
   if "$py" -c 'import vllm_mlx.server, uvicorn' 2>/dev/null; then
     note "import vllm_mlx.server, uvicorn: ok"
   else
-    warn "import failed — agent will fall back to StubEngine on next serve"
+    # Hard failure, not a warning: a venv that installed but doesn't import
+    # means EVERY engine spawn will crash at startup and the machine will
+    # silently serve stub-only. Failing here surfaces the problem at install
+    # time, where the user is watching, instead of at serve time, where they
+    # aren't. (Exactly this bit a fresh install when transformers 5.13.0
+    # broke mlx-lm's import — the old warn-and-continue let the install
+    # "succeed" and the engine crash-loop.)
+    err "venv verification failed — the installed packages don't import:"
     "$py" -c 'import vllm_mlx.server, uvicorn' 2>&1 | sed 's/^/    /' >&2 || true
+    err "re-run this installer to retry; if it persists, DM @cocore.dev on Bluesky"
+    exit 4
   fi
 }
 


### PR DESCRIPTION
Deep triage of all 12 uploaded tray bug-report bundles — with a focus on br_23e56917 (the "inference engine failed to come online after 3 attempts" Mac Studio report, whose owner also saw Secure Mode stuck on "Securing… / Re-attesting this Mac in the background" for 30+ minutes). Five distinct unaddressed defects fell out; this PR fixes all of them plus one panic captured in br_4bc92a25.

## 1. Fresh installs are currently broken: unpinned transformers (primary cause of br_23e56917)

Every engine spawn on that machine died at **import time**:

```
File ".../mlx_lm/tokenizer_utils.py", line 505, in <module>
  AutoTokenizer.register("NewlineTokenizer", fast_tokenizer_class=NewlineTokenizer)
...
AttributeError: 'str' object has no attribute '__module__'. Did you mean: '__mod__'?
```

transformers **5.13.0** (current latest on PyPI) added a `key.__module__` check in `register()` that breaks mlx-lm's string-key tokenizer registration. `bootstrap-python-venv.sh` installs `vllm-mlx mlx-lm uvicorn hf_transfer` **unpinned**, so every install since 5.13.0's release resolves a broken venv. (Older machines work only because their venvs hold 5.12.1.)

- Pin `transformers<5.13`. The bootstrap re-runs idempotently, so **re-running the installer now repairs a broken venv in place** by downgrading. Lift the ceiling once mlx-lm registers its tokenizer with a real config class upstream.
- The bootstrap's `verify()` step previously **warned** on import failure and let the install "succeed" — it now hard-fails (exit 4) so this class of breakage surfaces at install time, where the user is watching.

## 2. The agent misdiagnosed that crash and retried it pointlessly

The import crash was funneled into the generic `model-load-failed` fault ("the model isn't in MLX format… DM @cocore.dev"), sending the operator down a model-picking rabbit hole for an environment problem, after burning 3 attempts × backoff **per model** on a deterministic failure.

- New `is_python_env_broken` classifier (tested against the verbatim br_23e56917 traceback) → new `python-env-broken` fault with an actionable "re-run the installer; your models are fine" message.
- `start_engine_with_recovery` bails immediately on import-time deaths instead of retrying.

## 3. Secure Mode told a never-enrolled Mac it was "Re-attesting in the background…"

The tray's `EnrollmentProbe.isEnrolled()` had a loose fallback — `contains("enrolled") && !contains("not enrolled")` — that matches the `Enrolled via DEP: No` line `profiles status -type enrollment` prints on **every** Mac. So the probe returned true unconditionally, and a not-actually-enrolled machine (like br_23e56917's) showed the calm "Re-attesting this Mac in the background…" instead of the actionable "Finish enrollment in System Settings ▸ Device Management."

- Parse the `MDM enrollment:` line specifically (case-insensitive), agreeing with the agent's check.
- The agent's twin `mdm_enrolled()` is now case-insensitive too, and its previously **silent** not-enrolled skip in `acquire_auto` now logs — that silence cost a full triage round-trip, since nothing in the bundle explained why no MDA activity ever appeared.

## 4. Advisor service-auth minting 403s fleet-wide

Every bundle on a recent build shows:

```
could not mint service-auth JWT for advisor registration; registering without it
error=... ScopeMissingError: Missing required scope "rpc:dev.cocore.compute.register?aud=did:web:advisor.cocore.dev"
```

The shared OAuth scope list's `rpc` grant covers `devicePair.confirm` and `inference.dispatch` but never included `dev.cocore.compute.register`, so every agent falls back to **unauthenticated** advisor registration — which also blocks ever enforcing the C1 advisor DID-auth flags. Added the lxm.

⚠️ **Rollout note:** tokens issued before this change don't retroactively gain the grant — users must re-authorize before DID-auth can be enforced at the advisor.

## 5. Diag bundles reported chip "unknown" / 0 GB RAM

The tray spawns `cocore agent diag` with `environment = ["HOME": ...]`, which drops PATH; `sysctl`/`ioreg`/`system_profiler` live in `/usr/sbin`, which execvp's fallback path lacks, so every probe silently returned nothing and uploaded bundles carried a useless system profile (br_23e56917 said "unknown chip, 0 GB" for an M3 Ultra / 256 GB). Inherit the environment (still pinning HOME) and use absolute probe paths in the agent as belt-and-braces.

## 6. CLI panics on a closed pipe

br_4bc92a25's `last-panic.txt` captured `println!` panicking on EPIPE inside `cmd_set_active` (e.g. `cocore pause | head -1`). Rust ignores SIGPIPE by default; restore `SIG_DFL` at startup so piped CLI output ends quietly like every other Unix tool.

## Bundles reviewed, for the record

br_23e56917 (this PR's centerpiece), br_4bc92a25 (EPIPE panic; its AEAD churn is the already-fixed #90), br_9a60d54e (401 storm — fixed in 0.9.36), br_c68bdebd + br_d9c74cc0 (healthy; the reconnect cadence is the deliberate 14-min advisor recycle from #239), br_dcfcdbac + br_ca2ec947 (local DNS flapping, handled by backoff), br_7f4d469a / br_984b62f7 / br_0e7e271a / br_38177186 / br_13b65980 (transient provisioning races / clean).

## Testing

- `cargo test` (provider): 224 tests pass, including 3 new classifier tests (one uses the field traceback verbatim).
- `swift build` (provider-shell): clean.
- `tsc --noEmit` (packages/sdk): clean.
- `bash -n` on the bootstrap script.

## Deploy order

The console deploy is what fixes **new installs** (it serves the install script), so ship it first; broken machines are then repaired by re-running the installer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)