### PR TITLE
fix(tray): only register a login item when installed in /Applications

### DIFF
--- a/provider-shell/Sources/CoCoreShell/CocoreShellApp.swift
+++ b/provider-shell/Sources/CoCoreShell/CocoreShellApp.swift
@@ -72,6 +72,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func registerLoginItem() {
+        // Only the app installed in /Applications may register itself as a login
+        // item. Dev builds run from the build directory must NOT, otherwise every
+        // local build accumulates its own login item and they all launch at boot,
+        // each spawning a competing `agent serve` against the advisor.
+        guard Bundle.main.bundlePath.hasPrefix("/Applications/") else {
+            NSLog("cocore: skipping login-item registration (not installed in /Applications): %@", Bundle.main.bundlePath)
+            return
+        }
         do {
             if SMAppService.mainApp.status != .enabled {
                 try SMAppService.mainApp.register()


### PR DESCRIPTION
## Problem
`SMAppService.mainApp.register()` registers the **specific bundle path it's launched from** as a login item. Running local dev builds — each from a distinct path under `provider-shell/build/…` — accumulates a **separate login item per build**. At the next boot, macOS launches *all* of them, and each starts its own `agent serve` competing against the advisor under the same DID.

That's a plausible contributor to the duplicate-agent / churn / multi-machine ping-pong behavior we've been chasing on dev machines specifically.

## Fix
Guard registration on the app bundle living in `/Applications`:

```swift
guard Bundle.main.bundlePath.hasPrefix("/Applications/") else {
    NSLog("cocore: skipping login-item registration (not installed in /Applications): …")
    return
}
```

## Impact
- **Release builds** (in `/Applications`): **zero change** — they register exactly as before.
- **Dev builds** (out of `/Applications`): skip registration and log why, so they stop polluting login items with competing agents.

Tray-side only; builds clean. Shipping in 0.9.46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)