### PR TITLE
Remote diagnosability for advisor-unreachable machines (advisorFault)

### DIFF
--- a/lexicons/dev/cocore/compute/provider.json
+++ b/lexicons/dev/cocore/compute/provider.json
@@ -204,6 +204,28 @@
               }
             }
           },
+          "advisorFault": {
+            "type": "object",
+            "description": "Present when the agent cannot establish its WebSocket connection to its advisor (matchmaker) after repeated consecutive attempts. The machine may be perfectly healthy locally — engine loaded, records published, `serving: true` — yet completely absent from the network: no advisor registry entry, no jobs routed, and without this field the failure is invisible remotely (the record looks like a healthy idle machine, so operators misdiagnose it as an onboarding problem). Consumers SHOULD surface this as 'serving locally but cannot reach the network' with remediation guidance (VPN / firewall / WebSocket filtering). Known codes: `dns-failure`, `tls-failure`, `connect-timeout`, `connect-refused`, `upgrade-blocked` (plain HTTPS to the advisor works but the WebSocket upgrade cannot be established — a middlebox on the network is filtering WebSockets), `http-<status>` (the upgrade handshake got a non-101 HTTP answer), `closed-<code>` (the socket was closed with the given WebSocket close code), and `network-unreachable`; new codes may be added, and consumers MUST treat an unknown code as a generic advisor-unreachable fault. The agent publishes this through its record-write path over plain HTTPS — which is exactly the transport that still works in the failure this diagnoses — and clears the field on its next successful advisor registration, so presence reflects the current state, not a stale failure. Additive / optional — pre-2026-07 readers ignore it.",
+            "required": ["code", "message", "observedAt"],
+            "properties": {
+              "code": {
+                "type": "string",
+                "maxLength": 64,
+                "description": "Machine-readable fault class; see the field description for known values. Unknown codes MUST be treated as a generic advisor-unreachable fault."
+              },
+              "message": {
+                "type": "string",
+                "maxLength": 600,
+                "description": "Human-readable, content-safe summary with remediation guidance. Carries only the classified error kind — never raw error text, URLs, or credentials."
+              },
+              "observedAt": {
+                "type": "string",
+                "format": "datetime",
+                "description": "When the agent recorded the fault (RFC3339, UTC)."
+              }
+            }
+          },
           "toolCalls": {
             "type": "boolean",
             "description": "The owner's opt-in to serving tool/function calls on this machine. Owner-written INTENT, set from a management UI (the console's per-machine settings), exactly like `desiredModels`/`desiredTier`/`proBono`/`shareLocation`: the agent reconciles toward it but NEVER authors it, so it must PRESERVE whatever it finds on every re-publish. When `true`, the agent starts each eligible engine with vLLM automatic tool-choice enabled and verifies real tool-call behavior with a forced-tool startup canary before advertising support (per-model, via the advisor `Register.toolCallModels`); a model that fails the canary is served exactly as before, just without tool calls. Eligibility is RESTRICTED to the curated 'top models' the provider knows a tool-call parser pairing for — models outside that set never attempt tool calling even when this is on, so turning it on can only ADD capability, never break existing serving. Absent ≡ off: no engine advertises tool calls and the machine behaves exactly as it does today. Optional / additive; pre-2026-07 agents ignore it.\nNote: an operator may still force the raw vLLM passthrough on any model via the `COCORE_ENABLE_TOOL_CALLS` env var; this field is the curated, UI-driven path that does not require a known global parser."

--- a/packages/console/src/components/machines/MachineBadges.tsx
+++ b/packages/console/src/components/machines/MachineBadges.tsx
@@ -1,8 +1,45 @@
-// Small, shared visual indicators for a machine's advisory region and its
-// pro-bono election. Used in both the fleet table (MachinesDashboard) and the
-// machine detail header so the two stay in sync.
+// Small, shared visual indicators for a machine's advisory region, its
+// pro-bono election, and its live network standing. Used in both the fleet
+// table (MachinesDashboard) and the machine detail header so the two stay
+// in sync.
 
 import { Badge } from "@/design-system/badge";
+
+import { machineNetworkStanding, type Machine } from "./machines-data.ts";
+
+/** Live network-standing chip: "on network" when the advisor holds a live
+ *  connection to this machine, "not reachable" when the machine should be
+ *  serving but the network can't hear from it (absent from the advisor's
+ *  registry, and/or its agent published an `advisorFault`). Renders nothing
+ *  when a claim would be a guess — machine paused/offline/provisioning, or
+ *  live standing unavailable with no agent-reported fault. */
+export function NetworkStandingBadge({ m }: { m: Machine }) {
+  const standing = machineNetworkStanding(m);
+  if (standing === null) return null;
+  if (standing === "on-network") {
+    return (
+      <Badge
+        variant="success"
+        size="sm"
+        title="Connected to the co/core network — reachable for jobs"
+      >
+        on network
+      </Badge>
+    );
+  }
+  return (
+    <Badge
+      variant="warning"
+      size="sm"
+      title={
+        m.advisorFaultReason ??
+        "This machine is serving locally but the co/core network can't reach it — no jobs will arrive until it reconnects."
+      }
+    >
+      not reachable
+    </Badge>
+  );
+}
 
 /** Turn an ISO 3166-1 alpha-2 country code into a flag emoji by mapping each
  *  ASCII letter to its regional-indicator symbol. Returns null for anything

--- a/packages/console/src/components/machines/MachineDetail.tsx
+++ b/packages/console/src/components/machines/MachineDetail.tsx
@@ -50,10 +50,14 @@ import {
   setMyProviderToolCallsMutationOptions,
 } from "@/components/machines/machines.functions.ts";
 import type { MachineWorkItem } from "@/components/machines/machines.server.ts";
-import { ProBonoBadge, RegionFlag } from "@/components/machines/MachineBadges.tsx";
+import {
+  NetworkStandingBadge,
+  ProBonoBadge,
+  RegionFlag,
+} from "@/components/machines/MachineBadges.tsx";
 import { formatTokens } from "@/lib/token-display.ts";
 
-import { type Machine, machineStateLabel } from "./machines-data.ts";
+import { advisorUnreachable, type Machine, machineStateLabel } from "./machines-data.ts";
 
 const styles = stylex.create({
   root: {
@@ -435,6 +439,7 @@ export function MachineDetail({ rkey }: { rkey: string }) {
           </span>
           <RegionFlag region={m.region} />
           <ProBonoBadge mode={m.proBonoMode} />
+          <NetworkStandingBadge m={m} />
         </div>
         <div {...stylex.props(styles.metaRow)}>
           <span>{m.gpu}</span>
@@ -481,6 +486,29 @@ export function MachineDetail({ rkey }: { rkey: string }) {
             automatically when the download finishes. It appears under its models on the models page
             only once it's serving — typically a few minutes on a fast connection.
           </SmallBody>
+        </Alert>
+      ) : null}
+
+      {advisorUnreachable(m) ? (
+        <Alert variant="warning" title="Serving locally — can't reach the co/core network">
+          <Flex direction="column" gap="md">
+            <SmallBody>
+              {m.advisorFaultReason ??
+                "This machine's record says it's serving, but the network currently holds no live connection to it — no jobs will reach it until it reconnects. It usually rejoins on its own within a minute; if this persists, the connection is likely being blocked."}
+            </SmallBody>
+            <SmallBody variant="secondary">
+              Common causes: a VPN or proxy on the machine's network, a firewall that blocks
+              outbound WebSocket (wss) connections, or captive/guest Wi-Fi that filters them. Try a
+              different network or allow secure WebSocket traffic, then the machine rejoins
+              automatically — no restart needed.
+            </SmallBody>
+            {m.advisorFaultCode ? (
+              <SmallBody variant="secondary">
+                Fault code: <InlineCode>{m.advisorFaultCode}</InlineCode>
+                {m.advisorFaultAt ? <> · observed {formatWhen(m.advisorFaultAt)}</> : null}
+              </SmallBody>
+            ) : null}
+          </Flex>
         </Alert>
       ) : null}
 

--- a/packages/console/src/components/machines/MachinesDashboard.tsx
+++ b/packages/console/src/components/machines/MachinesDashboard.tsx
@@ -81,7 +81,11 @@ import {
   listMyFriendsQueryOptions,
   type ListedFriend,
 } from "@/components/friends/friends.functions.ts";
-import { ProBonoBadge, RegionFlag } from "@/components/machines/MachineBadges.tsx";
+import {
+  NetworkStandingBadge,
+  ProBonoBadge,
+  RegionFlag,
+} from "@/components/machines/MachineBadges.tsx";
 import {
   dedupMyProviderRecordsMutationOptions,
   deleteMyProviderRecordMutationOptions,
@@ -95,6 +99,7 @@ import {
 import { formatTokens, formatTokensCompact } from "@/lib/token-display.ts";
 
 import {
+  advisorUnreachable,
   type Machine,
   type MachineState,
   machineStateLabel,
@@ -2391,6 +2396,7 @@ export function MachinesDashboard() {
                                 {m.verifiedTier ? <TrustTierBadge tier={m.verifiedTier} /> : null}
                                 <RegionFlag region={m.region} />
                                 <ProBonoBadge mode={m.proBonoMode} />
+                                <NetworkStandingBadge m={m} />
                               </Flex>
                             </TableCell>
                           );
@@ -2432,7 +2438,11 @@ export function MachinesDashboard() {
                             <TableCell>
                               <LabelText
                                 variant="secondary"
-                                style={m.faultReason ? styles.faultText : undefined}
+                                style={
+                                  m.faultReason || advisorUnreachable(m)
+                                    ? styles.faultText
+                                    : undefined
+                                }
                               >
                                 {machineStatusText(m)}
                               </LabelText>
@@ -2579,6 +2589,7 @@ function FleetMachineCard({
           <span {...stylex.props(styles.fleetCardRkey)}>{m.id}</span>
         </div>
         <span {...stylex.props(styles.fleetCardState)}>
+          <NetworkStandingBadge m={m} />
           <span
             {...stylex.props(
               styles.statusDot,
@@ -2609,7 +2620,10 @@ function FleetMachineCard({
 
       <LabelText
         variant="secondary"
-        style={[styles.fleetCardStatus, m.faultReason ? styles.faultText : undefined]}
+        style={[
+          styles.fleetCardStatus,
+          m.faultReason || advisorUnreachable(m) ? styles.faultText : undefined,
+        ]}
       >
         {statusText}
       </LabelText>
@@ -2672,6 +2686,19 @@ function FleetMachineCard({
   );
 }
 
+/** "Jul 4, 01:52" for a fault's RFC3339 timestamp; the raw string when it
+ *  doesn't parse (the field is agent-published and advisory). */
+function formatMachineFaultAt(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
 function MachineDrawer({
   m,
   onAction,
@@ -2707,6 +2734,30 @@ function MachineDrawer({
                 <InlineCode>{m.faultCode ?? "unknown"}</InlineCode>, and we'll help you get it
                 online.
               </SmallBody>
+            </Flex>
+          </Alert>
+        ) : null}
+        {advisorUnreachable(m) ? (
+          <Alert variant="warning" title="Serving locally — can't reach the co/core network">
+            <Flex gap="md" direction="column">
+              <SmallBody>
+                {m.advisorFaultReason ??
+                  "This machine's record says it's serving, but the network currently holds no live connection to it — no jobs will reach it until it reconnects. It usually rejoins on its own within a minute; if this persists, the connection is likely being blocked."}
+              </SmallBody>
+              <SmallBody variant="secondary">
+                Common causes: a VPN or proxy on the machine's network, a firewall that blocks
+                outbound WebSocket (wss) connections, or captive/guest Wi-Fi that filters them. Try
+                a different network or allow secure WebSocket traffic, then the machine rejoins
+                automatically — no restart needed.
+              </SmallBody>
+              {m.advisorFaultCode ? (
+                <SmallBody variant="secondary">
+                  Fault code: <InlineCode>{m.advisorFaultCode}</InlineCode>
+                  {m.advisorFaultAt ? (
+                    <> · observed {formatMachineFaultAt(m.advisorFaultAt)}</>
+                  ) : null}
+                </SmallBody>
+              ) : null}
             </Flex>
           </Alert>
         ) : null}

--- a/packages/console/src/components/machines/machines-data.ts
+++ b/packages/console/src/components/machines/machines-data.ts
@@ -17,8 +17,12 @@ export function machineStatusText(m: {
   faultReason?: string;
   pausedReason?: string;
   offlineReason?: string;
+  advisorFaultReason?: string;
+  standingKnown?: boolean;
+  advisorConnected?: boolean;
 }): string {
   if (m.faultReason) return "Engine not loaded — only serving stub";
+  if (advisorUnreachable(m)) return "Serving locally — can't reach the co/core network";
   switch (m.state) {
     case "provisioning":
       return "Preparing — downloading models before it can serve…";
@@ -59,6 +63,19 @@ export interface Machine {
   /** The configured model ids that failed to load, if the agent
    *  reported them. */
   faultModels?: string[];
+  /** Machine-readable advisor-connectivity fault class published by the
+   *  agent when its WebSocket to the advisor keeps failing to connect
+   *  (e.g. "upgrade-blocked", "dns-failure", "connect-timeout"). The
+   *  machine is healthy and serving LOCALLY but invisible to the network —
+   *  no jobs will reach it. Cleared by the agent on its next successful
+   *  registration. See the provider record's `advisorFault` field. */
+  advisorFaultCode?: string;
+  /** Human-readable, content-safe summary of {@link advisorFaultCode} with
+   *  remediation guidance (VPN / firewall / WebSocket filtering). Present
+   *  iff the fault is. */
+  advisorFaultReason?: string;
+  /** RFC3339 timestamp of when the agent recorded the advisor fault. */
+  advisorFaultAt?: string;
   /** How the machine's environment is attested (from the provider record):
    *  `self-attested` (software) or `hardware-attested` (genuine Apple hardware +
    *  SIP, via a bound MDA chain). Evidence-derived; the UI humanizes it. */
@@ -138,4 +155,32 @@ export interface Machine {
    *  pairing for and verifies each with a startup canary before advertising it.
    *  Drives the "Tool calling" toggle in per-machine settings. Absent ≡ off. */
   toolCalls?: boolean;
+}
+
+/** Whether this machine looks cut off from the co/core network while
+ *  serving locally: its agent published an `advisorFault` (repeated
+ *  WebSocket connect failures), and/or its record says it's serving yet
+ *  the advisor holds no live connection to it. Only meaningful for a
+ *  machine that SHOULD be connected — a paused / offline / provisioning
+ *  box is expected to be absent from the advisor's registry. */
+export function advisorUnreachable(
+  m: Pick<Machine, "state" | "advisorFaultReason" | "standingKnown" | "advisorConnected">,
+): boolean {
+  if (m.state !== "idle" && m.state !== "running") return false;
+  // A live advisor connection outranks a fault the agent published earlier
+  // and hasn't gotten around to clearing yet (it clears on registration).
+  if (m.standingKnown === true && m.advisorConnected === true) return false;
+  if (m.advisorFaultReason) return true;
+  return m.standingKnown === true && m.advisorConnected === false;
+}
+
+/** The machine's live network standing for the "on network / not
+ *  reachable" badge. `null` when a badge would be noise: the machine
+ *  isn't expected on the network (paused/offline/provisioning) or the
+ *  advisor overlay was unavailable and the agent reports no fault. */
+export function machineNetworkStanding(m: Machine): "on-network" | "not-reachable" | null {
+  if (m.state !== "idle" && m.state !== "running") return null;
+  if (m.standingKnown === true && m.advisorConnected === true) return "on-network";
+  if (advisorUnreachable(m)) return "not-reachable";
+  return null;
 }

--- a/packages/console/src/components/machines/machines.server.test.ts
+++ b/packages/console/src/components/machines/machines.server.test.ts
@@ -19,7 +19,7 @@ import type {
   FleetReceiptStats,
   MachineReceiptStats,
 } from "./machines.server.ts";
-import type { Machine } from "./machines-data.ts";
+import { advisorUnreachable, machineNetworkStanding, type Machine } from "./machines-data.ts";
 
 const NOW = Date.UTC(2026, 5, 11, 12, 0, 0); // fixed "now"
 const minsAgo = (m: number) => new Date(NOW - m * 60_000).toISOString();
@@ -419,4 +419,110 @@ test("applyAdvisorStanding never fabricates health when the advisor is unreachab
   // unhealthy / advisorConnected stay UNDEFINED — unknown, not a green claim.
   assert.equal(m!.unhealthy, undefined);
   assert.equal(m!.advisorConnected, undefined);
+});
+
+// --- advisorFault: "serving locally, invisible to the network" ---------
+
+test("advisorFault is mapped onto the machine when the record carries it", () => {
+  const m = providerRowsToMachines(
+    [
+      providerRow({
+        supportedModels: ["qwen"],
+        serving: true,
+        advisorFault: {
+          code: "upgrade-blocked",
+          message: "WebSocket connections are being filtered on this network.",
+          observedAt: "2026-07-04T01:52:00Z",
+        },
+      }),
+    ],
+    ZERO_STATS,
+    new Map(),
+  )[0]!;
+  assert.equal(m.advisorFaultCode, "upgrade-blocked");
+  assert.match(m.advisorFaultReason ?? "", /filtered/);
+  assert.equal(m.advisorFaultAt, "2026-07-04T01:52:00Z");
+  // Independent of the engine fault surface.
+  assert.equal(m.faultReason, undefined);
+});
+
+test("an advisorFault without a message is ignored (no empty alert)", () => {
+  const m = providerRowsToMachines(
+    [providerRow({ supportedModels: ["qwen"], advisorFault: { code: "dns-failure" } })],
+    ZERO_STATS,
+    new Map(),
+  )[0]!;
+  assert.equal(m.advisorFaultCode, undefined);
+  assert.equal(m.advisorFaultReason, undefined);
+});
+
+test("advisorUnreachable: fault on an idle machine ⇒ unreachable, even without live standing", () => {
+  const m: Machine = {
+    ...machineStub("rkey-1"),
+    advisorFaultCode: "upgrade-blocked",
+    advisorFaultReason: "WebSocket connections are being filtered on this network.",
+  };
+  assert.equal(advisorUnreachable(m), true);
+  assert.equal(machineNetworkStanding(m), "not-reachable");
+});
+
+test("advisorUnreachable: serving on PDS but absent from the advisor ⇒ unreachable (the Jesse Beck case)", () => {
+  // Agent 0.9.40 published a healthy record but its WS never arrived — no
+  // fault field yet (old agent), but the advisor join says "not connected".
+  const [m] = applyAdvisorStanding([machineStub("rkey-1")], {
+    reachable: true,
+    byMachineId: new Map(),
+  });
+  assert.equal(advisorUnreachable(m!), true);
+  assert.equal(machineNetworkStanding(m!), "not-reachable");
+});
+
+test("advisorUnreachable: a live advisor connection outranks a stale fault", () => {
+  const machines = [
+    {
+      ...machineStub("rkey-1"),
+      advisorFaultCode: "connect-timeout",
+      advisorFaultReason: "stale — the agent just reconnected and hasn't cleared it yet",
+    },
+  ];
+  const [m] = applyAdvisorStanding(machines, {
+    reachable: true,
+    byMachineId: new Map([
+      [
+        "rkey-1",
+        {
+          unhealthy: false,
+          unhealthyReason: null,
+          silentFailure: false,
+          verifiedTier: "best-effort" as const,
+        },
+      ],
+    ]),
+  });
+  assert.equal(advisorUnreachable(m!), false);
+  assert.equal(machineNetworkStanding(m!), "on-network");
+});
+
+test("advisorUnreachable: never claimed for a paused/offline/provisioning machine", () => {
+  for (const state of ["paused", "offline", "provisioning"] as const) {
+    const m: Machine = {
+      ...machineStub("rkey-1"),
+      state,
+      advisorFaultCode: "dns-failure",
+      advisorFaultReason: "lingering fault on a stopped machine",
+      standingKnown: true,
+      advisorConnected: false,
+    };
+    assert.equal(advisorUnreachable(m), false, state);
+    assert.equal(machineNetworkStanding(m), null, state);
+  }
+});
+
+test("advisorUnreachable: unknown standing with no fault makes no claim", () => {
+  const [m] = applyAdvisorStanding([machineStub("rkey-1")], {
+    reachable: false,
+    byMachineId: new Map(),
+  });
+  assert.equal(advisorUnreachable(m!), false);
+  assert.equal(machineNetworkStanding(m!), null);
 });

--- a/packages/console/src/components/machines/machines.server.ts
+++ b/packages/console/src/components/machines/machines.server.ts
@@ -33,6 +33,12 @@ type EngineFaultBody = {
   models?: string[];
 };
 
+type AdvisorFaultBody = {
+  code?: string;
+  message?: string;
+  observedAt?: string;
+};
+
 type ProviderRecordBody = {
   machineLabel?: string;
   chip?: string;
@@ -49,6 +55,7 @@ type ProviderRecordBody = {
   supportedModels?: string[];
   desiredModels?: string[];
   engineFault?: EngineFaultBody;
+  advisorFault?: AdvisorFaultBody;
   shareLocation?: boolean;
   region?: string;
   proBono?: { mode?: string; dids?: string[] };
@@ -102,6 +109,7 @@ function parseProviderBody(body: unknown): ProviderRecordBody {
       ? o.desiredModels.filter((m): m is string => typeof m === "string")
       : undefined,
     engineFault: parseEngineFault(o.engineFault),
+    advisorFault: parseAdvisorFault(o.advisorFault),
     shareLocation: typeof o.shareLocation === "boolean" ? o.shareLocation : undefined,
     region: typeof o.region === "string" ? o.region : undefined,
     proBono: parseProBono(o.proBono),
@@ -136,6 +144,23 @@ function parseEngineFault(raw: unknown): EngineFaultBody | undefined {
     models: Array.isArray(o.models)
       ? o.models.filter((m): m is string => typeof m === "string")
       : undefined,
+  };
+}
+
+/** Parse the provider record's `advisorFault` — published by the agent when
+ *  its WebSocket to the advisor keeps failing to connect, i.e. the machine
+ *  serves locally but is invisible to the network. Same tolerance posture as
+ *  {@link parseEngineFault}: a fault is only meaningful with a message. */
+function parseAdvisorFault(raw: unknown): AdvisorFaultBody | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const o = raw as Record<string, unknown>;
+  const code = typeof o.code === "string" ? o.code : undefined;
+  const message = typeof o.message === "string" ? o.message : undefined;
+  if (!message) return undefined;
+  return {
+    code,
+    message,
+    observedAt: typeof o.observedAt === "string" ? o.observedAt : undefined,
   };
 }
 
@@ -699,6 +724,9 @@ export function providerRowsToMachines(
       faultCode: body.engineFault?.code,
       faultReason: body.engineFault?.message,
       faultModels: body.engineFault?.models,
+      advisorFaultCode: body.advisorFault?.code,
+      advisorFaultReason: body.advisorFault?.message,
+      advisorFaultAt: body.advisorFault?.observedAt,
       shareLocation: body.shareLocation,
       region: body.region,
       proBonoMode:

--- a/packages/console/src/routes/api/agent.status.ts
+++ b/packages/console/src/routes/api/agent.status.ts
@@ -170,6 +170,7 @@ export const Route = createFileRoute("/api/agent/status")({
           binaryVersion?: string;
           desiredTier?: string;
           attestationFault?: { code?: string; message?: string; at?: string };
+          advisorFault?: { code?: string; message?: string; observedAt?: string };
         };
 
         // Surface an attestation build/publish failure: a machine in this
@@ -180,6 +181,18 @@ export const Route = createFileRoute("/api/agent/status")({
               code: body.attestationFault.code ?? null,
               message: body.attestationFault.message ?? null,
               at: body.attestationFault.at ?? null,
+            }
+          : null;
+
+        // Surface an advisor-connectivity failure: a machine in this state is
+        // serving locally but invisible to the network (its WebSocket to the
+        // advisor never connects), so without this it just looks idle. Same
+        // shape and posture as attestationFault above.
+        const advisorFault = body.advisorFault
+          ? {
+              code: body.advisorFault.code ?? null,
+              message: body.advisorFault.message ?? null,
+              observedAt: body.advisorFault.observedAt ?? null,
             }
           : null;
 
@@ -209,6 +222,7 @@ export const Route = createFileRoute("/api/agent/status")({
             confidentialBlockedReason,
             agentVersion: body.binaryVersion ?? null,
             attestationFault,
+            advisorFault,
             needsReauth,
           }),
           { status: 200, headers: { "content-type": "application/json" } },

--- a/packages/sdk/src/types.gen.ts
+++ b/packages/sdk/src/types.gen.ts
@@ -207,6 +207,7 @@ export interface ProviderRecord {
   binaryVersion?: string;
   engineFault?: { code: string; message: string; models?: string[]; at: string };
   attestationFault?: { code: string; message: string; at: string };
+  advisorFault?: { code: string; message: string; observedAt: string };
   toolCalls?: boolean;
   shareLocation?: boolean;
   region?: string;

--- a/provider/src/advisor.rs
+++ b/provider/src/advisor.rs
@@ -166,14 +166,25 @@ impl AdvisorClient {
         require_secure_advisor_url(&self.url)?;
 
         tracing::info!(url = %self.url, "connecting to advisor");
+        // Connect failures return the classified `AdvisorConnect` variant —
+        // the Register frame never reached the advisor, so the serve loop can
+        // count consecutive occurrences and publish an `advisorFault` on the
+        // provider record (the only remotely-visible trace of a machine that
+        // serves locally but never joins the network).
         let (ws, _resp) =
             match tokio::time::timeout(CONNECT_TIMEOUT, connect_async(&self.url)).await {
-                Ok(r) => r.map_err(|e| ProviderError::Advisor(e.to_string()))?,
+                Ok(r) => r.map_err(|e| ProviderError::AdvisorConnect {
+                    code: classify_ws_connect_error(&e),
+                    detail: e.to_string(),
+                })?,
                 Err(_) => {
-                    return Err(ProviderError::Advisor(format!(
-                        "advisor connect timed out after {}s",
-                        CONNECT_TIMEOUT.as_secs()
-                    )));
+                    return Err(ProviderError::AdvisorConnect {
+                        code: "connect-timeout".to_string(),
+                        detail: format!(
+                            "advisor connect timed out after {}s",
+                            CONNECT_TIMEOUT.as_secs()
+                        ),
+                    });
                 }
             };
         let (mut write, mut read) = ws.split();
@@ -232,6 +243,33 @@ impl AdvisorClient {
         // marked after engines loaded (see main's provision-status marker).
         // Only now does the tray flip from "connecting…" to "Serving".
         clear_starting_provision_marker();
+        // It also proves the advisor path works end-to-end — remove any
+        // `advisorFault` published on the provider record (by this process
+        // after repeated connect failures, or left behind by a previous one)
+        // so the console stops showing "can't reach the network". Runs
+        // off-loop: a PDS round-trip must never stall ping handling. The
+        // maybe-published marker makes this a no-op — not even a read — on
+        // the common reconnect (the advisor's edge recycles the socket every
+        // ~14 minutes), and a failed clear leaves the marker set so the next
+        // registration retries.
+        if crate::pds::advisor_fault_maybe_published() {
+            if let Some(rk) = provider_rkey {
+                let pds_clear = pds.clone();
+                let rk = rk.to_string();
+                tokio::spawn(async move {
+                    match pds_clear.patch_provider_advisor_fault(&rk, None).await {
+                        Ok(true) => tracing::info!(
+                            "cleared advisorFault on provider record after successful registration"
+                        ),
+                        Ok(false) => {}
+                        Err(e) => tracing::warn!(
+                            error = %e,
+                            "could not clear advisorFault after registration; will retry on the next one"
+                        ),
+                    }
+                });
+            }
+        }
 
         let ctx = ServeContext {
             signer,
@@ -806,6 +844,219 @@ fn require_secure_advisor_url(url: &str) -> Result<()> {
         "refusing to connect to advisor over insecure transport: {url:?} (scheme {scheme:?}). \
          Use a wss:// URL, or set {ALLOW_INSECURE_ADVISOR_ENV}=1 to allow ws:// for local dev."
     )))
+}
+
+/// Classify a WebSocket connect failure into the machine-readable class the
+/// `advisorFault` lexicon field carries. Only ever called for CONNECT-phase
+/// errors (the handshake never completed), so every class here means "the
+/// Register frame never reached the advisor". Deliberately coarse: the class
+/// is published on a world-readable record, so it names the error KIND and
+/// nothing else (no addresses, no raw error text).
+fn classify_ws_connect_error(e: &tokio_tungstenite::tungstenite::Error) -> String {
+    use tokio_tungstenite::tungstenite::Error as WsError;
+    match e {
+        // The upgrade got a plain HTTP answer instead of 101 — the advisor
+        // host (or something in front of it) answered HTTP but refused the
+        // WebSocket handshake.
+        WsError::Http(resp) => format!("http-{}", resp.status().as_u16()),
+        WsError::Io(io) => classify_connect_io_error(io),
+        WsError::Url(_) => "bad-url".to_string(),
+        // Everything else (TLS, protocol violations, …) — tungstenite's TLS
+        // variant is feature-gated, so sniff the rendered error rather than
+        // matching it structurally.
+        other => {
+            let s = other.to_string().to_ascii_lowercase();
+            if s.contains("tls") || s.contains("certificate") || s.contains("ssl") {
+                "tls-failure".to_string()
+            } else {
+                "ws-handshake-failed".to_string()
+            }
+        }
+    }
+}
+
+/// Classify the io::Error under a failed WebSocket connect. DNS failures have
+/// no dedicated `ErrorKind` on the platforms we ship (they surface as an
+/// uncategorized getaddrinfo error), so those fall back to message sniffing.
+fn classify_connect_io_error(io: &std::io::Error) -> String {
+    use std::io::ErrorKind;
+    match io.kind() {
+        ErrorKind::TimedOut => "connect-timeout".to_string(),
+        ErrorKind::ConnectionRefused => "connect-refused".to_string(),
+        ErrorKind::ConnectionReset | ErrorKind::ConnectionAborted | ErrorKind::BrokenPipe => {
+            "connection-reset".to_string()
+        }
+        _ => {
+            let s = io.to_string().to_ascii_lowercase();
+            if s.contains("lookup")
+                || s.contains("resolve")
+                || s.contains("nodename")
+                || s.contains("name or service")
+                || s.contains("dns")
+            {
+                "dns-failure".to_string()
+            } else if s.contains("network is unreachable")
+                || s.contains("no route to host")
+                || s.contains("host is down")
+            {
+                "network-unreachable".to_string()
+            } else if s.contains("tls") || s.contains("certificate") || s.contains("ssl") {
+                "tls-failure".to_string()
+            } else {
+                "io-error".to_string()
+            }
+        }
+    }
+}
+
+/// Best-effort probe of the advisor's plain-HTTPS surface (`GET /ttft`, its
+/// cheap public endpoint), used when the WebSocket connect keeps failing.
+/// ANY HTTP response counts as reachable — it proves DNS + TCP + TLS + HTTP
+/// to the advisor host all work, which is exactly the signal that separates
+/// "this network filters WebSocket upgrades" (a middlebox) from "this
+/// machine can't reach the advisor at all".
+pub async fn probe_advisor_https(advisor_url: &str) -> bool {
+    let Some(url) = advisor_https_probe_url(advisor_url) else {
+        return false;
+    };
+    let Ok(client) = reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(15))
+        .build()
+    else {
+        return false;
+    };
+    match client.get(&url).send().await {
+        Ok(resp) => {
+            tracing::debug!(status = %resp.status(), "advisor HTTPS probe answered");
+            true
+        }
+        Err(e) => {
+            tracing::debug!(error = %e, "advisor HTTPS probe failed");
+            false
+        }
+    }
+}
+
+/// `wss://host[:port]/…` → `https://host[:port]/ttft` (and `ws://` →
+/// `http://` for local dev). `None` when the advisor URL has no
+/// recognizable scheme/authority.
+fn advisor_https_probe_url(advisor_url: &str) -> Option<String> {
+    let (scheme, rest) = advisor_url.split_once("://")?;
+    let authority = rest.split('/').next()?;
+    if authority.is_empty() {
+        return None;
+    }
+    let http_scheme = match scheme.to_ascii_lowercase().as_str() {
+        "wss" | "https" => "https",
+        "ws" | "http" => "http",
+        _ => return None,
+    };
+    Some(format!("{http_scheme}://{authority}/ttft"))
+}
+
+/// Build the `advisorFault` body from a classified connect-failure code and
+/// the outcome of the plain-HTTPS probe. The probe result FOLDS INTO the
+/// classification: ambiguous network-ish failures with working HTTPS become
+/// `upgrade-blocked` (a middlebox is filtering WebSockets specifically),
+/// while a failed probe keeps the base code and says the advisor is
+/// unreachable outright. Every message is a fixed, content-safe template —
+/// remediation guidance only, never raw error text, URLs, or credentials.
+pub fn build_advisor_fault(base_code: &str, https_reachable: bool) -> crate::pds::AdvisorFault {
+    const RETRYING: &str = "The machine keeps serving locally and retries automatically; \
+        it will rejoin the network on its own the moment a connection succeeds.";
+    let (code, message): (String, String) = if https_reachable {
+        match base_code {
+            // A real HTTP answer to the upgrade: the advisor host is
+            // reachable; the WebSocket endpoint itself said no.
+            c if c.starts_with("http-") => (
+                c.to_string(),
+                format!(
+                    "The co/core network service is reachable, but it answered this machine's \
+                     WebSocket handshake with a plain HTTP error instead of accepting it. This \
+                     is usually transient (a deploy or an edge hiccup). {RETRYING} If it \
+                     persists for hours, check status with the co/core team."
+                ),
+            ),
+            "tls-failure" => (
+                "tls-failure".to_string(),
+                format!(
+                    "Secure-connection (TLS) setup for this machine's WebSocket to the co/core \
+                     network failed even though plain HTTPS works — a TLS-intercepting proxy or \
+                     security appliance on this network is the usual cause. {RETRYING} Try a \
+                     network without TLS inspection, or exempt WebSocket traffic from it."
+                ),
+            ),
+            // Timeouts, resets, refusals, protocol failures with HTTPS fine:
+            // something on the path accepts HTTPS but kills WebSockets.
+            _ => (
+                "upgrade-blocked".to_string(),
+                format!(
+                    "This machine reaches the co/core network service over plain HTTPS, but its \
+                     WebSocket connection — the channel jobs are dispatched over — cannot be \
+                     established. A firewall, VPN, or proxy on this network is likely filtering \
+                     WebSocket connections. {RETRYING} Try a different network, disable the \
+                     VPN/proxy, or allow outbound secure WebSocket (wss) traffic."
+                ),
+            ),
+        }
+    } else {
+        match base_code {
+            "dns-failure" => (
+                "dns-failure".to_string(),
+                format!(
+                    "This machine could not look up the co/core network service's address (DNS \
+                     resolution failed). {RETRYING} Check this machine's internet connection, \
+                     DNS settings, or any VPN/firewall software."
+                ),
+            ),
+            "connect-timeout" => (
+                "connect-timeout".to_string(),
+                format!(
+                    "Connection attempts to the co/core network service time out — neither its \
+                     WebSocket nor plain HTTPS answered. {RETRYING} Check this machine's \
+                     internet connection and any VPN/firewall software."
+                ),
+            ),
+            "connect-refused" => (
+                "connect-refused".to_string(),
+                format!(
+                    "The co/core network service actively refused this machine's connection, \
+                     and plain HTTPS did not answer either — a local proxy or firewall is \
+                     likely intercepting outbound traffic. {RETRYING} Check any VPN/proxy/\
+                     firewall software on this machine or network."
+                ),
+            ),
+            "tls-failure" => (
+                "tls-failure".to_string(),
+                format!(
+                    "Secure-connection (TLS) setup to the co/core network service failed. \
+                     {RETRYING} Check this machine's date & time, and any VPN or security \
+                     software that inspects network traffic."
+                ),
+            ),
+            "network-unreachable" => (
+                "network-unreachable".to_string(),
+                format!(
+                    "This machine has no network route to the co/core network service. \
+                     {RETRYING} Check this machine's internet connection."
+                ),
+            ),
+            other => (
+                other.to_string(),
+                format!(
+                    "This machine cannot establish its connection to the co/core network \
+                     service (checked both WebSocket and plain HTTPS). {RETRYING} Check this \
+                     machine's internet connection and any VPN/firewall software."
+                ),
+            ),
+        }
+    };
+    crate::pds::AdvisorFault {
+        code,
+        message,
+        observedAt: Utc::now(),
+    }
 }
 
 /// How often the serve loop checks that every previously-ready engine's
@@ -1846,6 +2097,95 @@ mod tests {
         // Even with the opt-in, a non-ws/wss scheme is still refused.
         assert!(require_secure_advisor_url("http://localhost:8080").is_err());
         std::env::remove_var(ALLOW_INSECURE_ADVISOR_ENV);
+    }
+
+    #[test]
+    fn advisor_https_probe_url_maps_ws_scheme_and_path() {
+        assert_eq!(
+            advisor_https_probe_url("wss://advisor.cocore.dev/v1/agent").as_deref(),
+            Some("https://advisor.cocore.dev/ttft")
+        );
+        assert_eq!(
+            advisor_https_probe_url("ws://localhost:8080/v1/agent").as_deref(),
+            Some("http://localhost:8080/ttft")
+        );
+        // Port is carried through; a bare authority (no path) works too.
+        assert_eq!(
+            advisor_https_probe_url("wss://advisor.cocore.dev:8443").as_deref(),
+            Some("https://advisor.cocore.dev:8443/ttft")
+        );
+        // Unrecognizable inputs probe nothing rather than a fabricated URL.
+        assert_eq!(advisor_https_probe_url("advisor.cocore.dev"), None);
+        assert_eq!(advisor_https_probe_url("ftp://x"), None);
+        assert_eq!(advisor_https_probe_url("wss:///path-only"), None);
+    }
+
+    #[test]
+    fn classify_connect_io_error_covers_the_field_failures() {
+        use std::io::{Error, ErrorKind};
+        assert_eq!(
+            classify_connect_io_error(&Error::new(ErrorKind::TimedOut, "t")),
+            "connect-timeout"
+        );
+        assert_eq!(
+            classify_connect_io_error(&Error::new(ErrorKind::ConnectionRefused, "r")),
+            "connect-refused"
+        );
+        // macOS getaddrinfo failure has no dedicated kind — sniffed from the
+        // message ("nodename nor servname provided, or not known").
+        assert_eq!(
+            classify_connect_io_error(&Error::other(
+                "failed to lookup address information: nodename nor servname provided"
+            )),
+            "dns-failure"
+        );
+        assert_eq!(
+            classify_connect_io_error(&Error::other("Network is unreachable (os error 51)")),
+            "network-unreachable"
+        );
+        assert_eq!(
+            classify_connect_io_error(&Error::other("something else entirely")),
+            "io-error"
+        );
+    }
+
+    #[test]
+    fn build_advisor_fault_folds_the_https_probe_into_the_code() {
+        // HTTPS works but the WS connect keeps timing out / being reset →
+        // a middlebox is filtering WebSockets specifically.
+        for base in ["connect-timeout", "connection-reset", "ws-handshake-failed"] {
+            let f = build_advisor_fault(base, true);
+            assert_eq!(f.code, "upgrade-blocked", "base {base}");
+            assert!(f.message.contains("WebSocket"));
+        }
+        // A real HTTP answer to the upgrade keeps its status-carrying code.
+        assert_eq!(build_advisor_fault("http-503", true).code, "http-503");
+        // TLS failure stays TLS regardless of the probe (interception vs. broken).
+        assert_eq!(build_advisor_fault("tls-failure", true).code, "tls-failure");
+        assert_eq!(
+            build_advisor_fault("tls-failure", false).code,
+            "tls-failure"
+        );
+        // Probe also failing keeps the network-level base classification.
+        assert_eq!(
+            build_advisor_fault("dns-failure", false).code,
+            "dns-failure"
+        );
+        assert_eq!(
+            build_advisor_fault("connect-timeout", false).code,
+            "connect-timeout"
+        );
+        // Unknown base codes pass through (fail open to a generic message).
+        assert_eq!(build_advisor_fault("io-error", false).code, "io-error");
+        // Content safety: no message ever carries a URL or raw error text.
+        for (base, probe) in [("connect-timeout", true), ("dns-failure", false)] {
+            let f = build_advisor_fault(base, probe);
+            assert!(
+                !f.message.contains("://"),
+                "message leaks a URL: {}",
+                f.message
+            );
+        }
     }
 
     #[test]

--- a/provider/src/error.rs
+++ b/provider/src/error.rs
@@ -8,6 +8,15 @@ pub enum ProviderError {
     AttestationStale,
     #[error("advisor: {0}")]
     Advisor(String),
+    /// The advisor WebSocket never came up — the Register frame never
+    /// reached the advisor. Distinct from [`ProviderError::Advisor`] (which
+    /// also covers post-connect drops) so the serve loop can count
+    /// consecutive CONNECT failures and publish an `advisorFault` on the
+    /// provider record. `code` is the machine-readable class the fault
+    /// publishes (e.g. `dns-failure`, `connect-timeout`); `detail` is for
+    /// local logs only and never leaves the machine.
+    #[error("advisor connect ({code}): {detail}")]
+    AdvisorConnect { code: String, detail: String },
     #[error("pds: {0}")]
     Pds(String),
     #[error("io: {0}")]

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -850,6 +850,114 @@ async fn dedup_and_publish_provider(
         .unwrap_or_else(|| anyhow::anyhow!("provider record publish exhausted retries")))
 }
 
+/// Consecutive advisor CONNECT failures before the agent publishes an
+/// `advisorFault` on its provider record. One or two failed attempts are
+/// routine (a sleeping laptop, a deploy); three in a row with no successful
+/// registration in between means the machine is durably cut off from the
+/// network while looking healthy everywhere else.
+const ADVISOR_FAULT_THRESHOLD: u32 = 3;
+
+/// Once past the threshold with a publish still outstanding (the patch
+/// itself failed — e.g. the console proxy blipped), retry it every this
+/// many further failures rather than on each ~5–30s reconnect attempt.
+const ADVISOR_FAULT_PUBLISH_RETRY_EVERY: u32 = 10;
+
+/// Tracks consecutive advisor CONNECT failures — the WebSocket never came
+/// up, so the Register frame never reached the advisor — and reflects them
+/// onto the provider record's `advisorFault` field. This is the remote
+/// diagnosability for the "serving locally, invisible on the network"
+/// failure: the WS is blocked but the record write path (console proxy over
+/// plain HTTPS) still works, so the fault is the one trace an operator can
+/// see. The fault is cleared by `AdvisorClient::run` on the next successful
+/// registration; this tracker only ever sets it.
+struct AdvisorFaultTracker {
+    consecutive: u32,
+    /// Fault code currently on the PDS record as far as this process knows,
+    /// so an unchanged classification isn't re-published every retry.
+    published_code: Option<String>,
+    /// Base classification of the previous failure, to detect a changed
+    /// cause (e.g. dns-failure → connect-timeout) past the threshold.
+    last_base_code: Option<String>,
+}
+
+impl AdvisorFaultTracker {
+    fn new() -> Self {
+        Self {
+            consecutive: 0,
+            published_code: None,
+            last_base_code: None,
+        }
+    }
+
+    /// The connection came up (or the failure wasn't a connect failure —
+    /// registration succeeded, so `run` already cleared any fault).
+    fn reset(&mut self) {
+        self.consecutive = 0;
+        self.published_code = None;
+        self.last_base_code = None;
+    }
+
+    /// Feed one serve-loop error. Counts only classified CONNECT failures;
+    /// past the threshold it probes the advisor's plain-HTTPS surface to
+    /// separate "WebSockets are filtered on this network" from "the advisor
+    /// is unreachable outright", folds that into the classification, and
+    /// CAS-patches the fault onto the provider record.
+    async fn on_serve_error(
+        &mut self,
+        e: &cocore_provider::error::ProviderError,
+        pds: &PdsClient,
+        provider_rkey: Option<&str>,
+        advisor_url: &str,
+    ) {
+        let cocore_provider::error::ProviderError::AdvisorConnect { code, .. } = e else {
+            // The socket connected (a post-register drop, a policy error, …)
+            // — the advisor path works, so this is not an advisor fault.
+            self.reset();
+            return;
+        };
+        self.consecutive += 1;
+        let crossed = self.consecutive == ADVISOR_FAULT_THRESHOLD;
+        let cause_changed = self.consecutive > ADVISOR_FAULT_THRESHOLD
+            && self.last_base_code.as_deref() != Some(code);
+        let publish_retry = self.consecutive > ADVISOR_FAULT_THRESHOLD
+            && self.published_code.is_none()
+            && self
+                .consecutive
+                .is_multiple_of(ADVISOR_FAULT_PUBLISH_RETRY_EVERY);
+        self.last_base_code = Some(code.clone());
+        if !(crossed || cause_changed || publish_retry) {
+            return;
+        }
+        let Some(rkey) = provider_rkey else {
+            tracing::warn!(
+                consecutive = self.consecutive,
+                code = %code,
+                "advisor unreachable but no provider rkey; cannot publish advisorFault"
+            );
+            return;
+        };
+        let https_ok = cocore_provider::advisor::probe_advisor_https(advisor_url).await;
+        let fault = cocore_provider::advisor::build_advisor_fault(code, https_ok);
+        if self.published_code.as_deref() == Some(fault.code.as_str()) {
+            return;
+        }
+        tracing::warn!(
+            consecutive = self.consecutive,
+            code = %fault.code,
+            https_reachable = https_ok,
+            "advisor unreachable; publishing advisorFault on provider record"
+        );
+        let publish = pds.patch_provider_advisor_fault(rkey, Some(&fault));
+        match tokio::time::timeout(std::time::Duration::from_secs(15), publish).await {
+            Ok(Ok(_)) => self.published_code = Some(fault.code),
+            Ok(Err(e)) => {
+                tracing::warn!(error = %e, "failed to publish advisorFault; will retry")
+            }
+            Err(_) => tracing::warn!("advisorFault publish timed out; will retry"),
+        }
+    }
+}
+
 /// `~/.cocore/serving-paused` — present while the owner has this machine
 /// stopped from the console. The menu-bar app polls for it to show the
 /// machine as paused (vs. the local "serving" state, which only tracks
@@ -1894,6 +2002,10 @@ async fn cmd_serve(
                 // machines available"). Only a connection that fails QUICKLY,
                 // repeatedly, still earns the growing backoff.
                 const HEALTHY_UPTIME: std::time::Duration = std::time::Duration::from_secs(30);
+                // Publishes `advisorFault` after repeated connect failures so
+                // a machine the network never hears from is still diagnosable
+                // from the console; `run` clears it on the next registration.
+                let mut advisor_fault = AdvisorFaultTracker::new();
                 loop {
                     // Honour a remote stop: if the owner stopped this machine
                     // from the console, don't (re)connect — poll until they
@@ -1922,6 +2034,7 @@ async fn cmd_serve(
                     match result {
                         Ok(()) => {
                             // Advisor closed cleanly (e.g. deploy); rejoin shortly.
+                            advisor_fault.reset();
                             backoff = std::time::Duration::from_secs(1);
                             tokio::time::sleep(std::time::Duration::from_secs(2)).await;
                         }
@@ -1929,12 +2042,16 @@ async fn cmd_serve(
                             // Dropped after a healthy run — reconnect promptly
                             // and reset the backoff rather than penalising a
                             // connection that was working.
+                            advisor_fault.reset();
                             tracing::warn!(lived_s = lived.as_secs(), "advisor connection dropped after healthy uptime; reconnecting promptly");
                             backoff = std::time::Duration::from_secs(1);
                             tokio::time::sleep(std::time::Duration::from_secs(1)).await;
                         }
                         Err(e) => {
                             tracing::warn!(error = %e, lived_s = lived.as_secs(), backoff_s = backoff.as_secs(), "advisor connection dropped; reconnecting");
+                            advisor_fault
+                                .on_serve_error(&e, &pds, provider_rkey.as_deref(), advisor_url)
+                                .await;
                             tokio::time::sleep(backoff).await;
                             backoff = (backoff * 2).min(std::time::Duration::from_secs(30));
                         }
@@ -1953,6 +2070,10 @@ async fn cmd_serve(
                 // on the first in-window run; free them while idle and
                 // rebuild on the next open. `None` == freed/idle.
                 let mut current = Some(engines);
+                // Same advisor-unreachable diagnosability as the continuous
+                // branch: repeated in-window connect failures publish an
+                // `advisorFault`; registration clears it.
+                let mut advisor_fault = AdvisorFaultTracker::new();
                 loop {
                     if window.contains_now() {
                         // Remote stop overrides the schedule window too.
@@ -1977,8 +2098,14 @@ async fn cmd_serve(
                         let client = AdvisorClient::new(advisor_url);
                         tokio::select! {
                             res = client.run(register.clone(), &*signer, &enc, &pds, attestation.clone(), &eng, provider_rkey.as_deref(), &desired_at_start, desired_tier_at_start.as_deref(), &model_schedules, &configured_models, push_rx.as_mut(), &pro_bono_at_start, tool_calls_at_start) => {
-                                if let Err(e) = res {
-                                    tracing::warn!(error = %e, "advisor run ended; reconnecting within window in 5s");
+                                match &res {
+                                    Ok(()) => advisor_fault.reset(),
+                                    Err(e) => {
+                                        tracing::warn!(error = %e, "advisor run ended; reconnecting within window in 5s");
+                                        advisor_fault
+                                            .on_serve_error(e, &pds, provider_rkey.as_deref(), advisor_url)
+                                            .await;
+                                    }
                                 }
                                 // Connection ended on its own but the window
                                 // is still open — keep engines, reconnect soon.
@@ -3668,6 +3795,32 @@ mod offline_marker_tests {
             merged.get("someFutureOwnerToggle"),
             Some(&serde_json::json!({ "nested": [1, 2, 3] })),
             "an unknown field must survive an agent re-publish"
+        );
+    }
+
+    /// `advisorFault` is deliberately NOT a `ProviderRecord` field (it is
+    /// written with the field-scoped `patch_provider_advisor_fault`), so a
+    /// full agent re-publish — the offline marker, the attestation-refresh
+    /// republish — must carry a live fault through untouched rather than
+    /// wiping the one trace of an advisor-unreachable machine.
+    #[test]
+    fn merge_preserves_a_published_advisor_fault() {
+        let republished = agent_built_record();
+        let live = serde_json::json!({
+            "active": true,
+            "advisorFault": {
+                "code": "upgrade-blocked",
+                "message": "WebSocket connections are being filtered on this network.",
+                "observedAt": "2026-07-04T01:52:00Z"
+            }
+        });
+
+        let merged = merge_agent_provider_fields(&live, &republished);
+
+        assert_eq!(
+            merged.get("advisorFault"),
+            live.get("advisorFault"),
+            "a full agent re-publish must not clobber the advisorFault"
         );
     }
 

--- a/provider/src/pds.rs
+++ b/provider/src/pds.rs
@@ -374,6 +374,46 @@ pub struct AttestationFault {
     pub at: chrono::DateTime<chrono::Utc>,
 }
 
+/// A content-safe description of why the advisor WebSocket cannot be
+/// established. Published on the provider record (mirroring [`EngineFault`] /
+/// [`AttestationFault`]) so the console can show "serving locally but can't
+/// reach the network" instead of a healthy-looking machine that silently
+/// never receives jobs. Written through the console's HTTPS proxy — exactly
+/// the transport that still works in the failure this diagnoses — and
+/// cleared on the next successful advisor registration.
+///
+/// Deliberately NOT a field on [`ProviderRecord`]: it changes mid-serve (set
+/// after repeated connect failures, cleared on registration), so it is
+/// written with the field-scoped [`PdsClient::patch_provider_advisor_fault`]
+/// rather than the whole-record merge — a full re-publish (offline marker,
+/// attestation refresh) carries it through untouched as an unknown key.
+#[allow(non_snake_case)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct AdvisorFault {
+    /// Machine-readable fault class: `dns-failure`, `tls-failure`,
+    /// `connect-timeout`, `connect-refused`, `upgrade-blocked`,
+    /// `http-<status>`, `network-unreachable`, … (see the lexicon).
+    pub code: String,
+    /// Human-readable summary with remediation guidance. Carries only the
+    /// classified error kind — never raw error text, URLs, or credentials.
+    pub message: String,
+    /// When the agent recorded the fault.
+    pub observedAt: chrono::DateTime<chrono::Utc>,
+}
+
+/// Whether this process may have an `advisorFault` published on its provider
+/// record (or one left over from a previous process). Starts true so the
+/// first successful registration after boot checks the record once and
+/// removes any stale fault; [`PdsClient::patch_provider_advisor_fault`]
+/// keeps it in sync afterwards, so subsequent reconnects skip the read
+/// entirely instead of hitting the PDS every ~14-minute edge recycle.
+static ADVISOR_FAULT_MAYBE_PUBLISHED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(true);
+
+pub fn advisor_fault_maybe_published() -> bool {
+    ADVISOR_FAULT_MAYBE_PUBLISHED.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 #[allow(non_snake_case)]
 #[derive(Debug, Serialize, Clone)]
 pub struct ModelPrice {
@@ -701,6 +741,89 @@ impl PdsClient {
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
         Some((active, desired, desired_tier, tool_calls))
+    }
+
+    /// Field-scoped patch of this machine's provider record: set (or, with
+    /// `None`, remove) ONLY the `advisorFault` key, leaving every other field
+    /// exactly as read. The record-transactor rule in miniature — read the
+    /// LATEST record, patch one field, put under a compare-and-swap guard,
+    /// re-read and replay on a swap conflict — so a concurrent owner edit or
+    /// agent re-publish is never clobbered. Skips the write entirely (and
+    /// returns `Ok(false)`) when the record already carries the desired
+    /// state, so the serve loop's retries don't spam the PDS with no-op
+    /// commits. Fails closed: an unreadable record aborts rather than
+    /// fabricating a body.
+    ///
+    /// Returns whether a write actually happened. Keeps the process-wide
+    /// [`advisor_fault_maybe_published`] marker in sync on success.
+    pub async fn patch_provider_advisor_fault(
+        &self,
+        rkey: &str,
+        fault: Option<&AdvisorFault>,
+    ) -> Result<bool> {
+        const MAX_ATTEMPTS: u32 = 4;
+        let collection = "dev.cocore.compute.provider";
+        for attempt in 1..=MAX_ATTEMPTS {
+            let listed = self.list_my_records(collection).await?;
+            let Some(rec) = listed
+                .iter()
+                .find(|r| r.uri.rsplit('/').next() == Some(rkey))
+            else {
+                return Err(ProviderError::Pds(format!(
+                    "provider record {rkey} not found; cannot patch advisorFault"
+                )));
+            };
+            let existing = rec.value.get("advisorFault");
+            // Compare by code only: the message is deterministic per code and
+            // observedAt changes every classification, so keying on it would
+            // defeat the dedup and rewrite the record on every retry.
+            let existing_code = existing
+                .and_then(|f| f.get("code"))
+                .and_then(|c| c.as_str());
+            let unchanged = match fault {
+                Some(f) => existing_code == Some(f.code.as_str()),
+                None => existing.is_none(),
+            };
+            if unchanged {
+                ADVISOR_FAULT_MAYBE_PUBLISHED
+                    .store(fault.is_some(), std::sync::atomic::Ordering::Relaxed);
+                return Ok(false);
+            }
+            let mut body = rec.value.as_object().cloned().unwrap_or_default();
+            match fault {
+                Some(f) => {
+                    let v = serde_json::to_value(f)
+                        .map_err(|e| ProviderError::Pds(format!("encode advisorFault: {e}")))?;
+                    body.insert("advisorFault".to_string(), v);
+                }
+                None => {
+                    body.remove("advisorFault");
+                }
+            }
+            let patched = serde_json::Value::Object(body);
+            match self
+                .put_record(collection, rkey, &patched, Some(&rec.cid))
+                .await
+            {
+                Ok(_) => {
+                    ADVISOR_FAULT_MAYBE_PUBLISHED
+                        .store(fault.is_some(), std::sync::atomic::Ordering::Relaxed);
+                    return Ok(true);
+                }
+                Err(ProviderError::Pds(msg))
+                    if msg.contains("InvalidSwap") && attempt < MAX_ATTEMPTS =>
+                {
+                    // Someone committed between our read and put — re-read the
+                    // now-current record and replay the patch on top of it.
+                    tracing::debug!(attempt, "advisorFault patch swap conflict; retrying");
+                    tokio::time::sleep(std::time::Duration::from_millis(50 * attempt as u64)).await;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        Err(ProviderError::Pds(
+            "advisorFault patch exhausted swap retries".to_string(),
+        ))
     }
 
     /// Walk the DID PLC directory to find this DID's PDS host. The


### PR DESCRIPTION
## Why

Field failure (2026-07-04, did:plc:lltrbh5br76ebkrg7r5gr4pg): an agent on 0.9.40 provisioned its models and published a healthy provider record (`serving: true`, no faults), but its WebSocket to `wss://advisor.cocore.dev/v1/agent` never arrived — no register, no rejection, no orphan open in advisor logs. The agent retries the connect forever, the failure is completely invisible remotely, and the console showed the machine as fine — so the operator reasonably blamed onboarding.

The one transport this incident proved still works is the console's HTTPS record-write proxy. This PR uses it to make the failure visible.

## What

**Lexicon (additive, commit-ordered first):** optional `advisorFault { code, message, observedAt }` on `dev.cocore.compute.provider`, mirroring `engineFault`/`attestationFault`. Known codes: `dns-failure`, `tls-failure`, `connect-timeout`, `connect-refused`, `upgrade-blocked`, `http-<status>`, `network-unreachable`, `closed-<code>`; unknown codes read as a generic advisor-unreachable fault. `types.gen.ts` regenerated.

**Provider agent:**
- Connect-phase failures return a classified `ProviderError::AdvisorConnect` (the Register frame never reached the advisor) instead of a stringly error.
- After 3 consecutive connect failures, the serve loop probes `https://advisor…/ttft` over plain HTTPS: probe OK + WS failing folds to `upgrade-blocked` (a middlebox is filtering WebSockets); probe failing keeps the network-level classification.
- The fault is written with a field-scoped CAS patch (record-transactor rule: read latest → patch only `advisorFault` → put under swap guard → replay on conflict), so it can never clobber owner intent. It is deliberately NOT a `ProviderRecord` field, so full agent re-publishes (offline marker, attestation refresh) carry it through untouched as an unknown key — covered by a merge test.
- A successful registration clears it, spawned off the hot serve loop; an atomic maybe-published marker makes the routine ~14-minute edge-recycle reconnects a no-op (not even a read).
- Fault messages are fixed content-safe templates — classified error kind + remediation only, never raw error text, URLs, or credentials (asserted in tests).

**Console:**
- `advisorFault` parsed onto `Machine`; `advisorUnreachable()` = fault present and/or `serving` on PDS but absent from the advisor `/providers` join the machines surface already does. A live advisor connection outranks a stale fault; no claim is made for paused/offline/provisioning machines or when live standing is unavailable with no agent-reported fault.
- "on network / not reachable" `NetworkStandingBadge` on the fleet table, fleet cards, and machine detail header.
- Explicit "Serving locally — can't reach the co/core network" state: row/card status text plus a warning alert (fleet drawer + detail page) with the fault code, observed-at, and VPN / firewall / WebSocket-filtering troubleshooting copy.
- `/api/agent.status` mirrors `advisorFault` alongside `attestationFault` so the tray can surface it too.

Even before agents update to a release with this change, the advisor-join half already flags a machine in this state ("not reachable", generic copy); the fault code + remediation detail arrives once the fleet updates.

## Test plan

- `cargo test` — 226 pass (new: connect-error classifier, probe-URL derivation, probe-folding incl. content-safety assertions, merge-preserves-advisorFault); `cargo clippy --all-targets` and `cargo fmt --check` clean.
- Console: `machines.server.test.ts` 32/32 (new cases: fault mapping, message-required tolerance, the exact field-failure shape — serving on PDS + absent from advisor, stale-fault-vs-live-connection, no-claim states); typecheck, oxlint, oxfmt, and production build clean. (The 3 sqlite-backed test files fail locally on Node 26 — the known better-sqlite3 ABI issue, unrelated; CI runs Node 22.)
- `make lex-validate`, `make lex-codegen-check`, SDK tests 125/125.

## After merge

- Re-publish lexicons (`scripts/publish-lexicons.sh`) so the schema record under cocore.dev's DID includes the new field.
- Cut an agent/tray release — the provider half only reaches the field once machines run the new binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)