### PR TITLE
fix(provider): serve is the single signing-key authority — memoized identity + published pubkey

### DIFF
--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -325,7 +325,7 @@ fn open_pds() -> Result<(PdsClient, String, String)> {
     let session = oauth::load_session()?.context("not paired — run `cocore agent pair` first")?;
     let did = session.did.clone();
     let pds = PdsClient::new(session);
-    let signer = secure_enclave::load_or_create_identity()?;
+    let signer = secure_enclave::shared_identity()?;
     Ok((pds, did, signer.public_key_b64()))
 }
 
@@ -567,7 +567,7 @@ async fn read_desired_tier_live() -> TierRead {
     let Some(session) = oauth::load_session().ok().flatten() else {
         return TierRead::Unreadable; // not paired / no session on disk
     };
-    let Ok(signer) = secure_enclave::load_or_create_identity() else {
+    let Ok(signer) = secure_enclave::shared_identity() else {
         return TierRead::Unreadable;
     };
     let pubkey = signer.public_key_b64();
@@ -1518,7 +1518,7 @@ async fn read_my_desired_models() -> Vec<String> {
     };
     let did = session.did.clone();
     let pds = PdsClient::new(session);
-    let Ok(signer) = secure_enclave::load_or_create_identity() else {
+    let Ok(signer) = secure_enclave::shared_identity() else {
         return Vec::new();
     };
     let pubkey = signer.public_key_b64();
@@ -1615,8 +1615,12 @@ async fn cmd_serve(
     // close the connection with `attestation-bad-signature`.
     // Held as an `Arc` so the background re-attestation task can share the same
     // signing identity as the serve loop (the trait is `Send + Sync`).
-    let signer: Arc<dyn secure_enclave::SigningIdentity> =
-        secure_enclave::load_or_create_identity()?.into();
+    let signer = secure_enclave::shared_identity()?;
+    // The serve is the single SE-key authority: publish its pubkey so the
+    // `agent pubkey` CLI (which the Secure Mode wizard runs) requests MDM
+    // attestation for THIS exact key, instead of loading a possibly-different
+    // usable key in its own process context.
+    secure_enclave::publish_signing_pubkey(&signer.public_key_b64());
 
     // Encryption key for sealed prompts + the APNs code-challenge nonce. On a
     // confidential (`secure_enclave`) build this is the SE-resident P-256 ECIES
@@ -3651,8 +3655,18 @@ fn cmd_whoami() -> Result<()> {
 /// (or creates) the Secure Enclave identity, same as the serve loop, so the
 /// printed key matches what attestations publish.
 fn cmd_pubkey() -> Result<()> {
-    let signer = secure_enclave::load_or_create_identity()?;
-    println!("{}", signer.public_key_b64());
+    // Prefer the SERVE's published pubkey. The serve is the single process that
+    // holds the SE key; a one-shot CLI (which is what the Secure Mode wizard runs
+    // to bind MDM attestation) may load a DIFFERENT usable SE key than the serve
+    // in its own process context, so loading a key here would request attestation
+    // for the wrong key. Reading the serve's published pubkey guarantees the
+    // wizard requests attestation for the exact key the serve signs with. Fall
+    // back to loading only when no serve has published one (e.g. pre-setup).
+    if let Some(pubkey) = secure_enclave::read_published_signing_pubkey() {
+        println!("{pubkey}");
+        return Ok(());
+    }
+    println!("{}", secure_enclave::shared_identity()?.public_key_b64());
     Ok(())
 }
 

--- a/provider/src/secure_enclave.rs
+++ b/provider/src/secure_enclave.rs
@@ -12,6 +12,9 @@
 //! distinguishes these cases.
 
 use anyhow::Result;
+use once_cell::sync::OnceCell;
+use std::path::PathBuf;
+use std::sync::Arc;
 
 #[derive(Debug, thiserror::Error)]
 pub enum EnclaveError {
@@ -60,6 +63,74 @@ pub fn load_or_create_identity() -> Result<Box<dyn SigningIdentity>> {
     }
     #[allow(unreachable_code)]
     Ok(Box::new(software::SoftwareIdentity::generate()?))
+}
+
+/// Process-global signing identity, loaded exactly ONCE and shared thereafter.
+///
+/// Loading is NOT deterministic across repeated calls on a real machine: an SE
+/// key created/accessible in one process context is not always reconstructible
+/// in another, so a fresh `load_or_create_identity()` on each call could return
+/// DIFFERENT keys within the same process (observed: a serve publishing one
+/// attestation under `1feH…` then the rest under `1MPNTd…`). That flapping is
+/// fatal for MDM attestation — the captured chain binds `sha256(signing pubkey)`,
+/// so a moving key never binds. Memoizing here pins the process to the first key
+/// it successfully loads, which is what every in-process caller must share.
+static SHARED_IDENTITY: OnceCell<Arc<dyn SigningIdentity>> = OnceCell::new();
+
+pub fn shared_identity() -> Result<Arc<dyn SigningIdentity>> {
+    SHARED_IDENTITY
+        .get_or_try_init(|| -> Result<Arc<dyn SigningIdentity>> {
+            let arc: Arc<dyn SigningIdentity> = load_or_create_identity()?.into();
+            // DIAGNOSTIC (load-bearing for triaging Secure Mode): record exactly
+            // which key this process pinned and whether it's hardware-bound, so a
+            // serve↔wizard key mismatch is visible in the log instead of inferred
+            // from attestation records.
+            tracing::info!(
+                pubkey = %arc.public_key_b64(),
+                hardware_bound = arc.is_hardware_bound(),
+                "pinned process signing identity (memoized)"
+            );
+            Ok(arc)
+        })
+        .cloned()
+}
+
+/// `~/.cocore/signing-pubkey` — the serve's canonical signing public key in
+/// plaintext base64. The serve is the SINGLE process that holds the SE key; every
+/// other context (the `agent pubkey` CLI that backs the Secure Mode wizard) reads
+/// THIS file instead of loading its own SE key, so the wizard always requests MDM
+/// attestation for the exact key the serve signs with. This sidesteps the
+/// cross-context SE-key problem entirely: only one process ever touches the key.
+pub fn signing_pubkey_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".cocore").join("signing-pubkey"))
+}
+
+/// Called by the SERVE (and only the serve) after it pins its identity, so the
+/// file always reflects the key the running serve actually uses. Best-effort.
+pub fn publish_signing_pubkey(pubkey_b64: &str) {
+    let Some(path) = signing_pubkey_path() else {
+        return;
+    };
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Err(e) = std::fs::write(&path, pubkey_b64) {
+        tracing::warn!(error = %e, "could not publish signing-pubkey file");
+    } else {
+        tracing::info!(pubkey = %pubkey_b64, "published serve signing pubkey for the wizard/CLI");
+    }
+}
+
+/// Read the serve's published signing pubkey, if a serve has written it. `None`
+/// when absent (no serve has run yet) — the caller falls back to loading a key.
+pub fn read_published_signing_pubkey() -> Option<String> {
+    let raw = std::fs::read_to_string(signing_pubkey_path()?).ok()?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
 }
 
 #[cfg(all(target_os = "macos", feature = "secure_enclave"))]


### PR DESCRIPTION
## The real root cause (found by driving the live 0.9.48 app)
**An SE key created/accessible in one process context is not reliably usable in another.** On the real machine:
- the GUI-launched `serve` settled on key `1MPNTd…`
- the `agent pubkey` CLI (which the Secure Mode **wizard** runs to bind MDM attestation) read a **different** usable key `1feH…` — from the *same* blob file, same `HOME`
- so the wizard requested attestation for a key the serve never signs with → the captured chain (freshness = `sha256(signing pubkey)`) can never bind → `trustLevel=None` forever
- the serve *itself* flapped (`1feH…` then `1MPNTd…`) because 5 separate call sites each did a fresh, non-deterministic `load_or_create_identity()`

**Why the last six PRs each helped but none finished it:** they all tried to make two process contexts *share* one SE key (per-machine identity, rotation continuity, data-protection keychain #184, a plain file #185). Shared storage can't fix a *key* that's context-bound.

## Fix — stop sharing the key across contexts
1. **Memoize** the identity per process (`shared_identity()`, once_cell) so every in-process call site returns ONE key — the serve can't flap mid-run.
2. **The serve is the single SE-key holder.** It publishes its pubkey (plaintext) to `~/.cocore/signing-pubkey` at startup. `agent pubkey` **reads that file** instead of loading its own SE key, so the wizard always requests attestation for the exact key the serve signs with. Falls back to loading only when no serve has published one (pre-setup).
3. **Diagnostic logs** (`pinned process signing identity`, `published serve signing pubkey`) surface the serve's real key on-device instead of inferring it from attestation records.

Only one process ever touches the SE key; everyone else reads its published pubkey. That removes the cross-context assumption that kept breaking.

## Validation (before shipping)
Local build against a temp HOME:
- serve publishes `SERVEKEY…` → `agent pubkey` returns **exactly** `SERVEKEY…` (reads the file, doesn't load its own) ✅
- no file → falls back to a **stable** loaded key ✅
- 185 lib tests pass, fmt + clippy clean, links with `--features secure_enclave`

## On-device confirmation after release (the real proof)
The diagnostic log will show the serve's **pinned pubkey == `agent pubkey` == the attestation record's key**, and Secure Mode binds (`trustLevel: hardware-attested`). I'll verify that on the machine before calling it done — no more declaring victory from a clean-room test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)