### PR TITLE
fix(confidential): survive a stale agent session instead of silently stalling

### DIFF
--- a/packages/appview/src/api/agent-status.test.ts
+++ b/packages/appview/src/api/agent-status.test.ts
@@ -1,6 +1,8 @@
 import { test } from "vitest";
 import assert from "node:assert/strict";
 import { mkdtempSync } from "node:fs";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Store } from "../store.ts";
@@ -9,6 +11,37 @@ import { buildAppviewApp } from "./server.ts";
 import { withAppviewServer } from "./http-app.ts";
 
 const APPVIEW_DID = "did:web:appview.test";
+
+/** Stand up a stub advisor whose `/providers` returns `rows`, run `fn` with its
+ *  base URL, then tear it down. Mirrors the real advisor's response shape. */
+async function withStubAdvisor(
+  rows: unknown[],
+  fn: (advisorUrl: string) => Promise<void>,
+): Promise<void> {
+  const server = createServer((req, res) => {
+    if (req.url?.startsWith("/providers")) {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(rows));
+    } else {
+      res.writeHead(404);
+      res.end();
+    }
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  try {
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+interface ConfidentialStatusBody {
+  confidentialVerified: boolean;
+  confidentialDesired: boolean;
+  confidentialBlockedReason: string | null;
+  needsReauth: boolean;
+}
 
 function setup(): { store: Store; accountStore: AccountStore } {
   const dir = mkdtempSync(join(tmpdir(), "cocore-agent-status-"));
@@ -80,6 +113,98 @@ test("GET /api/agent/status: resolves an AppView-minted key and reports provider
       assert.equal(body.balance, null);
     },
   );
+});
+
+test("confidential-desired machine registered unauthenticated ⇒ 'sign in again', not 'not connected'", async () => {
+  const { store, accountStore } = setup();
+  const did = "did:plc:reauth";
+  const { secret } = accountStore.createKey({ did, name: "The Cauldron" });
+  // Owner opted into confidential (desiredTier on the provider record).
+  store.upsert({
+    uri: `at://${did}/dev.cocore.compute.provider/m1`,
+    cid: "cid-prov",
+    collection: "dev.cocore.compute.provider",
+    repo: did,
+    rkey: "m1",
+    body: { desiredTier: "attested-confidential", binaryVersion: "0.9.41" },
+  });
+  // The machine IS live on the advisor, but its registration didn't prove the
+  // DID (dead OAuth session ⇒ no service-auth JWT). Legs are irrelevant here.
+  const rows = [
+    {
+      did,
+      confidentialEligible: false,
+      registrationAuthenticated: false,
+      confidentialLegs: {
+        selfTierConfidential: false,
+        cdHashKnownGood: false,
+        challengeVerifiedSip: true,
+        codeAttested: false,
+      },
+    },
+  ];
+  await withStubAdvisor(rows, async (advisorUrl) => {
+    await withAppviewServer(
+      buildAppviewApp(store, { accountStore, appviewDid: APPVIEW_DID, advisorUrl }),
+      async (base) => {
+        const res = await fetch(`${base}/api/agent/status`, {
+          headers: { authorization: `Bearer ${secret}` },
+        });
+        assert.equal(res.status, 200);
+        const body = (await res.json()) as ConfidentialStatusBody;
+        assert.equal(body.confidentialVerified, false);
+        assert.equal(body.confidentialDesired, true);
+        assert.equal(body.needsReauth, true);
+        assert.match(body.confidentialBlockedReason ?? "", /sign in again/i);
+        assert.doesNotMatch(
+          body.confidentialBlockedReason ?? "",
+          /connected to the co\/core network/i,
+        );
+      },
+    );
+  });
+});
+
+test("authenticated-but-still-attesting machine shows the per-leg reason, not re-auth", async () => {
+  const { store, accountStore } = setup();
+  const did = "did:plc:attesting";
+  const { secret } = accountStore.createKey({ did, name: "machine" });
+  store.upsert({
+    uri: `at://${did}/dev.cocore.compute.provider/m1`,
+    cid: "cid-prov",
+    collection: "dev.cocore.compute.provider",
+    repo: did,
+    rkey: "m1",
+    body: { desiredTier: "attested-confidential", binaryVersion: "0.9.41" },
+  });
+  // Authenticated registration, confidential worker up, SIP + cdHash fine, but
+  // the code-identity challenge hasn't landed yet.
+  const rows = [
+    {
+      did,
+      confidentialEligible: false,
+      registrationAuthenticated: true,
+      confidentialLegs: {
+        selfTierConfidential: true,
+        cdHashKnownGood: true,
+        challengeVerifiedSip: true,
+        codeAttested: false,
+      },
+    },
+  ];
+  await withStubAdvisor(rows, async (advisorUrl) => {
+    await withAppviewServer(
+      buildAppviewApp(store, { accountStore, appviewDid: APPVIEW_DID, advisorUrl }),
+      async (base) => {
+        const res = await fetch(`${base}/api/agent/status`, {
+          headers: { authorization: `Bearer ${secret}` },
+        });
+        const body = (await res.json()) as ConfidentialStatusBody;
+        assert.equal(body.needsReauth, false);
+        assert.match(body.confidentialBlockedReason ?? "", /code-identity challenge/i);
+      },
+    );
+  });
 });
 
 test("GET /agent/status (no /api prefix) is also served", async () => {

--- a/packages/appview/src/api/agent-status.ts
+++ b/packages/appview/src/api/agent-status.ts
@@ -58,36 +58,54 @@ function blockingLegReason(legs: ConfidentialLegs): string | null {
  *  blocking leg when not verified. Mirrors the console's fetchConfidentialStanding;
  *  degrades to not-verified / no-reason when no advisor is configured or it's
  *  unreachable ("can't tell", distinct from a known leg failure). */
+/** The C1 re-auth prompt, kept in sync with the console route. */
+const REAUTH_REASON =
+  "This Mac needs to sign in again — its co/core account session expired, so it can't prove its identity to the network. Open the app and choose “Sign in again”.";
+
 async function fetchConfidentialStanding(
   advisorUrl: string | undefined,
   did: string,
-): Promise<{ verified: boolean; blockedReason: string | null }> {
-  if (!advisorUrl) return { verified: false, blockedReason: null };
+): Promise<{ verified: boolean; blockedReason: string | null; needsReauth: boolean }> {
+  if (!advisorUrl) return { verified: false, blockedReason: null, needsReauth: false };
   try {
     const base = advisorUrl.replace(/\/$/, "");
     const r = await fetch(`${base}/providers`);
-    if (!r.ok) return { verified: false, blockedReason: null };
+    if (!r.ok) return { verified: false, blockedReason: null, needsReauth: false };
     const list = (await r.json()) as Array<{
       did: string;
       confidentialEligible?: boolean;
       trustTier?: string;
+      // C1: whether this registration proved control of its DID (`false` ⇒ an
+      // expired OAuth session that can't mint a service-auth JWT).
+      registrationAuthenticated?: boolean;
       confidentialLegs?: ConfidentialLegs;
     }>;
     const mine = list.filter((p) => p.did === did);
     const verified = mine.some(
       (p) => p.confidentialEligible === true || p.trustTier === "attested-confidential",
     );
-    if (verified) return { verified: true, blockedReason: null };
+    if (verified) return { verified: true, blockedReason: null, needsReauth: false };
     const best = mine.find((p) => p.confidentialLegs?.selfTierConfidential) ?? mine[0];
     if (!best)
       return {
         verified: false,
         blockedReason:
           "This Mac isn't connected to the co/core network yet — confidential can't be verified until it is.",
+        needsReauth: false,
       };
-    return { verified: false, blockedReason: blockingLegReason(best.confidentialLegs ?? {}) };
+    // An unauthenticated registration can never reach an attested tier — the
+    // owner's session has expired. Most-actionable, so it outranks the per-leg
+    // reasons (and the misleading "not connected to the network").
+    if (best.registrationAuthenticated === false) {
+      return { verified: false, blockedReason: REAUTH_REASON, needsReauth: true };
+    }
+    return {
+      verified: false,
+      blockedReason: blockingLegReason(best.confidentialLegs ?? {}),
+      needsReauth: false,
+    };
   } catch {
-    return { verified: false, blockedReason: null };
+    return { verified: false, blockedReason: null, needsReauth: false };
   }
 }
 
@@ -156,6 +174,10 @@ async function buildStatus(ctx: AgentStatusContext, did: string) {
   const confidentialDesired = body.desiredTier === "attested-confidential";
   const confidentialBlockedReason =
     confidentialDesired && !standing.verified ? standing.blockedReason : null;
+  // Advisor-derived re-auth signal: a confidential-desired machine live on the
+  // advisor but registered unauthenticated has a dead OAuth session. Scoped to
+  // confidential so a best-effort agent isn't nagged during staged rollout.
+  const needsReauth = confidentialDesired && standing.needsReauth;
 
   return {
     did,
@@ -170,6 +192,7 @@ async function buildStatus(ctx: AgentStatusContext, did: string) {
     confidentialVerified: standing.verified,
     confidentialDesired,
     confidentialBlockedReason,
+    needsReauth,
   };
 }
 

--- a/packages/console/src/routes/api/agent.status.ts
+++ b/packages/console/src/routes/api/agent.status.ts
@@ -56,7 +56,18 @@ interface ConfidentialStanding {
    *  single most-actionable blocking leg, phrased for the operator. Null when
    *  verified, or when we can't reach the advisor to know. */
   blockedReason: string | null;
+  /** The machine is live on the advisor but registered WITHOUT proving control
+   *  of its DID (`registrationAuthenticated === false`) — its OAuth session has
+   *  expired, so it can't mint the service-auth JWT. This is the un-fixable-by-
+   *  waiting leg: the owner must sign in again. Distinct from a transient
+   *  advisor-unreachable ("can't tell"). */
+  needsReauth: boolean;
 }
+
+/** The C1 re-auth prompt. Phrased as an action, not a diagnosis: this is what
+ *  the owner sees when a confidential-desired machine can't authenticate. */
+const REAUTH_REASON =
+  "This Mac needs to sign in again — its co/core account session expired, so it can't prove its identity to the network. Open the app and choose “Sign in again”.";
 
 /** Map the advisor's per-leg breakdown to ONE operator-facing reason, in
  *  most-actionable-first order. Returns null when every leg holds (verified).
@@ -85,18 +96,21 @@ async function fetchConfidentialStanding(did: string): Promise<ConfidentialStand
   try {
     const base = cocoreConfig().advisorUrl.replace(/\/$/, "");
     const r = await fetch(`${base}/providers`);
-    if (!r.ok) return { verified: false, blockedReason: null };
+    if (!r.ok) return { verified: false, blockedReason: null, needsReauth: false };
     const list = (await r.json()) as Array<{
       did: string;
       confidentialEligible?: boolean;
       trustTier?: string;
+      // C1: whether this registration proved control of its DID. `false` means
+      // the agent couldn't mint a service-auth JWT — an expired OAuth session.
+      registrationAuthenticated?: boolean;
       confidentialLegs?: ConfidentialLegs;
     }>;
     const mine = list.filter((p) => p.did === did);
     const verified = mine.some(
       (p) => p.confidentialEligible === true || p.trustTier === "attested-confidential",
     );
-    if (verified) return { verified: true, blockedReason: null };
+    if (verified) return { verified: true, blockedReason: null, needsReauth: false };
     // Not verified on any row. Prefer the row that's claiming the confidential
     // tier (furthest along) for the most relevant blocking leg; fall back to
     // any row. With no rows at all the machine isn't connected to the advisor.
@@ -106,11 +120,24 @@ async function fetchConfidentialStanding(did: string): Promise<ConfidentialStand
         verified: false,
         blockedReason:
           "This Mac isn't connected to the co/core network yet — confidential can't be verified until it is.",
+        needsReauth: false,
       };
     }
-    return { verified: false, blockedReason: blockingLegReason(best.confidentialLegs ?? {}) };
+    // An unauthenticated registration can never reach an attested tier — the
+    // OAuth session that proves the DID has expired. This is the MOST-actionable
+    // block (it also silently pins the worker to best-effort and fails receipt
+    // publishing), so it outranks the per-leg reasons: tell the owner to sign in
+    // again rather than the misleading "not connected to the network".
+    if (best.registrationAuthenticated === false) {
+      return { verified: false, blockedReason: REAUTH_REASON, needsReauth: true };
+    }
+    return {
+      verified: false,
+      blockedReason: blockingLegReason(best.confidentialLegs ?? {}),
+      needsReauth: false,
+    };
   } catch {
-    return { verified: false, blockedReason: null };
+    return { verified: false, blockedReason: null, needsReauth: false };
   }
 }
 
@@ -206,6 +233,16 @@ export const Route = createFileRoute("/api/agent/status")({
         // confidential — a best-effort machine isn't "blocked", it's off.
         const confidentialBlockedReason =
           confidentialDesired && !standing.verified ? standing.blockedReason : null;
+
+        // A confidential-desired machine that's live on the advisor but
+        // registered unauthenticated (registrationAuthenticated === false) is a
+        // DEFINITIVE re-auth condition the session probe above can miss: the
+        // agent's OAuth session is dead but its WebSocket is healthy, so the
+        // AppView session store may not have observed the death. Trust the
+        // advisor-derived signal so the app's existing "Sign in again" prompt
+        // fires reliably. Scoped to confidential so a best-effort agent that's
+        // merely unauthenticated during staged rollout isn't nagged.
+        if (confidentialDesired && standing.needsReauth) needsReauth = true;
 
         return new Response(
           JSON.stringify({

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -485,33 +485,158 @@ fn is_swap_conflict(e: &cocore_provider::error::ProviderError) -> bool {
     matches!(e, cocore_provider::error::ProviderError::Pds(msg) if msg.contains("InvalidSwap"))
 }
 
-/// Read this machine's owner-chosen `desiredTier` from its PDS provider
-/// record. Returns `None` when not paired, when this machine has no record yet
-/// (never served), or on any read error — all of which the caller treats as
-/// best-effort. Backs both the confidential entry gate and the `agent tier`
-/// probe the macOS supervisor runs to pick a worker binary.
-async fn read_my_desired_tier() -> Option<String> {
-    let session = oauth::load_session().ok()??;
-    let pds = PdsClient::new(session);
-    let signer = secure_enclave::load_or_create_identity().ok()?;
+/// The outcome of trying to read the owner's `desiredTier` from the PDS.
+enum TierRead {
+    /// The provider record was read cleanly. `Some("attested-confidential")`
+    /// when the owner opted in; `None` when the field is absent (best-effort).
+    Read(Option<String>),
+    /// The PDS could not be reached or authenticated — most commonly an expired
+    /// OAuth session that 401s every read. The caller must NOT treat this as
+    /// best-effort (that's the silent-downgrade bug that abandons a confidential
+    /// machine's worker on a transient hiccup); it honors cached intent instead.
+    Unreadable,
+}
+
+/// This machine's current identity `(did, attestationPubKey)`, or `None` when
+/// not paired / the enclave key can't be loaded. Scopes the durable tier cache
+/// the same way `provider-rkey.json` is scoped.
+fn current_identity() -> Option<(String, String)> {
+    let session = oauth::load_session().ok().flatten()?;
+    let pubkey = secure_enclave::load_or_create_identity()
+        .ok()?
+        .public_key_b64();
+    Some((session.did, pubkey))
+}
+
+/// Read this machine's owner-chosen `desiredTier` straight from its PDS provider
+/// record, distinguishing a clean read (best-effort or confidential) from an
+/// unreadable PDS. The list read is split out from the record match so a
+/// transport/auth failure is `Unreadable` while a genuine "no record / no field"
+/// stays a clean best-effort answer.
+async fn read_desired_tier_live() -> TierRead {
+    let Some(session) = oauth::load_session().ok().flatten() else {
+        return TierRead::Unreadable; // not paired / no session on disk
+    };
+    let Ok(signer) = secure_enclave::load_or_create_identity() else {
+        return TierRead::Unreadable;
+    };
     let pubkey = signer.public_key_b64();
-    let (_rkey, value, _cid) = find_my_provider_record(&pds, &pubkey).await.ok()?;
-    value
-        .get("desiredTier")
-        .and_then(|v| v.as_str())
-        .map(str::to_string)
+    let pds = PdsClient::new(session);
+    let listed = match pds.list_my_records("dev.cocore.compute.provider").await {
+        Ok(l) => l,
+        // A transport/auth failure (e.g. 401 "session no longer valid") is
+        // Unreadable — honor cached intent, don't collapse to best-effort.
+        Err(_) => return TierRead::Unreadable,
+    };
+    let tier = listed
+        .into_iter()
+        .find(|r| {
+            r.value.get("attestationPubKey").and_then(|v| v.as_str()) == Some(pubkey.as_str())
+        })
+        .and_then(|r| {
+            r.value
+                .get("desiredTier")
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+        });
+    TierRead::Read(tier)
+}
+
+/// Resolve the owner-chosen tier to one of the two worker-selection answers
+/// (`"attested-confidential"` | `"best-effort"`), backed by a durable cache so a
+/// stale/expired session can't silently collapse a confidential machine to
+/// best-effort. A clean read refreshes the cache; an unreadable PDS falls back
+/// to the last cached intent; only with neither do we default to best-effort.
+/// Backs both `agent tier` and the in-process confidential gate.
+async fn resolve_desired_tier() -> &'static str {
+    let ident = current_identity();
+    match read_desired_tier_live().await {
+        TierRead::Read(Some(t)) if t == "attested-confidential" => {
+            if let Some((did, pk)) = &ident {
+                cache_desired_tier(did, pk, "attested-confidential");
+            }
+            "attested-confidential"
+        }
+        TierRead::Read(_) => {
+            // Read cleanly; owner is best-effort (field absent or other value).
+            if let Some((did, pk)) = &ident {
+                cache_desired_tier(did, pk, "best-effort");
+            }
+            "best-effort"
+        }
+        TierRead::Unreadable => {
+            match ident
+                .as_ref()
+                .and_then(|(did, pk)| cached_desired_tier(did, pk))
+            {
+                Some(t) if t == "attested-confidential" => {
+                    tracing::warn!(
+                        "could not read desiredTier from PDS (session may be expired); honoring cached owner intent = attested-confidential"
+                    );
+                    "attested-confidential"
+                }
+                Some(_) => "best-effort",
+                None => {
+                    tracing::warn!(
+                        "could not read desiredTier from PDS and no cached intent; defaulting to best-effort"
+                    );
+                    "best-effort"
+                }
+            }
+        }
+    }
+}
+
+/// `~/.cocore/desired-tier.json` — the last SUCCESSFULLY-READ owner tier intent
+/// for this identity, so `resolve_desired_tier` can survive a transient/expired
+/// session instead of collapsing a confidential machine to best-effort. Keyed
+/// to (did, attestationPubKey) exactly like `provider-rkey.json`: a re-pair or a
+/// re-keyed enclave invalidates it rather than resurrecting a foreign intent.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct CachedDesiredTier {
+    did: String,
+    attestation_pub_key: String,
+    /// "attested-confidential" | "best-effort"
+    tier: String,
+}
+
+fn desired_tier_cache_path() -> Option<std::path::PathBuf> {
+    dirs::home_dir().map(|h| h.join(".cocore").join("desired-tier.json"))
+}
+
+/// Best-effort: never blocks or fails the tier probe.
+fn cache_desired_tier(did: &str, attestation_pub_key: &str, tier: &str) {
+    let Some(path) = desired_tier_cache_path() else {
+        return;
+    };
+    let entry = CachedDesiredTier {
+        did: did.to_string(),
+        attestation_pub_key: attestation_pub_key.to_string(),
+        tier: tier.to_string(),
+    };
+    if let Ok(json) = serde_json::to_string(&entry) {
+        let _ = std::fs::write(path, json);
+    }
+}
+
+fn cached_desired_tier(did: &str, attestation_pub_key: &str) -> Option<String> {
+    let raw = std::fs::read_to_string(desired_tier_cache_path()?).ok()?;
+    parse_cached_desired_tier(&raw, did, attestation_pub_key)
+}
+
+/// Honor the cache only for the exact identity that wrote it; a foreign DID,
+/// a re-keyed enclave, or a corrupt file reads as no cache.
+fn parse_cached_desired_tier(raw: &str, did: &str, attestation_pub_key: &str) -> Option<String> {
+    let entry: CachedDesiredTier = serde_json::from_str(raw).ok()?;
+    (entry.did == did && entry.attestation_pub_key == attestation_pub_key).then_some(entry.tier)
 }
 
 /// `cocore agent tier`: print this machine's owner-chosen trust tier
-/// (`attested-confidential` or `best-effort`). Normalises an absent/unknown
-/// value to `best-effort` so the caller (the macOS supervisor) always gets one
-/// of the two binary-selection answers.
+/// (`attested-confidential` or `best-effort`). Cache-backed so a stale session
+/// can't silently downgrade the answer the macOS supervisor uses to pick a
+/// worker binary.
 async fn cmd_print_tier() -> Result<()> {
-    let tier = match read_my_desired_tier().await.as_deref() {
-        Some("attested-confidential") => "attested-confidential",
-        _ => "best-effort",
-    };
-    println!("{tier}");
+    println!("{}", resolve_desired_tier().await);
     Ok(())
 }
 
@@ -1116,8 +1241,7 @@ async fn cmd_serve_entry(advisor: String) -> Result<()> {
     // (The macOS supervisor normally only spawns this binary for confidential
     // machines via `agent tier`; this in-process gate is the backstop so a
     // stale/raced spawn can never silently flip a machine's behaviour.)
-    let desired_tier = read_my_desired_tier().await;
-    let confidential = desired_tier.as_deref() == Some("attested-confidential");
+    let confidential = resolve_desired_tier().await == "attested-confidential";
     if !confidential {
         tracing::info!(
             "desiredTier is not attested-confidential — serving best-effort (no push host, subprocess engine)"
@@ -3532,6 +3656,63 @@ mod apply_desired_tier_tests {
         let mut v = serde_json::json!({});
         assert!(!apply_desired_tier(&mut v, false)); // absent == off already
         assert!(apply_desired_tier(&mut v, true)); // off -> on
+    }
+}
+
+#[cfg(test)]
+mod desired_tier_cache_tests {
+    use super::*;
+
+    fn write(did: &str, pk: &str, tier: &str) -> String {
+        serde_json::to_string(&CachedDesiredTier {
+            did: did.to_string(),
+            attestation_pub_key: pk.to_string(),
+            tier: tier.to_string(),
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn round_trips_for_the_same_identity() {
+        let raw = write("did:plc:abc", "PUBKEY", "attested-confidential");
+        assert_eq!(
+            parse_cached_desired_tier(&raw, "did:plc:abc", "PUBKEY").as_deref(),
+            Some("attested-confidential"),
+        );
+    }
+
+    #[test]
+    fn ignores_a_foreign_did_or_rekeyed_enclave() {
+        let raw = write("did:plc:abc", "PUBKEY", "attested-confidential");
+        // Different DID (re-pair under another account) → no cache.
+        assert_eq!(
+            parse_cached_desired_tier(&raw, "did:plc:xyz", "PUBKEY"),
+            None
+        );
+        // Different attestation key (re-keyed enclave) → no cache.
+        assert_eq!(
+            parse_cached_desired_tier(&raw, "did:plc:abc", "OTHER"),
+            None
+        );
+    }
+
+    #[test]
+    fn corrupt_file_reads_as_no_cache() {
+        assert_eq!(
+            parse_cached_desired_tier("not json", "did:plc:abc", "PUBKEY"),
+            None,
+        );
+    }
+
+    #[test]
+    fn best_effort_intent_round_trips_too() {
+        // The cache stores best-effort as well, so a clean read of an opted-out
+        // machine doesn't leave a stale confidential cache to resurrect.
+        let raw = write("did:plc:abc", "PUBKEY", "best-effort");
+        assert_eq!(
+            parse_cached_desired_tier(&raw, "did:plc:abc", "PUBKEY").as_deref(),
+            Some("best-effort"),
+        );
     }
 }
 


### PR DESCRIPTION
## What & why

Diagnosed from **shapeshift.wicca.social**'s bug bundle (`br_4711ff77`, tray 0.9.41, M3 Ultra). Their agent was registering with the advisor and serving best-effort fine, but **Confidential was stuck on "Applying… / This mac isn't connected to the co/core network yet"** and "Retry now" never helped. The bundle showed the real cause: a **dead agent OAuth session** (the two-client refresh-token cannibalization) — `getServiceAuth` and receipt-publish returning `401 "underlying ATProto session no longer valid"`.

A dead session silently broke confidential three ways, none legible to the owner:

1. **`cocore agent tier` read `desiredTier` only from the PDS provider record.** A 401 read → `None` → normalized to `best-effort` → the macOS supervisor spawned the **default** binary, so the nested confidential worker *never launched*. (Confirmed: the agent ran subprocess best-effort models the whole time; zero APNs/code-attestation activity.)
2. The agent then registered **unauthenticated** (couldn't mint a service-auth JWT) → advisor `registrationAuthenticated=false`, which **caps confidential at best-effort even with all four attestation legs green**. Verified live against `/providers`: `regAuth:true` + 4 green legs ⇒ `elig:true`; same legs + `regAuth:false` ⇒ `elig:false`.
3. The console/appview surfaced the misleading **"not connected to the network"** instead of "sign in again."

## Changes

**1. provider (`provider/src/main.rs`) — stop the silent downgrade.**
Durable `~/.cocore/desired-tier.json` cache + `resolve_desired_tier()`:
- a **clean** PDS read refreshes the cache;
- an **unreadable** PDS (401/transport) falls back to the last cached owner intent instead of collapsing to best-effort;
- only with **neither** do we default to best-effort.

The read is split so a transport/auth failure (`Unreadable`) is distinct from a genuine "no record / no field" (best-effort). Cache is scoped to `(did, attestationPubKey)` exactly like `provider-rkey.json` (a re-pair / re-keyed enclave invalidates it). Backs both `agent tier` and the in-process confidential gate. So a confidential machine with a briefly-expired session keeps its worker and recovers when the session comes back, rather than silently dropping to best-effort.

**2. console + appview `/agent/status` — make it legible + reliably prompt re-auth.**
Read the advisor's `registrationAuthenticated` leg. When a confidential-desired machine is live but registered unauthenticated:
- the `confidentialBlockedReason` becomes an actionable **"sign in again"** (outranks the per-leg reasons and the "not connected" copy);
- the top-level **`needsReauth` flips true** so the app's existing "Sign in again" prompt fires reliably — independent of the flaky AppView session probe.

Scoped to confidential-desired so a best-effort agent isn't nagged during staged rollout. Mirrored in both routes since a paired agent's `apiBase` may point at either the console or the AppView.

## Tests
- `provider`: `desired_tier_cache_tests` (identity scoping, corrupt-file, best-effort round-trip).
- `appview`: `agent-status.test.ts` — unauthenticated-registration ⇒ "sign in again" + `needsReauth`, and authenticated-but-still-attesting ⇒ per-leg reason (not re-auth).
- Typecheck (console + appview), oxfmt, oxlint, rustfmt all clean.

## Follow-ups (not in this PR)
- **Durable root-cause fix:** finish the AppView single-session-owner cutover so the session doesn't die in the first place (the two-client refresh cannibalization).
- **Tray confidential preflight:** warn on toggle when the selected model isn't native-compatible (shapeshift's Qwen3.5-122B silently isn't) instead of spinning on "Applying…".

🤖 Generated with [Claude Code](https://claude.com/claude-code)