### PR TITLE
fix(console): stop OAuth refresh-token cannibalization (session dies every few hours)

### DIFF
--- a/packages/console/src/lib/disputes-resolve.server.ts
+++ b/packages/console/src/lib/disputes-resolve.server.ts
@@ -34,6 +34,8 @@ import { cocoreConfig } from "@/lib/cocore-config.ts";
 import { consoleDb } from "@/lib/console-db.server.ts";
 import { signRecordIfConfigured } from "@/lib/signing.server.ts";
 import { restoreAtprotoSessionEffect } from "@/integrations/auth/atproto.server.ts";
+import { appviewBackedSession, appviewSessionInfo } from "@/lib/appview-backed-session.server.ts";
+import { isAppviewForwardConfigured } from "@/lib/appview-pds-forward.server.ts";
 import type { Did } from "@atcute/lexicons";
 import { isDid } from "@atcute/lexicons/syntax";
 
@@ -166,6 +168,23 @@ async function loadExchangeSession(): Promise<OAuthSession> {
       "exchange-not-onboarded",
       `cocoreConfig.exchangeDid is not a DID (${exchangeDid})`,
     );
+  }
+  // Single-owner cutover: when forwarding is configured the AppView owns and
+  // solely refreshes the exchange service DID's session (its keep-alive is the
+  // designated refresher — see packages/appview/src/auth/oauth-client.ts). A
+  // local restore here would refresh in parallel and cannibalize the single-use
+  // refresh token — precisely the 2026-06 settlement stall (a dead exchange
+  // session blocking every settlement write). Replay dispute writes through the
+  // AppView-backed session; only a DEFINITIVE "absent" means re-auth is needed.
+  if (isAppviewForwardConfigured()) {
+    const info = await appviewSessionInfo(exchangeDid);
+    if (info.checked && !info.present) {
+      throw new ResolveDisputeError(
+        "exchange-not-onboarded",
+        `no live AppView session for ${exchangeDid} — exchange must sign in to resolve disputes`,
+      );
+    }
+    return appviewBackedSession(exchangeDid as Did);
   }
   const session = await runTraced(
     "auth.restoreSession",

--- a/packages/console/src/lib/pds-write.server.test.ts
+++ b/packages/console/src/lib/pds-write.server.test.ts
@@ -1,0 +1,105 @@
+// Regression test for the single-owner OAuth cutover.
+//
+// The bug: `pdsGetServiceAuth` restored the DID's OAuth session LOCALLY on the
+// console on every call. The agent re-mints a service-auth token on every
+// advisor registration (~every 14 min), and a local restore refreshes the
+// session — rotating the single-use DPoP refresh token out from under the
+// AppView, which is the designated single owner/refresher. Two refreshers
+// cannibalize one token → the session dies every few hours (browser logouts +
+// agent 401s + `registrationAuthenticated` dropping → confidential/Secure off).
+//
+// The fix: when forwarding is configured, mint the token through the
+// AppView-backed session (which replays via the AppView's owned session and
+// refreshes nothing on the console). These tests lock that: with the forward
+// configured the local restore is NEVER called; without it the legacy local
+// path is preserved unchanged.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = {
+  forwardConfigured: true,
+  did: "did:plc:owner" as string,
+  restoreCalls: 0,
+  backedHandleCalls: 0,
+};
+
+vi.mock("@/lib/api-keys.server.ts", () => ({
+  resolveBearerKey: (_bearer: string) => ({ did: state.did }),
+}));
+
+vi.mock("@/lib/appview-pds-forward.server.ts", () => ({
+  isAppviewForwardConfigured: () => state.forwardConfigured,
+  // unused on the getServiceAuth path but imported at module load
+  forwardPdsWrite: async () => new Response("{}", { status: 200 }),
+}));
+
+vi.mock("@/lib/appview-backed-session.server.ts", () => ({
+  appviewBackedSession: (did: string) => ({
+    did,
+    handle: async (_path: string, _init?: unknown) => {
+      state.backedHandleCalls += 1;
+      return new Response(JSON.stringify({ token: "appview-minted-token" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  }),
+}));
+
+vi.mock("@/integrations/auth/atproto.server.ts", async () => {
+  const { Effect } = await import("effect");
+  return {
+    lastRestoreError: () => undefined,
+    // If this ever runs while the forward is configured, the cannibalizing
+    // second refresher is back — the test asserts it does NOT.
+    restoreAtprotoSessionEffect: () =>
+      Effect.sync(() => {
+        state.restoreCalls += 1;
+        return {
+          did: state.did,
+          handle: async () =>
+            new Response(JSON.stringify({ token: "local-minted-token" }), {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            }),
+        };
+      }),
+  };
+});
+
+async function callGetServiceAuth() {
+  const { pdsGetServiceAuth } = await import("./pds-write.server.ts");
+  const req = new Request("https://console.example/api/pds/getServiceAuth", {
+    method: "POST",
+    headers: { authorization: "Bearer k", "content-type": "application/json" },
+    body: JSON.stringify({ aud: "did:web:advisor.cocore.dev", lxm: "dev.cocore.compute.register" }),
+  });
+  return pdsGetServiceAuth(req);
+}
+
+describe("pdsGetServiceAuth single-owner cutover", () => {
+  beforeEach(() => {
+    state.forwardConfigured = true;
+    state.did = "did:plc:owner";
+    state.restoreCalls = 0;
+    state.backedHandleCalls = 0;
+    delete process.env["COCORE_ADVISOR_DID"];
+  });
+
+  it("mints via the AppView-backed session and never restores locally when forwarding is configured", async () => {
+    const res = await callGetServiceAuth();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ token: "appview-minted-token" });
+    expect(state.backedHandleCalls).toBe(1);
+    expect(state.restoreCalls).toBe(0); // the cannibalizing second refresher stays dormant
+  });
+
+  it("falls back to the legacy local restore when forwarding is NOT configured", async () => {
+    state.forwardConfigured = false;
+    const res = await callGetServiceAuth();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ token: "local-minted-token" });
+    expect(state.restoreCalls).toBe(1);
+    expect(state.backedHandleCalls).toBe(0);
+  });
+});

--- a/packages/console/src/lib/pds-write.server.ts
+++ b/packages/console/src/lib/pds-write.server.ts
@@ -24,6 +24,7 @@ import {
   restoreAtprotoSessionEffect,
 } from "@/integrations/auth/atproto.server.ts";
 import { resolveBearerKey } from "@/lib/api-keys.server.ts";
+import { appviewBackedSession } from "@/lib/appview-backed-session.server.ts";
 import { forwardPdsWrite, isAppviewForwardConfigured } from "@/lib/appview-pds-forward.server.ts";
 import { bridgeHeaders, cocoreConfig } from "@/lib/cocore-config.ts";
 
@@ -508,12 +509,33 @@ export async function pdsGetServiceAuth(request: Request): Promise<Response> {
     return jsonError(403, "aud not permitted");
   }
 
-  const session = await restoreSessionOr401(did);
+  // Single-owner cutover: when forwarding is configured the AppView OWNS and
+  // solely refreshes this DID's session. Minting a service-auth token requires
+  // a live PDS call (com.atproto.server.getServiceAuth) — and restoring the
+  // session locally here refreshes it, rotating the single-use DPoP refresh
+  // token out from under the AppView. The agent re-mints on EVERY advisor
+  // registration (~every 14 min), so this un-migrated path was the second
+  // refresher that cannibalized the session every few hours (browser logouts +
+  // agent 401s + registrationAuthenticated dropping → confidential/Secure off).
+  // Replay through the AppView-backed session instead; the AppView's internal
+  // proxy allowlists exactly this method (see packages/appview/src/pds/write.ts).
+  const session = isAppviewForwardConfigured()
+    ? appviewBackedSession(did)
+    : await restoreSessionOr401(did);
   if (session instanceof Response) return session;
   const qs = new URLSearchParams({ aud, lxm }).toString();
-  const r = await session.handle(`/xrpc/com.atproto.server.getServiceAuth?${qs}`, {
-    method: "GET",
-  });
+  let r: Response;
+  try {
+    r = await session.handle(`/xrpc/com.atproto.server.getServiceAuth?${qs}`, {
+      method: "GET",
+    });
+  } catch (e) {
+    // An AppView-backed `.handle()` throws only on an internal-layer failure
+    // (AppView unreachable / bad secret) — a transient transport problem, not
+    // an upstream PDS status. Surface a 502 so the agent registers without the
+    // token this cycle and retries on the next, rather than a 500 stack.
+    return jsonError(502, `pds getServiceAuth via appview: ${(e as Error).message.slice(0, 200)}`);
+  }
   if (!r.ok) {
     const body = await r.text().catch(() => "");
     return jsonError(r.status >= 500 ? 502 : r.status, `pds getServiceAuth: ${body.slice(0, 300)}`);


### PR DESCRIPTION
## Symptom
Sessions die every few hours across the fleet: the **browser logs you out**, **re-sign-in doesn't stick**, and the **agent 401s** so `registrationAuthenticated` drops → **confidential + Secure Mode both turn off**. It used to be "log in once, stay logged in forever."

## Root cause: a second OAuth refresher
ATProto OAuth refresh tokens are **single-use** (rotated on every refresh), so exactly one process may refresh a session. The design makes the **AppView** that sole owner — the console hands the session off at login and thereafter must never call `restore()` (which refreshes). The write routes and the browser middleware were migrated to forward-to-AppView, but **two paths never got the cutover** and still refreshed locally on the console:

1. **`pdsGetServiceAuth`** restored the session locally on every call. The agent re-mints a service-auth token on **every advisor registration (~every 14 min)**, so this refreshed the token in parallel with the AppView's owned session and cannibalized it.
2. **`loadExchangeSession`** (dispute resolution) restored the exchange **service** DID locally, racing the AppView keep-alive that owns it — same class, and precisely the shape of the 2026-06 settlement stall.

### Confirmed in prod logs
```
console  [atproto.restore] FAILED did=…jijwtzgroy76… session was deleted by another process
appview  did=…jijwtzgroy76… error="Invalid refresh token"          (93ms apart, same DID)
agent    could not mint service-auth JWT … 401 … re-authenticate    (every ~14 min)
```
The console `restore` (every 14 min, from getServiceAuth) rotated the token out from under the AppView; both copies died; every PDS write 401'd; the browser session (same DID-keyed OAuth session) went with it.

## Fix
Both paths now use `appviewBackedSession(did)` when forwarding is configured, which replays the call through the single owner and **refreshes nothing on the console**. `com.atproto.server.getServiceAuth` is **already allowlisted** by the AppView's internal proxy (`packages/appview/src/pds/write.ts`) — the AppView side was ready; only the console handler wasn't wired in. The legacy local-restore path is preserved unchanged for the forward-unconfigured case.

## Security
No trust-boundary change. The service-auth token is still minted by the **caller's own repo key** and scoped to `dev.cocore.*` lxm (the H1 confused-deputy guard is untouched). This only moves **where** the DPoP session is refreshed — eliminating the second writer.

## Tests
- New `pds-write.server.test.ts`: forward configured → local restore **never** called, token minted via AppView; unconfigured → legacy path intact.
- tsc clean, oxlint clean, openai-routes tests pass.
- (Pre-existing `app-session-store.test.ts` failures are the known better-sqlite3 Node-ABI mismatch, unrelated — they fail identically on main.)

## Deploy
Console-only; deploys on Railway. No agent/app release needed — existing agents recover on their next registration once the console stops cannibalizing the token. Users may need **one** final re-auth after deploy to seed a clean session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)