### PR TITLE
feat(console): explore + filter network machines by agent version

### DIFF
--- a/packages/console/src/components/AppviewExplorer.tsx
+++ b/packages/console/src/components/AppviewExplorer.tsx
@@ -322,6 +322,7 @@ export function AppviewExplorer() {
   const [providerF, setProviderF] = useState("");
   const [requesterF, setRequesterF] = useState("");
   const [jobF, setJobF] = useState("");
+  const [versionF, setVersionF] = useState("");
 
   const receiptFilters = useMemo(
     () => ({
@@ -334,6 +335,21 @@ export function AppviewExplorer() {
 
   const providersQuery = useQuery(listProvidersAppviewQueryOptions);
   const receiptsQuery = useQuery(getReceiptsAppviewQueryOptions(receiptFilters));
+
+  // Client-side agent-version filter over the (≤100-row) providers table.
+  // Prefix match so "0.9" catches a whole minor series; the literal
+  // "none" surfaces records that predate the binaryVersion field.
+  const filteredProviders = useMemo(() => {
+    const rows = providersQuery.data?.providers ?? [];
+    const wanted = versionF.trim().toLowerCase();
+    if (!wanted) return rows;
+    return rows.filter((r) => {
+      const o = asRecord(r.body);
+      const v = o ? jsonString(o.binaryVersion) : null;
+      if (wanted === "none") return v == null;
+      return (v ?? "").toLowerCase().startsWith(wanted.replace(/^v/, ""));
+    });
+  }, [providersQuery.data, versionF]);
 
   const [settlementReceiptF, setSettlementReceiptF] = useState("");
   const [settlementRequesterF, setSettlementRequesterF] = useState("");
@@ -371,11 +387,23 @@ export function AppviewExplorer() {
           <div {...stylex.props(styles.sectionDescription)}>Loading providers…</div>
         ) : null}
         {providersQuery.data ? (
-          <IndexedTable
-            variant="provider"
-            rows={providersQuery.data.providers}
-            empty="No providers indexed yet."
-          />
+          <>
+            <Flex direction="row" style={styles.filters}>
+              <TextField
+                label="Agent version"
+                value={versionF}
+                onChange={setVersionF}
+                placeholder='0.9.40, 0.9, or "none"'
+              />
+            </Flex>
+            <IndexedTable
+              variant="provider"
+              rows={filteredProviders}
+              empty={
+                versionF.trim() ? "No providers match that version." : "No providers indexed yet."
+              }
+            />
+          </>
         ) : null}
       </AppviewSection>
 
@@ -608,6 +636,7 @@ function IndexedTable({
             <tr>
               <th {...stylex.props(styles.th)}>provider</th>
               <th {...stylex.props(styles.th)}>hardware</th>
+              <th {...stylex.props(styles.th)}>version</th>
               <th {...stylex.props(styles.th)}>status</th>
               <th {...stylex.props(styles.th)}>trust</th>
               <th {...stylex.props(styles.th)}>models</th>
@@ -799,6 +828,7 @@ function ProviderTableRow({ row }: { row: AppviewIndexedRecordEnriched }) {
   const ramGB = o ? jsonNumber(o.ramGB) : null;
   const models = o ? jsonStringArray(o.supportedModels) : [];
   const trustLevel = o ? jsonString(o.trustLevel) : null;
+  const binaryVersion = o ? jsonString(o.binaryVersion) : null;
 
   const hardwareParts: string[] = [];
   if (chip) hardwareParts.push(chip);
@@ -812,6 +842,7 @@ function ProviderTableRow({ row }: { row: AppviewIndexedRecordEnriched }) {
       <td {...stylex.props(styles.td, styles.bodyMeta)}>
         {hardwareParts.length > 0 ? hardwareParts.join(" · ") : "—"}
       </td>
+      <td {...stylex.props(styles.td, styles.mono)}>{binaryVersion ? `v${binaryVersion}` : "—"}</td>
       <td {...stylex.props(styles.td)}>
         <ProviderStatusBadges body={row.body} />
       </td>

--- a/packages/console/src/components/explorer/ExplorerPage.tsx
+++ b/packages/console/src/components/explorer/ExplorerPage.tsx
@@ -19,6 +19,7 @@ import { Flex } from "@/design-system/flex";
 import { Page } from "@/design-system/page";
 import { SearchField } from "@/design-system/search-field";
 import { SegmentedControl, SegmentedControlItem } from "@/design-system/segmented-control";
+import { Select, SelectItem } from "@/design-system/select";
 import { uiColor } from "@/design-system/theme/color.stylex";
 import { radius } from "@/design-system/theme/radius.stylex";
 import { gap, verticalSpace } from "@/design-system/theme/semantic-spacing.stylex";
@@ -287,6 +288,19 @@ function NodeDetail({ node }: { node: ExplorerNode }) {
         </div>
       ) : null}
 
+      {node.versions.length > 0 ? (
+        <div>
+          <div {...stylex.props(styles.specLabel)}>agent version</div>
+          <div {...stylex.props(styles.chips)}>
+            {node.versions.map((v) => (
+              <span key={v} {...stylex.props(styles.chip)}>
+                v{v}
+              </span>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
       <Link
         to="/u/$identifier"
         params={{ identifier: node.handle ?? node.did }}
@@ -299,11 +313,33 @@ function NodeDetail({ node }: { node: ExplorerNode }) {
   );
 }
 
+/** Newest-first ordering for agent version strings — numeric dot-part
+ *  compare with lexicographic fallback (mirrors the server's ordering
+ *  inside a node's own `versions`, which we can't import client-side). */
+function compareVersionsDesc(a: string, b: string): number {
+  const pa = a.split(".").map((p) => Number.parseInt(p, 10));
+  const pb = b.split(".").map((p) => Number.parseInt(p, 10));
+  if (pa.every(Number.isFinite) && pb.every(Number.isFinite)) {
+    for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+      const d = (pb[i] ?? 0) - (pa[i] ?? 0);
+      if (d !== 0) return d;
+    }
+    return 0;
+  }
+  return b.localeCompare(a);
+}
+
+/** Sentinel ids for the version filter's non-version choices. Real agent
+ *  versions are dotted numerics, so these can't collide. */
+const VERSION_ANY = "any";
+const VERSION_NONE = "unversioned";
+
 export function ExplorerPage() {
   const graphQuery = useQuery(explorerGraphQueryOptions);
   const [selectedDid, setSelectedDid] = useState<string | null>(null);
   const [query, setQuery] = useState("");
   const [filter, setFilter] = useState<"all" | "providers">("all");
+  const [versionFilter, setVersionFilter] = useState<string>(VERSION_ANY);
 
   const graph = graphQuery.data;
   const nodesByDid = useMemo(() => {
@@ -312,6 +348,40 @@ export function ExplorerPage() {
     return m;
   }, [graph]);
   const selected = selectedDid ? (nodesByDid.get(selectedDid) ?? null) : null;
+
+  // Distinct agent versions on the network, newest first, with provider
+  // counts for the dropdown labels. "unversioned" appears only when some
+  // provider's records predate the binaryVersion field.
+  const versionOptions = useMemo(() => {
+    const counts = new Map<string, number>();
+    let unversioned = 0;
+    for (const n of graph?.nodes ?? []) {
+      if (!n.isProvider) continue;
+      if (n.versions.length === 0) unversioned += 1;
+      for (const v of n.versions) counts.set(v, (counts.get(v) ?? 0) + 1);
+    }
+    const versions = [...counts.keys()].sort(compareVersionsDesc);
+    return { versions, counts, unversioned };
+  }, [graph]);
+
+  // The DID set the graph should keep for the active version filter; null
+  // when the filter is off. Keeping the sentinel logic here means the
+  // graph component only ever sees a plain allow-set.
+  const versionDids = useMemo(() => {
+    if (versionFilter === VERSION_ANY) return null;
+    const keep = new Set<string>();
+    for (const n of graph?.nodes ?? []) {
+      if (!n.isProvider) continue;
+      if (
+        versionFilter === VERSION_NONE
+          ? n.versions.length === 0
+          : n.versions.includes(versionFilter)
+      ) {
+        keep.add(n.did);
+      }
+    }
+    return keep;
+  }, [graph, versionFilter]);
 
   return (
     <Page.Root variant="large" style={styles.root}>
@@ -367,6 +437,29 @@ export function ExplorerPage() {
                 <SegmentedControlItem id="all">everyone</SegmentedControlItem>
                 <SegmentedControlItem id="providers">providers</SegmentedControlItem>
               </SegmentedControl>
+              <Select
+                aria-label="filter by agent version"
+                label="version"
+                labelVariant="horizontal"
+                selectedKey={versionFilter}
+                onSelectionChange={(key) => {
+                  if (key != null) setVersionFilter(String(key));
+                }}
+              >
+                <SelectItem id={VERSION_ANY} textValue="any">
+                  any
+                </SelectItem>
+                {versionOptions.versions.map((v) => (
+                  <SelectItem key={v} id={v} textValue={`v${v}`}>
+                    v{v} · {versionOptions.counts.get(v)}
+                  </SelectItem>
+                ))}
+                {versionOptions.unversioned > 0 ? (
+                  <SelectItem id={VERSION_NONE} textValue="unversioned">
+                    unversioned · {versionOptions.unversioned}
+                  </SelectItem>
+                ) : null}
+              </Select>
               <div {...stylex.props(styles.legend)}>
                 <span {...stylex.props(styles.legendItem)}>
                   <span {...stylex.props(styles.dot, styles.dotProvider)} />
@@ -388,6 +481,7 @@ export function ExplorerPage() {
               onSelect={setSelectedDid}
               query={query}
               providersOnly={filter === "providers"}
+              versionDids={versionDids}
             />
             <Card size="md" style={styles.detailCard}>
               <CardHeader hasBorder style={styles.detailCardHeader}>

--- a/packages/console/src/components/explorer/NetworkGraph.tsx
+++ b/packages/console/src/components/explorer/NetworkGraph.tsx
@@ -32,6 +32,10 @@ export interface NetworkGraphProps {
   query: string;
   /** Show only providers (and edges between them). */
   providersOnly: boolean;
+  /** When set, show only these DIDs (and edges between them) — the page
+   *  computes the set from its version filter so the sentinel semantics
+   *  ("unversioned") stay out of the graph. Null = no version filter. */
+  versionDids: ReadonlySet<string> | null;
 }
 
 function nodeRadius(n: ExplorerNode): number {
@@ -110,6 +114,7 @@ export function NetworkGraph({
   onSelect,
   query,
   providersOnly,
+  versionDids,
 }: NetworkGraphProps) {
   const svgRef = useRef<SVGSVGElement | null>(null);
   const wrapRef = useRef<HTMLDivElement | null>(null);
@@ -129,13 +134,18 @@ export function NetworkGraph({
 
   // Filtered view of the graph.
   const { vizNodes, vizEdges } = useMemo(() => {
-    if (!providersOnly) return { vizNodes: nodes, vizEdges: edges };
-    const keep = new Set(nodes.filter((n) => n.isProvider).map((n) => n.did));
+    if (!providersOnly && !versionDids) return { vizNodes: nodes, vizEdges: edges };
+    const keep = new Set(
+      nodes
+        .filter((n) => !providersOnly || n.isProvider)
+        .filter((n) => !versionDids || versionDids.has(n.did))
+        .map((n) => n.did),
+    );
     return {
       vizNodes: nodes.filter((n) => keep.has(n.did)),
       vizEdges: edges.filter((e) => keep.has(e.source) && keep.has(e.target)),
     };
-  }, [nodes, edges, providersOnly]);
+  }, [nodes, edges, providersOnly, versionDids]);
 
   const degree = useMemo(() => {
     const d = new Map<string, number>();

--- a/packages/console/src/lib/explorer-graph.server.ts
+++ b/packages/console/src/lib/explorer-graph.server.ts
@@ -129,7 +129,7 @@ interface ProviderAgg {
  *  well-formed versions ("0.9.40" > "0.9.9"), lexicographic fallback for
  *  anything else. Good enough for display + filter ordering; no semver
  *  pre-release semantics needed for agent versions. */
-export function sortVersionsDesc(versions: string[]): string[] {
+function sortVersionsDesc(versions: string[]): string[] {
   const parts = (v: string) => v.split(".").map((p) => Number.parseInt(p, 10));
   return [...versions].sort((a, b) => {
     const pa = parts(a);

--- a/packages/console/src/lib/explorer-graph.server.ts
+++ b/packages/console/src/lib/explorer-graph.server.ts
@@ -42,6 +42,10 @@ export interface ExplorerNode {
   chips: string[];
   /** Distinct supported models across machines. */
   models: string[];
+  /** Distinct agent versions across machines (provider record
+   *  `binaryVersion`, stamped on every serve), newest first. Empty for
+   *  members and for providers whose records predate the field. */
+  versions: string[];
   /** Outgoing trust: machines this DID is willing to route jobs to. */
   trustsOut: number;
   /** Incoming trust: how many DIDs route their jobs to this DID. */
@@ -118,6 +122,27 @@ interface ProviderAgg {
   cpuCores: number;
   chips: Set<string>;
   models: Set<string>;
+  versions: Set<string>;
+}
+
+/** Sort version strings newest-first: numeric dot-part comparison for
+ *  well-formed versions ("0.9.40" > "0.9.9"), lexicographic fallback for
+ *  anything else. Good enough for display + filter ordering; no semver
+ *  pre-release semantics needed for agent versions. */
+export function sortVersionsDesc(versions: string[]): string[] {
+  const parts = (v: string) => v.split(".").map((p) => Number.parseInt(p, 10));
+  return [...versions].sort((a, b) => {
+    const pa = parts(a);
+    const pb = parts(b);
+    if (pa.every(Number.isFinite) && pb.every(Number.isFinite)) {
+      for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+        const d = (pb[i] ?? 0) - (pa[i] ?? 0);
+        if (d !== 0) return d;
+      }
+      return 0;
+    }
+    return b.localeCompare(a);
+  });
 }
 
 /** Group raw provider records by owning DID, summing hardware. */
@@ -128,7 +153,14 @@ function aggregateProviders(rows: AppviewIndexedRecord[]): Map<string, ProviderA
     if (!o) continue;
     let agg = byDid.get(row.repo);
     if (!agg) {
-      agg = { machines: 0, ramGB: 0, cpuCores: 0, chips: new Set(), models: new Set() };
+      agg = {
+        machines: 0,
+        ramGB: 0,
+        cpuCores: 0,
+        chips: new Set(),
+        models: new Set(),
+        versions: new Set(),
+      };
       byDid.set(row.repo, agg);
     }
     agg.machines += 1;
@@ -139,6 +171,9 @@ function aggregateProviders(rows: AppviewIndexedRecord[]): Map<string, ProviderA
       agg.cpuCores += o["cpuCores"];
     }
     if (typeof o["chip"] === "string" && o["chip"].length > 0) agg.chips.add(o["chip"]);
+    if (typeof o["binaryVersion"] === "string" && o["binaryVersion"].length > 0) {
+      agg.versions.add(o["binaryVersion"]);
+    }
     const sm = o["supportedModels"];
     if (Array.isArray(sm)) {
       for (const m of sm) if (typeof m === "string" && m.length > 0) agg.models.add(m);
@@ -159,6 +194,7 @@ function blankNode(did: string): ExplorerNode {
     cpuCores: 0,
     chips: [],
     models: [],
+    versions: [],
     trustsOut: 0,
     trustedByIn: 0,
     lastActivityAt: null,
@@ -231,6 +267,7 @@ async function buildExplorerGraph(): Promise<ExplorerGraph> {
     n.cpuCores = agg.cpuCores;
     n.chips = [...agg.chips];
     n.models = [...agg.models];
+    n.versions = sortVersionsDesc([...agg.versions]);
     if (agg.machines > 0) n.isProvider = true;
   }
 


### PR DESCRIPTION
The provider record has carried `binaryVersion` since PR #120 (stamped by the agent on every `serve`), but no read surface showed it — during the 2026-07-03 bug-report triage the only way to see which machines were on a fixed build was pulling raw records. This lifts it into both machine-browsing surfaces. **No lexicon, indexer, or API changes** — the field was already in the indexed record bodies.

## Explore page (`/explore`)

- `ExplorerNode` gains `versions`: distinct `binaryVersion` strings across a DID's machines, newest first (numeric dot-part sort, lexicographic fallback).
- New **version** dropdown in the controls row (next to everyone/providers): lists every agent version currently on the network with provider counts — e.g. `v0.9.40 · 12` — plus an `unversioned` entry when some provider's records predate the field. Selecting one filters the graph to providers running that version (edges between kept nodes only).
- The node detail panel now shows an **agent version** chip row, so clicking any provider answers "what are they running" at a glance.
- Sentinel semantics (`any` / `unversioned`) live in the page; `NetworkGraph` only receives a plain allow-set of DIDs (`versionDids`), composing cleanly with the existing `providersOnly` filter.

## Raw appview index (providers table)

- New **version** column (`v0.9.40` / `—`).
- New **Agent version** filter above the table: client-side prefix match over the ≤100-row window, so `0.9` catches a whole minor series; the literal `none` surfaces pre-field records.

## Why this matters operationally

Together with the `/explore` graph this answers, in one click, the questions that kept coming up this week: *who is still on a build without the venv fix*, *has the fleet converged on 0.9.40 far enough to flip `COCORE_ADVISOR_REQUIRE_AUTH`*, and *which machines predate version stamping entirely*.

## Testing

- `tsc --noEmit` clean, `oxlint` clean, `oxfmt --check` clean on all touched files.
- Smoke-tested in the dev server: page renders, dropdown mounts and defaults to `any`, no new console errors (the graph shows the empty state locally since there's no local AppView data — option lists populate from live data in prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)