### PR TITLE
fix: stop showing live machines as "not reachable" when the boot publish fails

### DIFF
--- a/packages/console/src/components/machines/machines-data.ts
+++ b/packages/console/src/components/machines/machines-data.ts
@@ -39,6 +39,14 @@ export function machineStatusText(m: {
 
 export interface Machine {
   id: string;
+  /** The machine's Secure-Enclave attestation pubkey from its provider
+   *  record. This is the machine's identity that does NOT depend on a
+   *  successful boot-time PDS publish: when the agent couldn't publish
+   *  (dead session → no rkey to echo), it registers with the advisor
+   *  without a `machine_id` and the advisor keys it by this pubkey
+   *  instead. The advisor-standing join falls back to it so such a
+   *  machine still reads as connected. */
+  attestationPubKey?: string;
   alias: string;
   state: MachineState;
   gpu: string;

--- a/packages/console/src/components/machines/machines.server.test.ts
+++ b/packages/console/src/components/machines/machines.server.test.ts
@@ -477,6 +477,65 @@ test("advisorUnreachable: serving on PDS but absent from the advisor ⇒ unreach
   assert.equal(machineNetworkStanding(m!), "not-reachable");
 });
 
+test("applyAdvisorStanding joins by attestation pubkey when the advisor has no rkey (dead-session agent)", () => {
+  // An agent whose PDS session died can't publish at boot, so it registers
+  // with no machine_id and the advisor keys it by its attestation pubkey.
+  // The machine is LIVE on the network — the pubkey fallback must find it.
+  const pubkey = "BFakeUncompressedP256PointBase64==";
+  const machines = [{ ...machineStub("rkey-mini"), attestationPubKey: pubkey }];
+  const [m] = applyAdvisorStanding(machines, {
+    reachable: true,
+    byMachineId: new Map([
+      [
+        pubkey,
+        {
+          unhealthy: false,
+          unhealthyReason: null,
+          silentFailure: false,
+          verifiedTier: "attested-confidential" as const,
+        },
+      ],
+    ]),
+  });
+  assert.equal(m!.standingKnown, true);
+  assert.equal(m!.advisorConnected, true);
+  assert.equal(m!.verifiedTier, "attested-confidential");
+  assert.equal(advisorUnreachable(m!), false);
+  assert.equal(machineNetworkStanding(m!), "on-network");
+});
+
+test("applyAdvisorStanding prefers the rkey join over the pubkey fallback", () => {
+  // Same machine present under BOTH keys (e.g. a race across reconnects):
+  // the rkey entry is the agent's own claim of identity — it wins.
+  const pubkey = "BFakeUncompressedP256PointBase64==";
+  const entry = (reason: string) => ({
+    unhealthy: true,
+    unhealthyReason: reason,
+    silentFailure: false,
+    verifiedTier: "best-effort" as const,
+  });
+  const machines = [{ ...machineStub("rkey-mini"), attestationPubKey: pubkey }];
+  const [m] = applyAdvisorStanding(machines, {
+    reachable: true,
+    byMachineId: new Map([
+      ["rkey-mini", entry("via-rkey")],
+      [pubkey, entry("via-pubkey")],
+    ]),
+  });
+  assert.equal(m!.unhealthyReason, "via-rkey");
+});
+
+test("providerRowsToMachines carries the record's attestationPubKey onto the machine", () => {
+  const withKey = providerRowsToMachines(
+    [providerRow({ attestationPubKey: "BSomeKey==" })],
+    ZERO_STATS,
+    new Map(),
+  )[0]!;
+  assert.equal(withKey.attestationPubKey, "BSomeKey==");
+  const withoutKey = providerRowsToMachines([providerRow({})], ZERO_STATS, new Map())[0]!;
+  assert.equal(withoutKey.attestationPubKey, undefined);
+});
+
 test("advisorUnreachable: a live advisor connection outranks a stale fault", () => {
   const machines = [
     {

--- a/packages/console/src/components/machines/machines.server.ts
+++ b/packages/console/src/components/machines/machines.server.ts
@@ -60,6 +60,7 @@ type ProviderRecordBody = {
   region?: string;
   proBono?: { mode?: string; dids?: string[] };
   toolCalls?: boolean;
+  attestationPubKey?: string;
 };
 
 type ReceiptRecordBody = {
@@ -114,6 +115,10 @@ function parseProviderBody(body: unknown): ProviderRecordBody {
     region: typeof o.region === "string" ? o.region : undefined,
     proBono: parseProBono(o.proBono),
     toolCalls: typeof o.toolCalls === "boolean" ? o.toolCalls : undefined,
+    attestationPubKey:
+      typeof o.attestationPubKey === "string" && o.attestationPubKey.length > 0
+        ? o.attestationPubKey
+        : undefined,
   };
 }
 
@@ -585,10 +590,14 @@ export async function fetchAdvisorStanding(did: string): Promise<AdvisorStanding
 }
 
 /** Overlay live advisor standing onto machines built from PDS records. The
- *  join is by machineId == provider-record rkey == {@link Machine.id}. When
- *  the advisor was unreachable, `standingKnown` is false on every machine and
- *  no unhealthy/connected claim is made (correctness over a fabricated
- *  green). */
+ *  join is by machineId == provider-record rkey == {@link Machine.id}, with a
+ *  fallback on the record's `attestationPubKey`: an agent that couldn't
+ *  publish its provider record at boot (dead PDS session) registers without
+ *  a `machine_id`, and the advisor then keys it by its attestation pubkey —
+ *  the machine is live on the network, so it must not read "not reachable".
+ *  When the advisor was unreachable, `standingKnown` is false on every
+ *  machine and no unhealthy/connected claim is made (correctness over a
+ *  fabricated green). */
 export function applyAdvisorStanding(
   machines: Machine[],
   standing: AdvisorStandingResult,
@@ -597,7 +606,9 @@ export function applyAdvisorStanding(
     if (!standing.reachable) {
       return { ...m, standingKnown: false };
     }
-    const s = standing.byMachineId.get(m.id);
+    const s =
+      standing.byMachineId.get(m.id) ??
+      (m.attestationPubKey ? standing.byMachineId.get(m.attestationPubKey) : undefined);
     return {
       ...m,
       standingKnown: true,
@@ -701,6 +712,7 @@ export function providerRowsToMachines(
 
     const base: Machine = {
       id: row.rkey,
+      attestationPubKey: body.attestationPubKey,
       alias: body.machineLabel?.trim() || row.rkey,
       state: machineStateFromProvider(body, recentlyActive),
       gpu: chip,

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -742,6 +742,54 @@ fn kickstart_launchagent_if_installed() {
 // owner-intent fields AND any unknown/future field are preserved by default, so
 // a new owner setting can't be silently clobbered by an agent write.
 
+/// `~/.cocore/provider-rkey.json` — the rkey of the provider record this
+/// machine last successfully published, scoped to the identity that
+/// published it. The rkey doubles as the advisor's `machine_id` (the join
+/// key the console uses to overlay live standing), so a boot where the
+/// publish fails — most commonly a dead PDS session that 401s every write —
+/// must still register under the SAME stable id instead of falling back to
+/// an anonymous pubkey slot the console can't join. The cache is only
+/// honored when both the DID and the attestation pubkey match the current
+/// identity: a re-pair under a different account or a re-keyed enclave
+/// invalidates it rather than resurrecting a foreign rkey.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct CachedProviderRkey {
+    did: String,
+    attestation_pub_key: String,
+    rkey: String,
+}
+
+fn provider_rkey_cache_path() -> Option<std::path::PathBuf> {
+    dirs::home_dir().map(|h| h.join(".cocore").join("provider-rkey.json"))
+}
+
+/// Best-effort: never blocks or fails the serve path.
+fn cache_provider_rkey(did: &str, attestation_pub_key: &str, rkey: &str) {
+    let Some(path) = provider_rkey_cache_path() else {
+        return;
+    };
+    let entry = CachedProviderRkey {
+        did: did.to_string(),
+        attestation_pub_key: attestation_pub_key.to_string(),
+        rkey: rkey.to_string(),
+    };
+    if let Ok(json) = serde_json::to_string(&entry) {
+        let _ = std::fs::write(path, json);
+    }
+}
+
+fn cached_provider_rkey(did: &str, attestation_pub_key: &str) -> Option<String> {
+    let raw = std::fs::read_to_string(provider_rkey_cache_path()?).ok()?;
+    parse_cached_provider_rkey(&raw, did, attestation_pub_key)
+}
+
+/// Honor the cache only for the exact identity that wrote it; anything
+/// else (foreign DID, re-keyed enclave, corrupt file) reads as no cache.
+fn parse_cached_provider_rkey(raw: &str, did: &str, attestation_pub_key: &str) -> Option<String> {
+    let entry: CachedProviderRkey = serde_json::from_str(raw).ok()?;
+    (entry.did == did && entry.attestation_pub_key == attestation_pub_key).then_some(entry.rkey)
+}
+
 /// Find this machine's existing provider record (if any) on the
 /// user's PDS by matching `attestationPubKey`, delete any other
 /// records that share the same key (they're stale duplicates), and
@@ -1837,11 +1885,30 @@ async fn cmd_serve(
                 deleted,
                 "published provider record (dedup-and-upsert)"
             );
-            published.uri.rsplit('/').next().map(|s| s.to_string())
+            let rkey = published.uri.rsplit('/').next().map(|s| s.to_string());
+            if let Some(r) = &rkey {
+                cache_provider_rkey(&session.did, &attestation_pub_key, r);
+            }
+            rkey
         }
         Err(e) => {
-            tracing::warn!(error = %e, "failed to publish provider record; machine will not appear on the console");
-            None
+            // Fall back to the rkey cached on the last successful publish so
+            // the advisor Register still carries our stable `machine_id` —
+            // otherwise the console can't join live standing onto the record
+            // and shows a healthy, connected machine as "not reachable".
+            let cached = cached_provider_rkey(&session.did, &attestation_pub_key);
+            match &cached {
+                Some(r) => tracing::warn!(
+                    error = %e,
+                    rkey = %r,
+                    "failed to publish provider record; registering with the cached rkey (record may be stale on the console)"
+                ),
+                None => tracing::warn!(
+                    error = %e,
+                    "failed to publish provider record; machine will not appear on the console"
+                ),
+            }
+            cached
         }
     };
 
@@ -3653,6 +3720,57 @@ mod active_gate_tests {
         let mut paused = false;
         assert_eq!(active_gate_decision(None, &mut paused), ActiveGate::Serve);
         assert!(!paused);
+    }
+}
+
+#[cfg(test)]
+mod provider_rkey_cache_tests {
+    use super::parse_cached_provider_rkey;
+
+    const RAW: &str =
+        r#"{"did":"did:plc:alice","attestation_pub_key":"BKey==","rkey":"3mov7tbvvns2m"}"#;
+
+    #[test]
+    fn matching_identity_returns_the_cached_rkey() {
+        assert_eq!(
+            parse_cached_provider_rkey(RAW, "did:plc:alice", "BKey=="),
+            Some("3mov7tbvvns2m".to_string())
+        );
+    }
+
+    #[test]
+    fn a_foreign_did_never_resurrects_the_rkey() {
+        // Re-paired under a different account: the old record isn't ours to
+        // impersonate on the advisor.
+        assert_eq!(
+            parse_cached_provider_rkey(RAW, "did:plc:bob", "BKey=="),
+            None
+        );
+    }
+
+    #[test]
+    fn a_rekeyed_enclave_invalidates_the_cache() {
+        assert_eq!(
+            parse_cached_provider_rkey(RAW, "did:plc:alice", "BOtherKey=="),
+            None
+        );
+    }
+
+    #[test]
+    fn garbage_or_legacy_content_reads_as_no_cache() {
+        assert_eq!(
+            parse_cached_provider_rkey("not json", "did:plc:alice", "BKey=="),
+            None
+        );
+        assert_eq!(
+            parse_cached_provider_rkey("", "did:plc:alice", "BKey=="),
+            None
+        );
+        // A bare rkey from a hypothetical older format is ignored, not trusted.
+        assert_eq!(
+            parse_cached_provider_rkey("\"3mov7tbvvns2m\"", "did:plc:alice", "BKey=="),
+            None
+        );
     }
 }
 


### PR DESCRIPTION
## Problem

A machine whose agent can't write to its PDS at boot (dead OAuth session → `401 AuthRequired` on every write, the known two-client refresh-token cannibalization) registers with the advisor **without a `machine_id`**: `dedup_and_publish_provider` fails, so there's no rkey to echo. The advisor falls back to keying the machine by its attestation pubkey — but the console joins live standing by `machineId == provider-record rkey`, so the join misses and a machine that is **live, healthy, and serving jobs** shows the "Serving locally — can't reach the co/core network" banner, pointing operators at VPN/firewall causes that don't exist. The tray correctly shows nothing wrong, which makes the console look broken.

Observed in production 2026-07-04: `Mac Mini 1` and two other 0.9.41 machines live on `advisor.cocore.dev/providers` with 88-char base64 `machineId`s (the pubkey fallback) while their console pages claimed they were unreachable.

## Fix (two independent halves)

**Console (deployable immediately, no agent release):** the advisor's fallback key *is* the record's `attestationPubKey`, so carry it onto `Machine` and fall back to it in `applyAdvisorStanding` when the rkey lookup misses. This also fixes pre-`machine_id` agents, which have always been keyed by pubkey. The rkey join still wins when both are present.

**Provider (belt-and-suspenders, ships with the next agent release):** persist the rkey to `~/.cocore/provider-rkey.json` on every successful publish, scoped to `(did, attestationPubKey)`, and register with the cached rkey when the boot publish fails. The cache is honored only for the exact identity that wrote it — a re-pair under another DID or a re-keyed enclave invalidates it rather than resurrecting a foreign rkey.

## Not fixed here (follow-ups)

- The root cause (session cannibalization): finish the AppView single-session-owner cutover — `pdsGetServiceAuth` and the other console session users still refresh in the console process.
- Tray surfacing of the dead-session state (`needsReauth`), so 196 silent 401s can't happen again.

## Tests

- `machines.server.test.ts`: pubkey-fallback join, rkey-precedence, and `attestationPubKey` carry-through (35 pass).
- `provider_rkey_cache_tests`: identity-scoped cache honor/invalidate/garbage cases (4 pass; full provider suite green).
- rustfmt, clippy, oxfmt, oxlint, tsc all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)