### PR TITLE
fix: honest status surfacing while a machine downloads its models

### DIFF
--- a/packages/console/src/components/machines/MachineDetail.tsx
+++ b/packages/console/src/components/machines/MachineDetail.tsx
@@ -477,9 +477,9 @@ export function MachineDetail({ rkey }: { rkey: string }) {
       {!m.faultReason && m.state === "provisioning" ? (
         <Alert variant="info" title="Preparing — downloading models">
           <SmallBody>
-            This machine is downloading its model weights (often several GB) and will start
-            serving automatically when the download finishes. It appears under its models on the
-            models page only once it's serving — typically a few minutes on a fast connection.
+            This machine is downloading its model weights (often several GB) and will start serving
+            automatically when the download finishes. It appears under its models on the models page
+            only once it's serving — typically a few minutes on a fast connection.
           </SmallBody>
         </Alert>
       ) : null}

--- a/packages/console/src/components/machines/MachineDetail.tsx
+++ b/packages/console/src/components/machines/MachineDetail.tsx
@@ -53,7 +53,7 @@ import type { MachineWorkItem } from "@/components/machines/machines.server.ts";
 import { ProBonoBadge, RegionFlag } from "@/components/machines/MachineBadges.tsx";
 import { formatTokens } from "@/lib/token-display.ts";
 
-import type { Machine } from "./machines-data.ts";
+import { type Machine, machineStateLabel } from "./machines-data.ts";
 
 const styles = stylex.create({
   root: {
@@ -429,7 +429,9 @@ export function MachineDetail({ rkey }: { rkey: string }) {
                 styles[m.faultReason ? "statusFault" : STATUS_STYLE[m.state]],
               )}
             />
-            <LabelText variant="secondary">{m.faultReason ? "fault" : m.state}</LabelText>
+            <LabelText variant="secondary">
+              {m.faultReason ? "fault" : machineStateLabel(m.state)}
+            </LabelText>
           </span>
           <RegionFlag region={m.region} />
           <ProBonoBadge mode={m.proBonoMode} />
@@ -464,6 +466,21 @@ export function MachineDetail({ rkey }: { rkey: string }) {
               </SmallBody>
             ) : null}
           </Flex>
+        </Alert>
+      ) : null}
+
+      {/* The agent publishes its record with `provisioning: true` the moment
+          serving starts, then spends the next stretch downloading model
+          weights (often several GB) before it can register with the network.
+          Say so explicitly — a machine that "shows up but isn't under its
+          model" on the models page looks broken without this. */}
+      {!m.faultReason && m.state === "provisioning" ? (
+        <Alert variant="info" title="Preparing — downloading models">
+          <SmallBody>
+            This machine is downloading its model weights (often several GB) and will start
+            serving automatically when the download finishes. It appears under its models on the
+            models page only once it's serving — typically a few minutes on a fast connection.
+          </SmallBody>
         </Alert>
       ) : null}
 

--- a/packages/console/src/components/machines/MachinesDashboard.tsx
+++ b/packages/console/src/components/machines/MachinesDashboard.tsx
@@ -94,7 +94,12 @@ import {
 } from "@/components/machines/machines.functions.ts";
 import { formatTokens, formatTokensCompact } from "@/lib/token-display.ts";
 
-import { type Machine, type MachineState } from "./machines-data.ts";
+import {
+  type Machine,
+  type MachineState,
+  machineStateLabel,
+  machineStatusText,
+} from "./machines-data.ts";
 import { Page } from "@/design-system/page/index.tsx";
 import { Text } from "@/design-system/typography/text.tsx";
 import { ResizableTableContainer, Collection } from "react-aria-components";
@@ -2408,7 +2413,7 @@ export function MachinesDashboard() {
                                   )}
                                 />
 
-                                {m.faultReason ? "fault" : m.state}
+                                {m.faultReason ? "fault" : machineStateLabel(m.state)}
                               </Flex>
                             </TableCell>
                           );
@@ -2425,20 +2430,12 @@ export function MachinesDashboard() {
                         if (column.id === "job") {
                           return (
                             <TableCell>
-                              {m.faultReason ? (
-                                <LabelText variant="secondary" style={styles.faultText}>
-                                  Engine not loaded — only serving stub
-                                </LabelText>
-                              ) : (
-                                <LabelText variant="secondary">
-                                  {m.state === "provisioning" &&
-                                    "Starting up — loading the engine…"}
-                                  {m.state === "idle" && "Eligible for matching when active"}
-                                  {m.state === "paused" && (m.pausedReason ?? "Paused")}
-                                  {m.state === "running" && "Served a job in the last 5 min"}
-                                  {m.state === "offline" && (m.offlineReason ?? "Offline")}
-                                </LabelText>
-                              )}
+                              <LabelText
+                                variant="secondary"
+                                style={m.faultReason ? styles.faultText : undefined}
+                              >
+                                {machineStatusText(m)}
+                              </LabelText>
                             </TableCell>
                           );
                         }
@@ -2567,17 +2564,7 @@ function FleetMachineCard({
   onOpenDetail: () => void;
 }) {
   const tokensEarned24h = formatTokens(m.earnings24h);
-  const statusText = m.faultReason
-    ? "Engine not loaded — only serving stub"
-    : m.state === "provisioning"
-      ? "Starting up — loading the engine…"
-      : m.state === "idle"
-        ? "Eligible for matching when active"
-        : m.state === "paused"
-          ? (m.pausedReason ?? "Paused")
-          : m.state === "running"
-            ? "Served a job in the last 5 min"
-            : (m.offlineReason ?? "Offline");
+  const statusText = machineStatusText(m);
   return (
     <div {...stylex.props(styles.fleetCard)}>
       <div {...stylex.props(styles.fleetCardHead)}>
@@ -2603,7 +2590,7 @@ function FleetMachineCard({
               Boolean(m.faultReason) && styles.statusFault,
             )}
           />
-          {m.faultReason ? "fault" : m.state}
+          {m.faultReason ? "fault" : machineStateLabel(m.state)}
         </span>
       </div>
 

--- a/packages/console/src/components/machines/machines-data.ts
+++ b/packages/console/src/components/machines/machines-data.ts
@@ -2,6 +2,37 @@ import type { VerifiedTier } from "@/lib/verified-standing.server.ts";
 
 export type MachineState = "running" | "idle" | "paused" | "offline" | "provisioning";
 
+/** Owner-facing label for a machine state chip. `provisioning` is agent
+ *  jargon — the owner-facing story is "it's preparing: downloading model
+ *  weights before it can serve", so the chip says "preparing" and the
+ *  accompanying status line spells out the download. */
+export function machineStateLabel(state: MachineState): string {
+  return state === "provisioning" ? "preparing" : state;
+}
+
+/** One-line status description for a machine, shared by the fleet table and
+ *  the narrow-screen cards so the copy can't drift between the two. */
+export function machineStatusText(m: {
+  state: MachineState;
+  faultReason?: string;
+  pausedReason?: string;
+  offlineReason?: string;
+}): string {
+  if (m.faultReason) return "Engine not loaded — only serving stub";
+  switch (m.state) {
+    case "provisioning":
+      return "Preparing — downloading models before it can serve…";
+    case "idle":
+      return "Eligible for matching when active";
+    case "paused":
+      return m.pausedReason ?? "Paused";
+    case "running":
+      return "Served a job in the last 5 min";
+    default:
+      return m.offlineReason ?? "Offline";
+  }
+}
+
 export interface Machine {
   id: string;
   alias: string;

--- a/provider-shell/Sources/CoCoreShell/MenuBarController.swift
+++ b/provider-shell/Sources/CoCoreShell/MenuBarController.swift
@@ -215,10 +215,14 @@ final class MenuBarController {
         // alive (state.serving == true), but it isn't actually serving yet.
         // The provisioning marker is the truth here — show it instead of
         // "serving and earning" so the app doesn't claim earnings prematurely.
+        // "starting" is the tail of the same window: engines are loaded but
+        // the machine hasn't registered with the network yet (gated on
+        // state.serving so a stopped agent's leftover marker can't show it).
         let provision = Self.provisionStatus()
         let provisioning = provision?.phase == "provisioning"
+        let connecting = state.serving && provision?.phase == "starting"
         let effectiveServing =
-            state.serving && !scheduledIdle && !remotelyPaused && !provisioning
+            state.serving && !scheduledIdle && !remotelyPaused && !provisioning && !connecting
 
         menu.addItem(.separator())
         // At-a-glance state + the one metric worth a glance. Everything
@@ -229,13 +233,19 @@ final class MenuBarController {
         if remotelyPaused {
             atAGlance = "⏸ Stopped from the console"
         } else if provisioning {
-            let bytes = provision?.bytesDownloaded ?? 0
-            atAGlance =
-                bytes > 0
-                ? "⏳ Provisioning… downloading model (\(Self.humanBytes(bytes)))"
-                : "⏳ Provisioning a model… (not earning yet)"
+            if provision?.loading == true {
+                atAGlance = "⏳ Loading models into memory… (not serving yet)"
+            } else {
+                let bytes = provision?.bytesDownloaded ?? 0
+                atAGlance =
+                    bytes > 0
+                    ? "⏳ Downloading models… (\(Self.humanBytes(bytes)) so far)"
+                    : "⏳ Downloading models… (not earning yet)"
+            }
+        } else if connecting {
+            atAGlance = "⏳ Almost ready — connecting to the network…"
         } else if provision?.phase == "failed" {
-            atAGlance = "⚠ Provisioning failed — not serving"
+            atAGlance = "⚠ Model setup failed — not serving"
         } else if scheduledIdle {
             atAGlance = "✓ Set up — idle until \(PreferencesView.hourLabel(sched.start)) (scheduled)"
         } else if effectiveServing {
@@ -281,6 +291,12 @@ final class MenuBarController {
             menu.addItem(action(title: "Resume serving", #selector(startServing)))
         } else if scheduledIdle {
             menu.addItem(disabled("○ Idle — serves \(PreferencesView.hourLabel(sched.start))–\(PreferencesView.hourLabel(sched.end))"))
+        } else if state.serving && (provisioning || connecting) {
+            // The agent process is up but not serving yet (downloading /
+            // loading / registering). Don't offer "Start serving" — it's
+            // already started; the honest action is pausing the preparation.
+            menu.addItem(disabled("◐ Preparing — not serving yet"))
+            menu.addItem(action(title: "Pause serving", #selector(stopServing)))
         } else {
             menu.addItem(disabled(effectiveServing ? "● Serving" : "○ Not serving"))
             if effectiveServing {
@@ -1183,7 +1199,9 @@ final class MenuBarController {
     /// machine is stopped). A marker older than 1h is ignored so a crashed
     /// agent can't pin "Provisioning…" on forever.
     struct ProvisionStatus {
-        let phase: String  // "provisioning" | "failed"
+        // "provisioning" (downloading/loading weights) | "starting" (engines
+        // up, registering with the network) | "failed"
+        let phase: String
         let models: [String]
         let bytesDownloaded: UInt64
         /// True while provisioning when nothing is actively downloading — the

--- a/provider-shell/Sources/CoCoreShell/StatusView.swift
+++ b/provider-shell/Sources/CoCoreShell/StatusView.swift
@@ -69,6 +69,20 @@ struct StatusRows: View {
         }
         Section("Serving") {
             LabeledContent("State", value: servingText)
+            // While downloading, name the models so a multi-GB wait is
+            // explained ("which models?" is the first question), and set the
+            // expectation that serving starts on its own afterwards.
+            if let p = MenuBarController.provisionStatus(), p.phase == "provisioning",
+                !p.models.isEmpty
+            {
+                Text(
+                    "Fetching \(p.models.joined(separator: ", ")) — often several GB. "
+                        + "Serving starts automatically when it finishes."
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
             // The full provisioning-failure reason lives here (not the menu,
             // where a long single line can't wrap and balloons the window).
             if let p = MenuBarController.provisionStatus(), p.phase == "failed",
@@ -228,11 +242,16 @@ struct StatusRows: View {
         // it isn't serving yet, so don't claim "Serving".
         if let p = MenuBarController.provisionStatus() {
             if p.phase == "provisioning" {
+                if p.loading { return "Loading models into memory…" }
                 return p.bytesDownloaded > 0
-                    ? "Provisioning… (\(MenuBarController.humanBytes(p.bytesDownloaded)) downloaded)"
-                    : "Provisioning…"
+                    ? "Downloading models… (\(MenuBarController.humanBytes(p.bytesDownloaded)) so far)"
+                    : "Downloading models…"
             }
-            if p.phase == "failed" { return "Provisioning failed" }
+            // Engines are up; the machine is registering with the network.
+            // Gated on state.serving so a stopped agent's leftover marker
+            // can't pin "connecting" over an honest "Not serving".
+            if p.phase == "starting", state.serving { return "Connecting to the network…" }
+            if p.phase == "failed" { return "Model setup failed" }
         }
         return state.serving ? "Serving" : "Not serving"
     }

--- a/provider-shell/Sources/CoCoreShell/WelcomeView.swift
+++ b/provider-shell/Sources/CoCoreShell/WelcomeView.swift
@@ -57,6 +57,11 @@ struct WelcomeView: View {
     @State private var signingIn = false
     @State private var startingServe = false
     @State private var venvInstalled = VenvBootstrapper.isInstalled
+    /// The agent's provisioning marker, re-read by the 3s poll. While the
+    /// process is up but still downloading/loading models (or registering
+    /// with the network), the serve step must NOT claim "Serving" — that
+    /// false "you're earning" was exactly the first-run complaint.
+    @State private var provision: MenuBarController.ProvisionStatus?
     /// Latch so the runtime install auto-fires at most once per window —
     /// a failure the user is retrying shouldn't re-trigger from the poll.
     @State private var autoKickedRuntime = false
@@ -94,7 +99,13 @@ struct WelcomeView: View {
     private var hasModels: Bool { !models.models.isEmpty }
     private var runtimeReady: Bool { venvInstalled }
     private var serving: Bool { state.serving }
-    private var allDone: Bool { signedIn && hasModels && runtimeReady && serving }
+    /// The agent process is up but still preparing — downloading/loading
+    /// model weights ("provisioning") or registering with the network
+    /// ("starting"). Distinct from `serving` so step 4 stays honest.
+    private var preparing: Bool {
+        serving && (provision?.phase == "provisioning" || provision?.phase == "starting")
+    }
+    private var allDone: Bool { signedIn && hasModels && runtimeReady && serving && !preparing }
     /// Real models can't run until the runtime exists, so block "Start
     /// serving" while a real model is selected and the runtime isn't
     /// ready yet (a stub-only setup — no models — can serve immediately).
@@ -342,19 +353,42 @@ struct WelcomeView: View {
     // MARK: step 4 — start serving
 
     private var stepServe: some View {
-        step(4, done: serving, active: canServe && !serving, title: "Start serving",
-             desc: serving
-                ? "Serving — answering requests and earning credits."
-                : (signedIn && hasModels && !runtimeReady)
-                    ? "Ready to serve as soon as the runtime finishes installing."
-                    : "Connect to the network and begin earning credits.") {
+        step(4, done: serving && !preparing, active: (canServe && !serving) || preparing,
+             title: "Start serving",
+             desc: servingStepDesc) {
             if !serving {
                 Button(startingServe ? "Starting…" : "Start serving") { startServing() }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.large)
                     .disabled(!canServe || startingServe)
+            } else if preparing {
+                // The long wait is the download — show it live so the step
+                // reads as progress, not a hang (and never a premature ✓).
+                ProgressView()
+                    .controlSize(.small)
             }
         }
+    }
+
+    /// Step 4's description, honest about the gap between "the agent process
+    /// is running" and "this machine is serving": a fresh model pick means a
+    /// multi-GB weight download before the first job can arrive.
+    private var servingStepDesc: String {
+        if serving, let p = provision, p.phase == "provisioning" {
+            if p.loading { return "Loading models into memory — almost there…" }
+            return p.bytesDownloaded > 0
+                ? "Downloading models… \(MenuBarController.humanBytes(p.bytesDownloaded)) so far. "
+                    + "Serving starts automatically when the download finishes."
+                : "Downloading models… Serving starts automatically when the download finishes."
+        }
+        if serving, provision?.phase == "starting" {
+            return "Almost ready — connecting to the network…"
+        }
+        if serving { return "Serving — answering requests and earning credits." }
+        if signedIn && hasModels && !runtimeReady {
+            return "Ready to serve as soon as the runtime finishes installing."
+        }
+        return "Connect to the network and begin earning credits."
     }
 
     // MARK: footer
@@ -419,6 +453,7 @@ struct WelcomeView: View {
         await models.refresh()
         venvInstalled = VenvBootstrapper.isInstalled
         state.serving = supervisor.isServing()
+        provision = MenuBarController.provisionStatus()
         if signedIn, hasModels, !venvInstalled, !venv.isRunning, !autoKickedRuntime {
             autoKickedRuntime = true
             runBootstrap()

--- a/provider/src/advisor.rs
+++ b/provider/src/advisor.rs
@@ -227,6 +227,11 @@ impl AdvisorClient {
         // stale "bad standing" marker from a previous serve so the tray's
         // red ping doesn't linger after the machine has recovered.
         clear_bad_standing();
+        // Registration is the moment this machine can actually take jobs, so
+        // it's what closes the boot-time "starting" window the serve path
+        // marked after engines loaded (see main's provision-status marker).
+        // Only now does the tray flip from "connecting…" to "Serving".
+        clear_starting_provision_marker();
 
         let ctx = ServeContext {
             signer,
@@ -1489,6 +1494,26 @@ fn clear_bad_standing() {
     };
     if std::fs::remove_file(&path).is_ok() {
         tracing::info!("cleared bad-standing marker");
+    }
+}
+
+/// Remove `~/.cocore/provision-status.json` iff it's in the "starting"
+/// phase — the boot-time marker the serve path leaves after engines load so
+/// the tray shows "connecting to the network" until this first successful
+/// advisor registration. Phase-guarded so a "failed" marker (engine fault,
+/// machine registers stub-only) keeps surfacing its fault in the tray, and
+/// best-effort like the bad-standing marker above.
+fn clear_starting_provision_marker() {
+    let Some(path) = dirs::home_dir().map(|h| h.join(".cocore").join("provision-status.json"))
+    else {
+        return;
+    };
+    let is_starting = std::fs::read(&path)
+        .ok()
+        .and_then(|b| serde_json::from_slice::<serde_json::Value>(&b).ok())
+        .is_some_and(|v| v.get("phase").and_then(|p| p.as_str()) == Some("starting"));
+    if is_starting && std::fs::remove_file(&path).is_ok() {
+        tracing::info!("registered — cleared the boot-time provisioning marker");
     }
 }
 

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -1528,7 +1528,19 @@ async fn cmd_serve(
             false,
             Some(f),
         ),
-        None => clear_provision_status(),
+        // Engines are up, but this machine can't take jobs until it registers
+        // with the advisor (attestation + record publish + WS connect are still
+        // ahead). Mark that window "starting" instead of clearing — the tray
+        // shows "connecting to the network" rather than a premature "Serving".
+        // `AdvisorClient::run` removes the marker on its first successful
+        // registration (see `advisor::clear_starting_provision_marker`).
+        None => write_provision_status(
+            "starting",
+            &provisioning_models,
+            model_download_bytes(&provisioning_models),
+            false,
+            None,
+        ),
     }
 
     // Advertise the LIVE set, not every registered engine: `live_models()`


### PR DESCRIPTION
## Problem

Field report (2026-07-03, Jesse Beck @thewebbeckons.ca): a brand-new provider's tray said **"Serving"** and the machine appeared in his console, but it wasn't listed under its model on `/models` — because the agent was still downloading ~7 GB of weights. His PDS provider record honestly showed `provisioning: true, serving: false, supportedModels: []` the whole time; the machine had not yet registered with the advisor. The pipeline worked correctly; the messaging didn't.

## Root cause

Most of the plumbing already existed (the `~/.cocore/provision-status.json` marker + provisioning-aware menu/Status tab shipped in v0.9.15). The lie came from the **Welcome setup checklist** — the window every new user has open — whose step 4 claimed *"Serving — answering requests and earning credits"* (plus the 🎉 "You're all set" footer) off the raw process-alive flag, ignoring the marker. Secondary gap: the marker was cleared as soon as engines loaded, before the machine had actually registered with the advisor.

## Changes

**Tray (provider-shell)**
- `WelcomeView` step 4 reads the marker: "Downloading models… N GB so far. Serving starts automatically when the download finishes." → "Loading models into memory…" → "Connecting to the network…", with a spinner and no premature ✓. "Serving" / 🎉 only once truly serving.
- Menu + Status tab drop the "Provisioning…" jargon for the same download/loading copy, name the models being fetched, and the toggle line shows "◐ Preparing — not serving yet" with **Pause** (instead of the misleading "○ Not serving / Start serving") while the process is up but not serving.

**Agent (provider)**
- After `build_engines` succeeds, the marker is written as a new `"starting"` phase instead of being cleared; `AdvisorClient::run` clears it on the first successful registration. Phase-guarded so an engine-fault `"failed"` marker survives a stub-only register. Net effect: the tray's "Serving" now means *engines up AND registered with the advisor*.
- Tray display of `"starting"` is gated on the process actually running, so a leftover marker can't pin "connecting…" on a stopped agent.

**Console (packages/console)**
- `provisioning` machines render a **"preparing"** chip with "Preparing — downloading models before it can serve…" (new shared `machineStateLabel` / `machineStatusText` helpers replace three drifting copies of the status strings).
- Machine detail page adds an info alert: downloading weights (often several GB), starts serving automatically, and *appears under its models on the models page only once it's serving — typically a few minutes on a fast connection*.

**Lexicon:** no change — `dev.cocore.compute.provider` already carries `provisioning` with exactly these semantics (verified).

## Testing

- `cargo check --locked`, `cargo fmt --check`, `cargo clippy --locked --all-targets` clean
- `swift build` (provider-shell) clean
- console `npm run typecheck` clean; all 25 `machines.server.test.ts` tests pass (the `provisioning wins over serving=false` derivation is unchanged)

## Rollout

Needs a tray release — both the agent and the shell changed. Console side is independent and safe to deploy first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)