### PR TITLE
fix(provider): survive signing-key rotation — keep confidential + Secure Mode across the 0.9.43 SE-key upgrade

### DIFF
--- a/lexicons/dev/cocore/compute/provider.json
+++ b/lexicons/dev/cocore/compute/provider.json
@@ -100,7 +100,12 @@
           "attestationPubKey": {
             "type": "string",
             "maxLength": 256,
-            "description": "P-256 public key (base64) bound to this machine's Secure Enclave. Used to verify attestation and receipt signatures. Doubles as the stable per-machine fingerprint: the SE keypair is generated once at first agent boot and survives reboots / re-pairs / OS updates, so two records with the same `attestationPubKey` describe the same physical machine. Agents reuse the rkey of any existing record with this same key (and delete duplicates) instead of creating a fresh provider record per `serve` invocation, so the on-PDS view stays one record per machine."
+            "description": "P-256 public key (base64) used to verify this machine's attestation and receipt signatures. HISTORICALLY doubled as the per-machine fingerprint, but the signing key can ROTATE — e.g. the 0.9.43 migration from a software key to a non-extractable Secure-Enclave key mints a new keypair, changing this value for the same physical machine. Record identity therefore keys on `machineFingerprint` (a stable hardware id) when present, falling back to `attestationPubKey` for pre-`machineFingerprint` records. Two records with the same `machineFingerprint` — or, legacy, the same `attestationPubKey` — describe the same machine; agents adopt its rkey (carrying the owner's intent fields) and delete duplicates so the on-PDS view stays one record per machine across key rotations."
+          },
+          "machineFingerprint": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "Stable per-machine identity that survives signing-key rotation: a hash of the hardware serial number (salted by the owner DID, so it does not correlate the machine across DIDs). Unlike `attestationPubKey`, this does NOT change when the agent rotates its signing key (software key -> Secure Enclave key on the 0.9.43 upgrade, a chip-bound key regenerated after a keychain reset, etc.), so the agent can recognize an existing provider record as its own prior incarnation and adopt it — reusing the rkey and carrying the owner-intent fields (`desiredTier`, `active`, `desiredModels`, ...) forward — instead of orphaning it and minting a fresh record. Optional / additive; records written by agents before 0.9.44 omit it (matched by `attestationPubKey` + hardware profile instead)."
           },
           "trustLevel": {
             "type": "ref",

--- a/packages/sdk/src/types.gen.ts
+++ b/packages/sdk/src/types.gen.ts
@@ -196,6 +196,7 @@ export interface ProviderRecord {
   priceList: ModelPrice[];
   encryptionPubKey: string;
   attestationPubKey: string;
+  machineFingerprint?: string;
   trustLevel: TrustLevel;
   tier?: Tier;
   desiredTier?: Tier;

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -903,16 +903,19 @@ fn cache_provider_rkey(did: &str, attestation_pub_key: &str, rkey: &str) {
     }
 }
 
-fn cached_provider_rkey(did: &str, attestation_pub_key: &str) -> Option<String> {
+fn cached_provider_rkey(did: &str) -> Option<String> {
     let raw = std::fs::read_to_string(provider_rkey_cache_path()?).ok()?;
-    parse_cached_provider_rkey(&raw, did, attestation_pub_key)
+    parse_cached_provider_rkey(&raw, did)
 }
 
-/// Honor the cache only for the exact identity that wrote it; anything
-/// else (foreign DID, re-keyed enclave, corrupt file) reads as no cache.
-fn parse_cached_provider_rkey(raw: &str, did: &str, attestation_pub_key: &str) -> Option<String> {
+/// Honor the cache for this machine's DID, REGARDLESS of the stored pubkey. The
+/// rkey is this machine's stable record id; a signing-key rotation (software →
+/// Secure Enclave on 0.9.43) changes the pubkey but NOT which record is ours, so
+/// gating on the pubkey used to strand the record and mint a fresh one. A re-pair
+/// under a different account (DID mismatch) still invalidates it.
+fn parse_cached_provider_rkey(raw: &str, did: &str) -> Option<String> {
     let entry: CachedProviderRkey = serde_json::from_str(raw).ok()?;
-    (entry.did == did && entry.attestation_pub_key == attestation_pub_key).then_some(entry.rkey)
+    (entry.did == did).then_some(entry.rkey)
 }
 
 /// Find this machine's existing provider record (if any) on the
@@ -929,17 +932,23 @@ fn parse_cached_provider_rkey(raw: &str, did: &str, attestation_pub_key: &str) -
 /// is the prevention story.
 async fn dedup_and_publish_provider(
     pds: &cocore_provider::pds::PdsClient,
-    attestation_pub_key: &str,
     record: &ProviderRecord,
+    cached_rkey: Option<&str>,
 ) -> anyhow::Result<(cocore_provider::pds::PublishedRecord, bool, usize)> {
     // The single agent write path for this machine's provider record: a
-    // compare-and-swap read-modify-write that reads the LATEST record, merges
-    // the agent's authored fields onto it (owner-intent + unknown fields
-    // preserved — see `merge_agent_provider_fields`), and putRecords under a
-    // swap guard, retrying on `InvalidSwap` by re-reading. A read failure
-    // aborts — we never publish a fabricated body on a blind read. It also
-    // dedups: a DID that holds several records with our attestationPubKey
-    // (stale reinstall dupes) keeps the newest and deletes the rest.
+    // compare-and-swap read-modify-write that reads the LATEST records, decides
+    // which one is OURS (across a signing-key rotation — see
+    // `reconcile_provider_records`), merges the agent's authored fields onto its
+    // body (owner-intent + unknown fields preserved AND harvested from any
+    // orphaned prior record), and putRecords under a swap guard, retrying on
+    // `InvalidSwap` by re-reading. A read failure aborts — we never publish a
+    // fabricated body on a blind read. It also dedups: stale duplicates for THIS
+    // machine (reinstalls, key rotations) are deleted; sibling machines under the
+    // same DID are left untouched.
+    use cocore_provider::pds::{
+        merge_agent_provider_fields, reconcile_provider_records, ListedProviderRecord,
+        MachineIdentity,
+    };
     const MAX_ATTEMPTS: u32 = 6;
     let collection = "dev.cocore.compute.provider";
     let mut deleted = 0usize;
@@ -947,62 +956,71 @@ async fn dedup_and_publish_provider(
     for attempt in 1..=MAX_ATTEMPTS {
         // Read latest. A transport/auth failure propagates and ABORTS — the
         // republish never invents a record on top of an unreadable PDS.
-        let listed = pds.list_my_records(collection).await?;
-        let mut matching: Vec<(String, String, String, serde_json::Value)> = Vec::new();
-        let mut other_pubkey_count = 0usize;
-        for r in &listed {
-            let rkey = r.uri.rsplit('/').next().unwrap_or("").to_string();
-            let key = r.value.get("attestationPubKey").and_then(|v| v.as_str());
-            let created_at = r
-                .value
-                .get("createdAt")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-            match key {
-                Some(k) if k == attestation_pub_key => {
-                    matching.push((rkey, r.cid.clone(), created_at, r.value.clone()));
-                }
-                Some(_) => other_pubkey_count += 1,
-                // No attestationPubKey — pre-2026-05 record; leave alone.
-                None => {}
-            }
-        }
-        if attempt == 1 && other_pubkey_count > 0 {
-            tracing::info!(
-                other_pubkey_count,
-                "saw provider records on this DID with a different attestationPubKey — those describe other machines; leaving alone"
-            );
-        }
-        // Sort newest-first by createdAt; the head is canonical.
-        matching.sort_by(|a, b| b.2.cmp(&a.2));
+        let listed_raw = pds.list_my_records(collection).await?;
+        let listed: Vec<ListedProviderRecord> = listed_raw
+            .iter()
+            .map(|r| {
+                let rkey = r.uri.rsplit('/').next().unwrap_or("").to_string();
+                ListedProviderRecord::from_value(rkey, r.cid.clone(), r.value.clone())
+            })
+            .collect();
 
-        let Some((rkey, cid, _, existing_value)) = matching.first().cloned() else {
-            // First publish: no record yet. The agent authors everything; owner
-            // fields are absent (correct for a brand-new machine).
+        // Identity is taken from the record we're about to publish — its
+        // fingerprint/pubkey/hardware profile — plus the locally-cached rkey.
+        let me = MachineIdentity {
+            attestation_pub_key: &record.attestationPubKey,
+            machine_fingerprint: record.machineFingerprint.as_deref(),
+            machine_label: &record.machineLabel,
+            model_identifier: record.modelIdentifier.as_deref(),
+            chip: &record.chip,
+            cached_rkey,
+        };
+
+        let Some(recon) = reconcile_provider_records(&listed, &me) else {
+            // No record is ours yet: first publish. The agent authors
+            // everything; owner fields are absent (correct for a new machine).
             let published = pds.publish_provider(record).await?;
             return Ok((published, false, deleted));
         };
+        if attempt == 1 && recon.ambiguous_legacy > 0 {
+            tracing::warn!(
+                count = recon.ambiguous_legacy,
+                "multiple legacy provider records share this machine's hardware profile; \
+                 leaving them alone (ambiguous) — resolve on the console"
+            );
+        }
 
-        // Delete duplicate losers (best-effort; only need to run once).
-        for (loser_rkey, loser_cid, _, _) in matching.iter().skip(1) {
-            match pds
-                .delete_record(collection, loser_rkey, Some(loser_cid))
-                .await
-            {
-                Ok(()) => {
-                    deleted += 1;
-                    tracing::info!(rkey = %loser_rkey, "deleted duplicate provider record");
-                }
-                Err(e) => {
-                    tracing::warn!(error = %e, rkey = %loser_rkey, "failed to delete duplicate provider record")
+        // Delete stale duplicates for THIS machine (best-effort; only need once).
+        // Reconciliation never lists a sibling machine's record here.
+        if attempt == 1 {
+            for (loser_rkey, loser_cid) in &recon.delete {
+                match pds
+                    .delete_record(collection, loser_rkey, Some(loser_cid))
+                    .await
+                {
+                    Ok(()) => {
+                        deleted += 1;
+                        tracing::info!(rkey = %loser_rkey, "deleted stale provider record for this machine (key rotation / reinstall)");
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, rkey = %loser_rkey, "failed to delete stale provider record")
+                    }
                 }
             }
         }
 
-        // Merge the agent's fields onto the LATEST body and CAS-put.
-        let merged = cocore_provider::pds::merge_agent_provider_fields(&existing_value, record);
-        match pds.put_record(collection, &rkey, &merged, Some(&cid)).await {
+        // Merge the agent's fields onto the harvested base and CAS-put at the
+        // canonical rkey (owner intent carried forward from any orphaned record).
+        let merged = merge_agent_provider_fields(&recon.base, record);
+        match pds
+            .put_record(
+                collection,
+                &recon.canonical_rkey,
+                &merged,
+                Some(&recon.canonical_cid),
+            )
+            .await
+        {
             Ok(published) => return Ok((published, true, deleted)),
             Err(e) if is_swap_conflict(&e) && attempt < MAX_ATTEMPTS => {
                 // Someone (a console edit, a sibling write) committed between our
@@ -1559,6 +1577,17 @@ async fn cmd_serve(
         "collected system profile"
     );
     let attestation_pub_key = signer.public_key_b64();
+    // Stable per-machine fingerprint (hashed hardware serial, salted by DID).
+    // Unlike `attestation_pub_key` this survives a signing-key rotation, so the
+    // agent recognizes its own record after the 0.9.43 software→Secure-Enclave
+    // key switch and adopts it (carrying `desiredTier`/`active`/... forward)
+    // instead of orphaning it. `None` on a host whose serial can't be read.
+    let machine_fingerprint: Option<String> = cocore_provider::mda_loader::device_serial()
+        .map(|serial| cocore_provider::pds::machine_fingerprint(&serial, &session.did));
+    // The rkey this machine last published to (DID-scoped, so it survives the
+    // key rotation). Lets the reconciler keep the machine's record id stable
+    // instead of minting a fresh one when the signing key changes.
+    let cached_rkey: Option<String> = cached_provider_rkey(&session.did);
 
     // Publish a PROVISIONING provider record immediately — before the
     // (potentially slow) engine load below. A cold model load can take
@@ -1582,6 +1611,7 @@ async fn cmd_serve(
             eCores: profile.e_cores,
             modelIdentifier: profile.model_identifier.clone(),
             os: profile.os.clone(),
+            machineFingerprint: machine_fingerprint.clone(),
             supportedModels: vec![],
             priceList: vec![],
             encryptionPubKey: enc.public_key_b64(),
@@ -1623,7 +1653,7 @@ async fn cmd_serve(
             regionObservedAt: None,
             createdAt: chrono::Utc::now(),
         };
-        match dedup_and_publish_provider(&pds, &attestation_pub_key, &provisioning_record).await {
+        match dedup_and_publish_provider(&pds, &provisioning_record, cached_rkey.as_deref()).await {
             Ok((published, _, _)) => tracing::info!(
                 uri = %published.uri,
                 "published provisioning provider record — machine is visible while the engine loads"
@@ -1929,6 +1959,7 @@ async fn cmd_serve(
         ramGB: profile.ram_gb,
         gpuCores: profile.gpu_cores,
         memoryBandwidthGBs: profile.memory_bandwidth_gbs,
+        machineFingerprint: machine_fingerprint.clone(),
         cpuCores: profile.cpu_cores,
         pCores: profile.p_cores,
         eCores: profile.e_cores,
@@ -2002,8 +2033,8 @@ async fn cmd_serve(
     // can flip `serving` to false at the same rkey on graceful shutdown.
     let provider_rkey: Option<String> = match dedup_and_publish_provider(
         &pds,
-        &attestation_pub_key,
         &provider_record,
+        cached_rkey.as_deref(),
     )
     .await
     {
@@ -2025,7 +2056,7 @@ async fn cmd_serve(
             // the advisor Register still carries our stable `machine_id` —
             // otherwise the console can't join live standing onto the record
             // and shows a healthy, connected machine as "not reachable".
-            let cached = cached_provider_rkey(&session.did, &attestation_pub_key);
+            let cached = cached_rkey.clone();
             match &cached {
                 Some(r) => tracing::warn!(
                     error = %e,
@@ -2139,7 +2170,7 @@ async fn cmd_serve(
         let enc_pub = enc.public_key_b64();
         let enc_scheme = enc_scheme.clone();
         let engine_facts = engine_facts.clone();
-        let attestation_pub_key = attestation_pub_key.clone();
+        let refresh_rkey = provider_rkey.clone();
         let base_record = provider_record.clone();
         tokio::spawn(async move {
             let interval = attestation_refresh_interval();
@@ -2170,7 +2201,7 @@ async fn cmd_serve(
                 // re-publish here doesn't affect the live attestation cell.
                 republish_attestation_fault(
                     &pds,
-                    &attestation_pub_key,
+                    refresh_rkey.as_deref(),
                     &base_record,
                     outcome.fault.clone(),
                 )
@@ -2373,7 +2404,7 @@ async fn cmd_serve(
                     // paused moments ago stays paused instead of being un-paused
                     // by this marker) and every other owner/unknown field — and
                     // retries on a swap conflict.
-                    dedup_and_publish_provider(&pds, &attestation_pub_key, &offline).await
+                    dedup_and_publish_provider(&pds, &offline, provider_rkey.as_deref()).await
                 };
                 match tokio::time::timeout(std::time::Duration::from_secs(5), publish).await {
                     Ok(Ok((published, _, _))) => tracing::info!(uri = %published.uri, "published provider record with serving=false (owner switches preserved)"),
@@ -2588,7 +2619,7 @@ fn attestation_refresh_interval() -> std::time::Duration {
 /// — a failure here never affects the live attestation cell.
 async fn republish_attestation_fault(
     pds: &PdsClient,
-    attestation_pub_key: &str,
+    cached_rkey: Option<&str>,
     base_record: &ProviderRecord,
     fault: Option<AttestationFault>,
 ) {
@@ -2601,7 +2632,7 @@ async fn republish_attestation_fault(
         rec.createdAt = chrono::Utc::now();
         // Single CAS write path: merges onto the latest record (owner switches +
         // unknown fields preserved) and retries on conflict.
-        dedup_and_publish_provider(pds, attestation_pub_key, &rec).await
+        dedup_and_publish_provider(pds, &rec, cached_rkey).await
     };
     match tokio::time::timeout(std::time::Duration::from_secs(10), publish).await {
         Ok(Ok(_)) => {}
@@ -3933,9 +3964,9 @@ mod provider_rkey_cache_tests {
         r#"{"did":"did:plc:alice","attestation_pub_key":"BKey==","rkey":"3mov7tbvvns2m"}"#;
 
     #[test]
-    fn matching_identity_returns_the_cached_rkey() {
+    fn matching_did_returns_the_cached_rkey() {
         assert_eq!(
-            parse_cached_provider_rkey(RAW, "did:plc:alice", "BKey=="),
+            parse_cached_provider_rkey(RAW, "did:plc:alice"),
             Some("3mov7tbvvns2m".to_string())
         );
     }
@@ -3944,33 +3975,32 @@ mod provider_rkey_cache_tests {
     fn a_foreign_did_never_resurrects_the_rkey() {
         // Re-paired under a different account: the old record isn't ours to
         // impersonate on the advisor.
-        assert_eq!(
-            parse_cached_provider_rkey(RAW, "did:plc:bob", "BKey=="),
-            None
-        );
+        assert_eq!(parse_cached_provider_rkey(RAW, "did:plc:bob"), None);
     }
 
     #[test]
-    fn a_rekeyed_enclave_invalidates_the_cache() {
+    fn a_rekeyed_enclave_keeps_the_cached_rkey() {
+        // THE fix: a signing-key rotation (software -> Secure Enclave on 0.9.43)
+        // changes the pubkey but NOT which record is this machine's. The cache is
+        // DID-scoped now, so the rkey survives the rotation and the reconciler
+        // adopts the record in place instead of orphaning it. (The stored pubkey
+        // in RAW is ignored on read.)
         assert_eq!(
-            parse_cached_provider_rkey(RAW, "did:plc:alice", "BOtherKey=="),
-            None
+            parse_cached_provider_rkey(RAW, "did:plc:alice"),
+            Some("3mov7tbvvns2m".to_string())
         );
     }
 
     #[test]
     fn garbage_or_legacy_content_reads_as_no_cache() {
         assert_eq!(
-            parse_cached_provider_rkey("not json", "did:plc:alice", "BKey=="),
+            parse_cached_provider_rkey("not json", "did:plc:alice"),
             None
         );
-        assert_eq!(
-            parse_cached_provider_rkey("", "did:plc:alice", "BKey=="),
-            None
-        );
+        assert_eq!(parse_cached_provider_rkey("", "did:plc:alice"), None);
         // A bare rkey from a hypothetical older format is ignored, not trusted.
         assert_eq!(
-            parse_cached_provider_rkey("\"3mov7tbvvns2m\"", "did:plc:alice", "BKey=="),
+            parse_cached_provider_rkey("\"3mov7tbvvns2m\"", "did:plc:alice"),
             None
         );
     }
@@ -3995,6 +4025,7 @@ mod offline_marker_tests {
             eCores: Some(4),
             modelIdentifier: Some("Macmini9,1".into()),
             os: Some("macOS 26.4.1".into()),
+            machineFingerprint: Some("fp-test".into()),
             supportedModels: vec!["stub".into()],
             priceList: vec![],
             encryptionPubKey: "enc".into(),

--- a/provider/src/mda_loader.rs
+++ b/provider/src/mda_loader.rs
@@ -469,11 +469,25 @@ pub fn acquire_auto(console_base: &str, api_key: &str, public_key_b64: &str) -> 
         tracing::warn!("MDA auto: could not read Hardware UUID; cannot request attestation");
         return Vec::new();
     };
-    if auto_request_cooldown_elapsed() {
+    // A signing-key ROTATION bypasses the time cooldown: the stale chain will
+    // never bind the new key, so waiting out 6h just prolongs "self-attested".
+    // The coordinator must issue a fresh key-bound attestation for the new key,
+    // and it can't until we ask with the new pubkey. Same key + within cooldown
+    // → hold off (don't hammer Apple's per-device attestation rate limit).
+    let key_rotated = last_requested_pubkey().as_deref() != Some(public_key_b64);
+    if key_rotated || auto_request_cooldown_elapsed() {
         let request_url = format!("{base}/api/agent/mdm/request-attestation");
         if post_request_attestation(&request_url, api_key, &serial, &udid, public_key_b64) {
-            mark_auto_requested();
-            tracing::info!("MDA auto: requested attestation; chain will land on a later refresh");
+            mark_auto_requested(public_key_b64);
+            if key_rotated {
+                tracing::info!(
+                    "MDA auto: signing key rotated — requested a fresh key-bound attestation (bypassed cooldown); chain lands on a later refresh"
+                );
+            } else {
+                tracing::info!(
+                    "MDA auto: requested attestation; chain will land on a later refresh"
+                );
+            }
         }
     } else {
         tracing::debug!("MDA auto: within request cooldown; not re-requesting this boot");
@@ -581,12 +595,30 @@ fn auto_request_cooldown_elapsed() -> bool {
     }
 }
 
-fn mark_auto_requested() {
+/// Record that we requested an attestation for `public_key_b64`. The marker's
+/// mtime drives the time cooldown; its CONTENT (the requested pubkey) lets a
+/// later boot detect a signing-key rotation and re-request immediately rather
+/// than waiting out the cooldown against a key the coordinator's chain can never
+/// bind. A legacy empty marker reads as a different key, so the first post-fix
+/// boot re-requests once — the desired behavior.
+fn mark_auto_requested(public_key_b64: &str) {
     if let Some(path) = auto_request_marker_path() {
         if let Some(parent) = path.parent() {
             let _ = std::fs::create_dir_all(parent);
         }
-        let _ = std::fs::write(&path, b"");
+        let _ = std::fs::write(&path, public_key_b64.as_bytes());
+    }
+}
+
+/// The signing key we last requested an MDA attestation for, if any.
+fn last_requested_pubkey() -> Option<String> {
+    let path = auto_request_marker_path()?;
+    let s = std::fs::read_to_string(path).ok()?;
+    let s = s.trim();
+    if s.is_empty() {
+        None
+    } else {
+        Some(s.to_string())
     }
 }
 

--- a/provider/src/pds.rs
+++ b/provider/src/pds.rs
@@ -64,6 +64,16 @@ pub struct ProviderRecord {
     pub priceList: Vec<ModelPrice>,
     pub encryptionPubKey: String,
     pub attestationPubKey: String,
+    /// Stable per-machine identity that survives signing-key rotation (a hash of
+    /// the hardware serial, salted by DID). Unlike `attestationPubKey`, this does
+    /// NOT change when the signing key rotates (software -> Secure Enclave on the
+    /// 0.9.43 upgrade), so the agent can recognize an existing record as its own
+    /// prior incarnation and adopt it (carrying `desiredTier`/`active`/... forward)
+    /// instead of orphaning it. Absent on records written before 0.9.44 and on
+    /// hosts where the serial can't be read; identity then falls back to
+    /// `attestationPubKey` + hardware profile. Additive.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub machineFingerprint: Option<String>,
     pub trustLevel: TrustLevel,
     /// Agent-published ACHIEVED confidentiality tier (`attested-confidential` |
     /// `best-effort`), derived from the signed attestation's evidence — NEVER
@@ -296,6 +306,207 @@ pub fn merge_agent_provider_fields(
         }
     }
     serde_json::Value::Object(out)
+}
+
+/// Stable per-machine fingerprint = `sha256(serial | did)`, hex. Salted by the
+/// owner DID so the value can't correlate a machine across different owners.
+/// Survives signing-key rotation because the hardware serial doesn't change.
+/// Mirrors the attestation's `serialNumberHash` salt scheme so the two agree.
+pub fn machine_fingerprint(serial: &str, did: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(serial.as_bytes());
+    h.update(b"|");
+    h.update(did.as_bytes());
+    hex::encode(h.finalize())
+}
+
+/// One `dev.cocore.compute.provider` record on the DID, reduced to the fields
+/// record-identity reconciliation needs. Built from a PDS list result.
+#[derive(Debug, Clone)]
+pub struct ListedProviderRecord {
+    pub rkey: String,
+    pub cid: String,
+    pub created_at: String,
+    pub attestation_pub_key: Option<String>,
+    pub machine_fingerprint: Option<String>,
+    pub machine_label: Option<String>,
+    pub model_identifier: Option<String>,
+    pub chip: Option<String>,
+    pub value: serde_json::Value,
+}
+
+impl ListedProviderRecord {
+    /// Extract the identity fields from a raw PDS record body.
+    pub fn from_value(rkey: String, cid: String, value: serde_json::Value) -> Self {
+        let s = |k: &str| value.get(k).and_then(|v| v.as_str()).map(str::to_string);
+        Self {
+            rkey,
+            cid,
+            created_at: s("createdAt").unwrap_or_default(),
+            attestation_pub_key: s("attestationPubKey"),
+            machine_fingerprint: s("machineFingerprint"),
+            machine_label: s("machineLabel"),
+            model_identifier: s("modelIdentifier"),
+            chip: s("chip"),
+            value,
+        }
+    }
+}
+
+/// This machine's identity, for matching its own records across a key rotation.
+#[derive(Debug, Clone)]
+pub struct MachineIdentity<'a> {
+    pub attestation_pub_key: &'a str,
+    /// `None` when the hardware serial couldn't be read.
+    pub machine_fingerprint: Option<&'a str>,
+    pub machine_label: &'a str,
+    pub model_identifier: Option<&'a str>,
+    pub chip: &'a str,
+    /// The rkey this agent last published to (from `provider-rkey.json`), if any.
+    pub cached_rkey: Option<&'a str>,
+}
+
+/// How a listed record relates to this machine.
+#[derive(Debug, PartialEq, Eq)]
+enum Kinship {
+    /// Definitely this machine (current key, matching fingerprint, or our cached rkey).
+    Mine,
+    /// A legacy record (no `machineFingerprint`) whose hardware profile matches —
+    /// probably ours from before the fix, but only adopted if it's the UNIQUE such
+    /// candidate (guards against two identically-named machines under one DID).
+    LegacyCandidate,
+    /// Someone else's machine (a different fingerprint, or an unrelated record).
+    Other,
+}
+
+fn classify(rec: &ListedProviderRecord, me: &MachineIdentity) -> Kinship {
+    // A present fingerprint is DEFINITIVE: equal => mine, unequal => not mine.
+    // This protects sibling machines from ever being adopted/deleted by heuristic.
+    if let (Some(rf), Some(mf)) = (rec.machine_fingerprint.as_deref(), me.machine_fingerprint) {
+        return if rf == mf {
+            Kinship::Mine
+        } else {
+            Kinship::Other
+        };
+    }
+    // A record carrying a fingerprint we don't share (we couldn't read our serial)
+    // is not something we can claim — leave it alone.
+    if rec.machine_fingerprint.is_some() {
+        return Kinship::Other;
+    }
+    // Current signing key matches (the common, un-rotated case).
+    if rec.attestation_pub_key.as_deref() == Some(me.attestation_pub_key) {
+        return Kinship::Mine;
+    }
+    // Our own record per the local rkey cache (survives a key rotation because the
+    // cache is keyed by DID, not pubkey).
+    if me.cached_rkey.is_some()
+        && rec.attestation_pub_key.is_some()
+        && rec.rkey == me.cached_rkey.unwrap()
+    {
+        return Kinship::Mine;
+    }
+    // Legacy record without a fingerprint: match on the stable hardware profile.
+    let profile_matches = rec.machine_label.as_deref() == Some(me.machine_label)
+        && rec.model_identifier.as_deref() == me.model_identifier
+        && rec.chip.as_deref() == Some(me.chip);
+    if profile_matches {
+        Kinship::LegacyCandidate
+    } else {
+        Kinship::Other
+    }
+}
+
+/// The outcome of reconciling this machine's provider records: which record to
+/// adopt (keep its rkey), the base body to publish onto (with the owner's intent
+/// harvested from any orphaned prior record), and which stale duplicates to delete.
+#[derive(Debug)]
+pub struct ProviderReconciliation {
+    pub canonical_rkey: String,
+    pub canonical_cid: String,
+    /// The canonical record body with owner-intent fields harvested from all of
+    /// this machine's records (so a `desiredTier` stranded on a pre-rotation
+    /// record is carried forward). Merge the agent's fields onto THIS.
+    pub base: serde_json::Value,
+    /// `(rkey, cid)` of stale duplicate records for THIS machine to delete.
+    pub delete: Vec<(String, String)>,
+    /// Count of legacy candidates left alone because the match was ambiguous
+    /// (more than one profile-matching record) — surfaced for logging.
+    pub ambiguous_legacy: usize,
+}
+
+/// Decide which of this machine's provider records to adopt and which to delete,
+/// carrying the owner's intent forward across a signing-key rotation. Returns
+/// `None` when no record belongs to this machine (caller creates a fresh one).
+///
+/// PURE (no I/O) so it's unit-testable; `dedup_and_publish_provider` supplies the
+/// listed records and performs the resulting put/delete under compare-and-swap.
+pub fn reconcile_provider_records(
+    listed: &[ListedProviderRecord],
+    me: &MachineIdentity,
+) -> Option<ProviderReconciliation> {
+    let mut mine: Vec<&ListedProviderRecord> = Vec::new();
+    let mut legacy: Vec<&ListedProviderRecord> = Vec::new();
+    for rec in listed {
+        match classify(rec, me) {
+            Kinship::Mine => mine.push(rec),
+            Kinship::LegacyCandidate => legacy.push(rec),
+            Kinship::Other => {}
+        }
+    }
+    // A legacy profile match is adopted ONLY when unique — otherwise two
+    // identically-named machines under one DID would cross-contaminate. When
+    // ambiguous, leave the legacy records untouched (they'll age out / be handled
+    // by the console cleanup), but still reconcile any definitively-mine records.
+    let ambiguous_legacy = if legacy.len() > 1 { legacy.len() } else { 0 };
+    if legacy.len() == 1 {
+        mine.push(legacy[0]);
+    }
+    if mine.is_empty() {
+        return None;
+    }
+    // Canonical = our cached rkey if it's among ours (keeps machineId stable),
+    // else the newest by createdAt.
+    mine.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    let canonical = me
+        .cached_rkey
+        .and_then(|rk| mine.iter().find(|r| r.rkey == rk).copied())
+        .unwrap_or(mine[0]);
+
+    // Harvest owner-intent: fill any owner key ABSENT on the canonical from the
+    // most-recent OTHER record of ours that has it (mine is newest-first). This is
+    // what carries a `desiredTier` stranded on a pre-rotation record forward.
+    let mut base = canonical.value.clone();
+    if let Some(obj) = base.as_object_mut() {
+        for key in OWNER_INTENT_KEYS {
+            let present = obj.get(*key).map(|v| !v.is_null()).unwrap_or(false);
+            if present {
+                continue;
+            }
+            if let Some(v) = mine
+                .iter()
+                .filter_map(|r| r.value.get(*key))
+                .find(|v| !v.is_null())
+            {
+                obj.insert((*key).to_string(), v.clone());
+            }
+        }
+    }
+
+    let delete = mine
+        .iter()
+        .filter(|r| r.rkey != canonical.rkey)
+        .map(|r| (r.rkey.clone(), r.cid.clone()))
+        .collect();
+
+    Some(ProviderReconciliation {
+        canonical_rkey: canonical.rkey.clone(),
+        canonical_cid: canonical.cid.clone(),
+        base,
+        delete,
+        ambiguous_legacy,
+    })
 }
 
 /// The owner's pro-bono election for a machine, mirroring the lexicon
@@ -979,6 +1190,237 @@ impl PdsClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn rec(
+        rkey: &str,
+        created: &str,
+        pubkey: Option<&str>,
+        fp: Option<&str>,
+        label: &str,
+        model: &str,
+        chip: &str,
+        extra: serde_json::Value,
+    ) -> ListedProviderRecord {
+        let mut v = serde_json::json!({
+            "machineLabel": label, "modelIdentifier": model, "chip": chip, "createdAt": created,
+        });
+        if let Some(k) = pubkey {
+            v["attestationPubKey"] = serde_json::json!(k);
+        }
+        if let Some(f) = fp {
+            v["machineFingerprint"] = serde_json::json!(f);
+        }
+        if let Some(o) = extra.as_object() {
+            for (k, val) in o {
+                v[k] = val.clone();
+            }
+        }
+        ListedProviderRecord::from_value(rkey.into(), format!("cid-{rkey}"), v)
+    }
+
+    #[test]
+    fn reconcile_current_key_single_record() {
+        // The common case: one record, current key. Adopt it, nothing to delete.
+        let listed = [rec(
+            "r1",
+            "t1",
+            Some("KEY_A"),
+            None,
+            "Mac Mini 1",
+            "Macmini9,1",
+            "Apple M1",
+            serde_json::json!({}),
+        )];
+        let me = MachineIdentity {
+            attestation_pub_key: "KEY_A",
+            machine_fingerprint: Some("FP1"),
+            machine_label: "Mac Mini 1",
+            model_identifier: Some("Macmini9,1"),
+            chip: "Apple M1",
+            cached_rkey: Some("r1"),
+        };
+        let r = reconcile_provider_records(&listed, &me).expect("mine");
+        assert_eq!(r.canonical_rkey, "r1");
+        assert!(r.delete.is_empty());
+    }
+
+    #[test]
+    fn reconcile_key_rotation_adopts_legacy_and_harvests_desired_tier() {
+        // THE bug: an old-key record (v0.9.42, no fingerprint) holds
+        // desiredTier=attested-confidential; the new SE-key record has none. The
+        // agent must adopt (keep the new/cached rkey), harvest desiredTier, and
+        // delete the stale old record.
+        let listed = [
+            rec(
+                "r_old",
+                "t1",
+                Some("KEY_OLD"),
+                None,
+                "Mac Mini 1",
+                "Macmini9,1",
+                "Apple M1",
+                serde_json::json!({ "desiredTier": "attested-confidential", "active": true }),
+            ),
+            rec(
+                "r_new",
+                "t2",
+                Some("KEY_NEW"),
+                None,
+                "Mac Mini 1",
+                "Macmini9,1",
+                "Apple M1",
+                serde_json::json!({}),
+            ),
+        ];
+        let me = MachineIdentity {
+            attestation_pub_key: "KEY_NEW",
+            machine_fingerprint: None, // this build read no fingerprint on the new record yet
+            machine_label: "Mac Mini 1",
+            model_identifier: Some("Macmini9,1"),
+            chip: "Apple M1",
+            cached_rkey: Some("r_new"),
+        };
+        let r = reconcile_provider_records(&listed, &me).expect("mine");
+        assert_eq!(
+            r.canonical_rkey, "r_new",
+            "keeps the current rkey (machineId stable)"
+        );
+        assert_eq!(
+            r.base.get("desiredTier").and_then(|v| v.as_str()),
+            Some("attested-confidential"),
+            "harvested owner intent"
+        );
+        assert_eq!(r.base.get("active").and_then(|v| v.as_bool()), Some(true));
+        assert_eq!(
+            r.delete,
+            vec![("r_old".into(), "cid-r_old".into())],
+            "prunes the stale duplicate"
+        );
+    }
+
+    #[test]
+    fn reconcile_never_touches_a_sibling_with_a_different_fingerprint() {
+        // A sibling machine (different fingerprint) under the same DID must be
+        // left completely alone even if some fields collide.
+        let listed = [
+            rec(
+                "r_me",
+                "t2",
+                Some("KEY_NEW"),
+                Some("FP_ME"),
+                "Mac Mini 1",
+                "Macmini9,1",
+                "Apple M1",
+                serde_json::json!({}),
+            ),
+            rec(
+                "r_sib",
+                "t1",
+                Some("KEY_SIB"),
+                Some("FP_SIB"),
+                "Mac Mini 1",
+                "Macmini9,1",
+                "Apple M1",
+                serde_json::json!({ "desiredTier": "attested-confidential" }),
+            ),
+        ];
+        let me = MachineIdentity {
+            attestation_pub_key: "KEY_NEW",
+            machine_fingerprint: Some("FP_ME"),
+            machine_label: "Mac Mini 1",
+            model_identifier: Some("Macmini9,1"),
+            chip: "Apple M1",
+            cached_rkey: Some("r_me"),
+        };
+        let r = reconcile_provider_records(&listed, &me).expect("mine");
+        assert_eq!(r.canonical_rkey, "r_me");
+        assert!(r.delete.is_empty(), "sibling never deleted");
+        assert!(
+            r.base.get("desiredTier").is_none(),
+            "sibling's intent never harvested"
+        );
+    }
+
+    #[test]
+    fn reconcile_ambiguous_legacy_left_alone() {
+        // Two legacy records with the SAME profile (identically-named machines):
+        // don't guess — adopt neither, delete neither.
+        let listed = [
+            rec(
+                "r1",
+                "t1",
+                Some("KEY_1"),
+                None,
+                "Mac",
+                "Macmini9,1",
+                "Apple M1",
+                serde_json::json!({ "desiredTier": "attested-confidential" }),
+            ),
+            rec(
+                "r2",
+                "t2",
+                Some("KEY_2"),
+                None,
+                "Mac",
+                "Macmini9,1",
+                "Apple M1",
+                serde_json::json!({}),
+            ),
+        ];
+        let me = MachineIdentity {
+            attestation_pub_key: "KEY_3", // neither matches our current key
+            machine_fingerprint: None,
+            machine_label: "Mac",
+            model_identifier: Some("Macmini9,1"),
+            chip: "Apple M1",
+            cached_rkey: None,
+        };
+        let r = reconcile_provider_records(&listed, &me);
+        assert!(r.is_none(), "ambiguous legacy → mint fresh, touch nothing");
+    }
+
+    #[test]
+    fn reconcile_fingerprint_match_survives_key_rotation() {
+        // Post-fix: both records carry a fingerprint. A rotated key with the same
+        // fingerprint is adopted; the older duplicate deleted.
+        let listed = [
+            rec(
+                "r_old",
+                "t1",
+                Some("KEY_OLD"),
+                Some("FP1"),
+                "Mac Mini 1",
+                "Macmini9,1",
+                "Apple M1",
+                serde_json::json!({ "desiredTier": "attested-confidential" }),
+            ),
+            rec(
+                "r_new",
+                "t2",
+                Some("KEY_NEW"),
+                Some("FP1"),
+                "Mac Mini 1",
+                "Macmini9,1",
+                "Apple M1",
+                serde_json::json!({}),
+            ),
+        ];
+        let me = MachineIdentity {
+            attestation_pub_key: "KEY_NEW",
+            machine_fingerprint: Some("FP1"),
+            machine_label: "Mac Mini 1",
+            model_identifier: Some("Macmini9,1"),
+            chip: "Apple M1",
+            cached_rkey: Some("r_new"),
+        };
+        let r = reconcile_provider_records(&listed, &me).expect("mine");
+        assert_eq!(r.canonical_rkey, "r_new");
+        assert_eq!(
+            r.base.get("desiredTier").and_then(|v| v.as_str()),
+            Some("attested-confidential")
+        );
+        assert_eq!(r.delete, vec![("r_old".into(), "cid-r_old".into())]);
+    }
 
     #[test]
     fn pro_bono_mode_any_serves_everyone() {


### PR DESCRIPTION
## The bug

The 0.9.43 software→Secure-Enclave signing-key switch changes a machine's `attestationPubKey`, and record + attestation-binding identity was keyed on that pubkey. So the rotation **orphaned everything bound to the old key** — one root cause, three user-visible symptoms:

1. **Confidential silently reverts.** The agent didn't recognize its old provider record (different pubkey → "another machine"), minted a fresh record with `desiredTier=None`, and stranded the owner's `desiredTier=attested-confidential` on the old record. Re-toggling in the tray lands on the wrong record.
2. **Clashing stale records.** The old-key record lingers → two `provider` records for one physical machine under one DID (breaks the console join, drives a register↔1006 reconcile loop).
3. **Secure Mode drops to `self-attested`.** The captured Apple MDA chain binds the old key via `freshnessCode == sha256(oldKey)`; the new SE key never gets a fresh chain, so `hardwareBound: no`.

This hits **every user upgrading to 0.9.43** who had confidential or Secure Mode on. Diagnosed live on a Mac Mini: 4 provider records under one DID, two for the same machine (old v0.9.42 w/ `desiredTier=attested-confidential`, new v0.9.43 w/ none).

## The fix

**Record continuity** (confidential toggle + stale duplicates):
- New `machineFingerprint` on the provider lexicon + record — a hash of the hardware serial (salted by DID, so it can't correlate a machine across owners). Unlike `attestationPubKey`, it **survives key rotation**.
- `reconcile_provider_records` — a pure, unit-tested function that identifies this machine's records (by fingerprint / current pubkey / cached rkey, plus a *unique* hardware-profile match for pre-fix legacy records), **harvests the owner's intent** (`desiredTier`, `active`, `desiredModels`, …) from any orphaned prior record into the canonical one, and prunes the stale duplicates — while provably **never touching a sibling machine's record** (a differing fingerprint is decisive; ambiguous legacy matches are left alone).
- `provider-rkey.json` decoupled from the pubkey (DID-scoped) so the rkey — and thus the advisor `machine_id` — stays stable across a rotation.
- **Self-heals** already-affected machines on the next serve (adopts the current record, harvests the stranded `desiredTier`, deletes the ghost).

**Secure Mode re-attestation** (agent side):
- Re-request a fresh key-bound MDA attestation the *moment* the signing key rotates, **bypassing the 6h cooldown** (the stale chain can never bind the new key, so waiting just prolongs `self-attested`). The marker now records the requested pubkey to detect the rotation. The coordinator (`requestDeviceInformationAttestation`) already enqueues a fresh DeviceInformation command with `nonce=sha256(newPubkey)`, so this closes the loop.

## Why a fingerprint (not just the pubkey)

The lexicon literally documented `attestationPubKey` as *"the stable per-machine fingerprint… survives reboots / re-pairs."* That held for a persisted software key but is violated by the SE rotation. This introduces an identity that's actually stable, and stops treating the signing key as machine identity.

## Tests

5 new `reconcile_provider_records` unit tests cover: current-key single record; **key-rotation adopts the legacy record + harvests `desiredTier` + prunes the old one**; a sibling with a different fingerprint is never touched/harvested; ambiguous legacy → mint fresh, touch nothing; fingerprint-match survives rotation. Provider suite **185 passing**; clippy / rustfmt / oxfmt / oxlint / lexicon-codegen all green; `--features apns` typechecks.

## Scope note

The MDM coordinator already re-issues correctly (no change needed). Apple's per-device attestation rate limit can still delay a *fresh* Secure Mode chain after a rotation — that's an Apple constraint, not something the agent can bypass; the agent now asks promptly and it lands when Apple's window allows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)