### PR TITLE
fix(mdm): discard stale-key attestation captures — don't serve a chain bound to a dead signing key

### DIFF
--- a/packages/console/src/lib/console-db.server.ts
+++ b/packages/console/src/lib/console-db.server.ts
@@ -142,6 +142,20 @@ CREATE TABLE IF NOT EXISTS mdm_attestation_chains (
   chain_json TEXT NOT NULL,
   captured_at TEXT NOT NULL
 );
+
+-- The signing key most recently requested for a device's MDA attestation. Set
+-- when the coordinator enqueues a DeviceInformation attestation (nonce =
+-- sha256(pubkey)); read when a chain is captured so we only STORE a chain whose
+-- freshness binds the currently-requested key. This is the fix for the
+-- signing-key rotation trap: stale queued commands (old-key nonces) drained by
+-- the device FIFO produced chains bound to a dead key, which then got served and
+-- rejected by the agent forever. We now discard those captures instead. Keyed
+-- by serial; a fresh request overwrites the expected key.
+CREATE TABLE IF NOT EXISTS mdm_attestation_expected (
+  serial TEXT PRIMARY KEY,
+  pubkey TEXT NOT NULL,
+  requested_at TEXT NOT NULL
+);
 `;
 
 // Indexes run after runMigrations() so they can reference columns

--- a/packages/console/src/lib/mdm-chain-store.server.ts
+++ b/packages/console/src/lib/mdm-chain-store.server.ts
@@ -41,3 +41,30 @@ export function getAttestationChain(
   }
   return null;
 }
+
+/** Record the signing key we just requested an MDA attestation for. Read at
+ *  capture time so we only store a chain whose freshness binds THIS key. */
+export function putExpectedAttestationKey(
+  serial: string,
+  pubkeyB64: string,
+  requestedAt: string,
+): void {
+  consoleDb()
+    .prepare(
+      `INSERT INTO mdm_attestation_expected (serial, pubkey, requested_at)
+       VALUES (?, ?, ?)
+       ON CONFLICT(serial) DO UPDATE SET
+         pubkey = excluded.pubkey,
+         requested_at = excluded.requested_at`,
+    )
+    .run(serial, pubkeyB64, requestedAt);
+}
+
+/** The signing key most recently requested for this device's attestation, or
+ *  null when none has been recorded (legacy captures — validation is skipped). */
+export function getExpectedAttestationKey(serial: string): string | null {
+  const row = consoleDb()
+    .prepare(`SELECT pubkey FROM mdm_attestation_expected WHERE serial = ?`)
+    .get(serial) as { pubkey: string } | undefined;
+  return row?.pubkey ?? null;
+}

--- a/packages/console/src/lib/mdm-coordinator.server.test.ts
+++ b/packages/console/src/lib/mdm-coordinator.server.test.ts
@@ -13,7 +13,9 @@ import {
   authenticateNanomdmWebhook,
   buildDeviceInformationAttestationCommand,
   buildEnrollmentProfile,
+  chainBindsPubkey,
   enqueueTargetNotEnrolled,
+  freshnessBindsPubkey,
   isValidSerial,
   isValidUdid,
   parseNanomdmAttestationWebhook,
@@ -346,5 +348,39 @@ describe("option-B DeviceInformation attestation (freshness binding)", () => {
     expect(authenticateNanomdmWebhook(wrong)).toBe(false);
     delete process.env["COCORE_NANOMDM_WEBHOOK_KEY"];
     expect(authenticateNanomdmWebhook(viaQuery)).toBe(false); // fail-closed when unset
+  });
+});
+
+describe("attestation key-binding guard (stale-command discard)", () => {
+  // A 64-byte raw P-256 pubkey (X||Y), base64 — the shape agent pubkey emits.
+  const PUBKEY = Buffer.alloc(64, 7).toString("base64");
+  const OTHER = Buffer.alloc(64, 9).toString("base64");
+
+  it("the nonce the coordinator sends for a key binds that key", () => {
+    // attestationNonceBytes(pubkey) is exactly the DeviceAttestationNonce we set,
+    // and Apple reflects it as the leaf freshness code.
+    const fresh = new Uint8Array(attestationNonceBytes(PUBKEY));
+    expect(freshnessBindsPubkey(fresh, PUBKEY)).toBe(true);
+  });
+
+  it("tolerates a DER OCTET STRING wrapper (04 20) on the freshness value", () => {
+    const fresh = attestationNonceBytes(PUBKEY);
+    const wrapped = new Uint8Array(Buffer.concat([Buffer.from([0x04, 0x20]), fresh]));
+    expect(freshnessBindsPubkey(wrapped, PUBKEY)).toBe(true);
+  });
+
+  it("REJECTS a stale key's freshness (the signing-key-rotation trap)", () => {
+    // A leftover queued command attested OTHER's nonce; it must not bind PUBKEY.
+    const staleFresh = new Uint8Array(attestationNonceBytes(OTHER));
+    expect(freshnessBindsPubkey(staleFresh, PUBKEY)).toBe(false);
+  });
+
+  it("rejects a wrong-length freshness value", () => {
+    expect(freshnessBindsPubkey(new Uint8Array(16), PUBKEY)).toBe(false);
+  });
+
+  it("chainBindsPubkey fails closed on an empty or unparseable chain", () => {
+    expect(chainBindsPubkey([], PUBKEY)).toBe(false);
+    expect(chainBindsPubkey(["not-base64-DER"], PUBKEY)).toBe(false);
   });
 });

--- a/packages/console/src/lib/mdm-coordinator.server.ts
+++ b/packages/console/src/lib/mdm-coordinator.server.ts
@@ -57,10 +57,53 @@
 //                              webhook presents to POST captured chains.
 //   COCORE_MDM_SIGNING_CERT_PEM / _KEY_PEM  CMS-sign the profile (TODO).
 
-import { createHash } from "node:crypto";
+import { parseExtensions } from "@cocore/sdk/mda";
+import { createHash, timingSafeEqual } from "node:crypto";
 
 import { resolveBearerKey, type ResolvedKey } from "@/lib/api-keys.server.ts";
-import { getAttestationChain, putAttestationChain } from "@/lib/mdm-chain-store.server.ts";
+import {
+  getAttestationChain,
+  getExpectedAttestationKey,
+  putAttestationChain,
+  putExpectedAttestationKey,
+} from "@/lib/mdm-chain-store.server.ts";
+
+/** Apple's freshness-code OID — the leaf extension whose value equals the
+ *  `DeviceAttestationNonce` we set (= sha256(pubkey)). Same OID the SDK/Rust/Py
+ *  verifiers key on. */
+const OID_FRESHNESS_CODE = "1.2.840.113635.100.8.11.1";
+
+/** Does a raw freshness-code value bind `pubkeyB64`? Mirrors the agent's
+ *  `mda::freshness_binds`: freshness == sha256(64-byte raw pubkey), tolerating a
+ *  DER OCTET STRING wrapper (0x04 0x20). Pure — the security-critical comparison. */
+export function freshnessBindsPubkey(freshness: Uint8Array, pubkeyB64: string): boolean {
+  const inner =
+    freshness.length === 34 && freshness[0] === 0x04 && freshness[1] === 0x20
+      ? freshness.subarray(2)
+      : freshness;
+  let digest: Buffer;
+  try {
+    digest = createHash("sha256").update(Buffer.from(pubkeyB64, "base64")).digest();
+  } catch {
+    return false;
+  }
+  return inner.length === digest.length && timingSafeEqual(Buffer.from(inner), digest);
+}
+
+/** Does the captured chain's leaf freshness code bind `pubkeyB64`? Parse-only (no
+ *  Apple-root verification — the agent + client still verify that); we only need
+ *  to know WHICH key this chain was minted for, to reject a stale-key capture. */
+export function chainBindsPubkey(chain: string[], pubkeyB64: string): boolean {
+  if (chain.length === 0) return false;
+  let ext: Uint8Array | undefined;
+  try {
+    const leaf = new Uint8Array(Buffer.from(chain[0]!, "base64"));
+    ext = parseExtensions(leaf).find((e) => e.oid === OID_FRESHNESS_CODE)?.value;
+  } catch {
+    return false;
+  }
+  return ext ? freshnessBindsPubkey(ext, pubkeyB64) : false;
+}
 
 // ---------------------------------------------------------------------------
 // Auth — same bearer-API-key surface every other /api/agent/* route uses.
@@ -616,11 +659,31 @@ export interface AttestationChainResult {
   capturedAt?: string;
 }
 
-/** Persist a captured Apple attestation chain (the step-ca webhook calls
- *  this after a successful device-attest-01). `nowIso` is the caller's
- *  timestamp so this stays a pure persistence step. */
-export function ingestAttestationChain(serial: string, chain: string[], nowIso: string): void {
+/** Persist a captured Apple attestation chain (a DeviceInformation command
+ *  result, or step-ca's device-attest-01 webhook). `nowIso` is the caller's
+ *  timestamp so this stays a pure persistence step.
+ *
+ *  KEY-BINDING GUARD (signing-key-rotation fix): the device drains its MDM
+ *  command queue FIFO, and Apple rate-limits DeviceAttestation to ~one per push
+ *  cycle — so a STALE queued command (an old signing key's nonce) can be the one
+ *  that attests, producing a chain bound to a dead key. Serving that chain used
+ *  to leave the machine looping on `does not bind the current signing key`
+ *  forever. We now only store a chain whose freshness binds the CURRENTLY
+ *  requested key; a stale-key capture is discarded (the good chain, if any, is
+ *  kept). When no expected key is recorded (legacy / pre-fix), we store as before
+ *  so nothing regresses. Returns whether the chain was stored. */
+export function ingestAttestationChain(serial: string, chain: string[], nowIso: string): boolean {
+  const expected = getExpectedAttestationKey(serial);
+  if (expected && !chainBindsPubkey(chain, expected)) {
+    console.warn(
+      `[mdm] discarding captured attestation chain for serial=${serial}: freshness does not ` +
+        `bind the currently-requested key (a stale queued DeviceAttestation command attested an ` +
+        `old key). Keeping any prior bound chain; the device will re-attest for the current key.`,
+    );
+    return false;
+  }
   putAttestationChain(serial, chain, nowIso);
+  return true;
 }
 
 /** Return the captured Apple x5c attestation chain for `serial`.
@@ -829,6 +892,11 @@ export async function requestDeviceInformationAttestation(
         detail: `NanoMDM enqueue failed (${enqueueResp.status}): ${text.slice(0, 200)}`,
       };
     }
+    // The command is now queued with nonce = sha256(publicKeyB64). Record it as
+    // the expected key so a capture that binds a STALE key (a leftover queued
+    // command draining ahead of this one) is discarded at ingest rather than
+    // served to the agent and rejected forever.
+    putExpectedAttestationKey(serial, publicKeyB64, new Date().toISOString());
     const pushResp = await fetch(`${root}/v1/push/${enc}`, {
       method: "GET",
       headers: { authorization: authHeader },


### PR DESCRIPTION
## The bug (Secure Mode, post key-rotation)

After the 0.9.43 software→Secure-Enclave signing-key rotation, Secure Mode gets stuck `self-attested` in a way the **agent can't fix** (follow-up to #177):

- The device drains its MDM command queue **FIFO**, and Apple **rate-limits DeviceAttestation to ~one per push cycle**.
- So a **stale queued `DeviceInformation` command** (carrying an *old* key's `nonce = sha256(oldKey)`) gets attested first. Apple returns a real chain whose **freshness binds a dead key**.
- The coordinator stored + served it; the agent rejected it forever: `captured chain does not bind the current signing key (rotated?)`.

Confirmed live on a real Mac: a fresh capture (`capturedAt` today) whose leaf freshness = `B016A7C3…` while `sha256(current key)` = `f302fd76…` — and no encoding of the current key produces `B016A7C3`. It's a genuinely stale key's chain.

## The fix

Only **store a captured chain whose freshness binds the *currently-requested* key**:

- Record the requested signing key per device when a `DeviceInformation` attestation is enqueued (`nonce = sha256(pubkey)`), in a new `mdm_attestation_expected` table.
- At ingest (`ingestAttestationChain`, the single capture seam for both the NanoMDM webhook and the manual ingest route), extract the leaf's Apple freshness OID — **reusing the SDK's `@cocore/sdk/mda` DER extension scanner** — and require it to equal `sha256(requested key)`, tolerating the `04 20` OCTET STRING wrapper (mirrors the agent's `mda::freshness_binds`, byte-for-byte).
- A **stale-key capture is discarded** (any prior bound chain is kept, not clobbered); when no expected key is recorded (legacy / pre-fix), behavior is unchanged so nothing regresses.

Net: a wrong-key chain is **never served**, and the machine converges to `hardware-attested` as soon as a current-key command attests.

## Tests

`freshnessBindsPubkey` / `chainBindsPubkey` are pure and unit-tested: the coordinator's own `attestationNonceBytes(key)` binds `key`; the `04 20` wrapper is tolerated; a **stale key's freshness is rejected** (the rotation trap); wrong-length + unparseable chains fail closed. Coordinator suite **25 passing**; oxfmt / oxlint / tsc clean.

## Honest caveat

Apple's per-device attestation rate limit still **paces convergence** as the queue drains stale commands — this PR doesn't flush the NanoMDM queue (no HTTP clear in stock NanoMDM). But a stale chain is no longer served in the meantime, so the machine can't get wedged on a dead-key chain; it lands on the right one once a current-key command attests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)