### PR TITLE
fix(mdm): idempotent DeviceInformation attestation enqueue (coordinator side of Secure Mode)

### DIFF
--- a/packages/console/src/lib/mdm-chain-store.server.ts
+++ b/packages/console/src/lib/mdm-chain-store.server.ts
@@ -68,3 +68,15 @@ export function getExpectedAttestationKey(serial: string): string | null {
     .get(serial) as { pubkey: string } | undefined;
   return row?.pubkey ?? null;
 }
+
+/** The key AND when it was requested — used to make DeviceInformation enqueue
+ *  idempotent (don't pile a second command for the same key onto NanoMDM's FIFO
+ *  queue while the first is still pending). Null when none recorded. */
+export function getExpectedAttestation(
+  serial: string,
+): { pubkey: string; requestedAt: string } | null {
+  const row = consoleDb()
+    .prepare(`SELECT pubkey, requested_at FROM mdm_attestation_expected WHERE serial = ?`)
+    .get(serial) as { pubkey: string; requested_at: string } | undefined;
+  return row ? { pubkey: row.pubkey, requestedAt: row.requested_at } : null;
+}

--- a/packages/console/src/lib/mdm-coordinator-idempotency.test.ts
+++ b/packages/console/src/lib/mdm-coordinator-idempotency.test.ts
@@ -1,0 +1,87 @@
+// Idempotency of the DeviceInformation attestation enqueue.
+//
+// NanoMDM's per-device command queue is FIFO with no clear API. Re-enqueuing a
+// DeviceInformation command for a key we already requested piles stale commands
+// ahead of the real one AND hammers Apple's rate-limited DeviceAttestation into
+// returning a CACHED (old-key) chain — which #178 then discards forever. So a
+// repeat request for the SAME key must NOT enqueue again; it only re-pushes the
+// command already queued. A key change must still enqueue immediately.
+//
+// The store is mocked (no better-sqlite3), and fetch is stubbed so we can assert
+// exactly which NanoMDM endpoints are hit.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const store = { pending: null as { pubkey: string; requestedAt: string } | null };
+
+vi.mock("./mdm-chain-store.server.ts", () => ({
+  getExpectedAttestation: () => store.pending,
+  getExpectedAttestationKey: () => store.pending?.pubkey ?? null,
+  putExpectedAttestationKey: (serial: string, pubkey: string, requestedAt: string) => {
+    store.pending = { pubkey, requestedAt };
+  },
+  getAttestationChain: () => null,
+  putAttestationChain: () => {},
+}));
+
+import { requestDeviceInformationAttestation } from "./mdm-coordinator.server.ts";
+
+const SERIAL = "H2WHW38LQ6NV";
+const UDID = "A1B2C3D4-1111-2222-3333-444455556666";
+const KEY_A = Buffer.alloc(64, 1).toString("base64");
+const KEY_B = Buffer.alloc(64, 2).toString("base64");
+
+let calls: string[] = [];
+
+beforeEach(() => {
+  store.pending = null;
+  calls = [];
+  process.env["COCORE_NANOMDM_URL"] = "https://nano.example";
+  process.env["COCORE_NANOMDM_API_KEY"] = "k";
+  vi.stubGlobal("fetch", async (url: string) => {
+    calls.push(String(url));
+    return { ok: true, status: 200, text: async () => "" } as Response;
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env["COCORE_NANOMDM_URL"];
+  delete process.env["COCORE_NANOMDM_API_KEY"];
+});
+
+const enqueued = () => calls.some((u) => u.includes("/v1/enqueue/"));
+const pushed = () => calls.some((u) => u.includes("/v1/push/"));
+
+describe("requestDeviceInformationAttestation idempotency", () => {
+  it("first request for a key enqueues + pushes", async () => {
+    await requestDeviceInformationAttestation(SERIAL, UDID, KEY_A);
+    expect(enqueued()).toBe(true);
+    expect(pushed()).toBe(true);
+    expect(store.pending?.pubkey).toBe(KEY_A);
+  });
+
+  it("a repeat request for the SAME key re-pushes but does NOT enqueue again", async () => {
+    store.pending = { pubkey: KEY_A, requestedAt: new Date().toISOString() };
+    const r = await requestDeviceInformationAttestation(SERIAL, UDID, KEY_A);
+    expect(enqueued()).toBe(false); // no duplicate command piled onto the queue
+    expect(pushed()).toBe(true); // but the queued command is nudged
+    expect(r.detail).toMatch(/already requested/i);
+  });
+
+  it("a KEY CHANGE enqueues immediately (bypasses dedup)", async () => {
+    store.pending = { pubkey: KEY_A, requestedAt: new Date().toISOString() };
+    await requestDeviceInformationAttestation(SERIAL, UDID, KEY_B);
+    expect(enqueued()).toBe(true);
+    expect(store.pending?.pubkey).toBe(KEY_B);
+  });
+
+  it("a STALE same-key request (past the dedup window) enqueues a fresh command", async () => {
+    store.pending = {
+      pubkey: KEY_A,
+      requestedAt: new Date(Date.now() - 7 * 60 * 60_000).toISOString(), // 7h ago > 6h window
+    };
+    await requestDeviceInformationAttestation(SERIAL, UDID, KEY_A);
+    expect(enqueued()).toBe(true);
+  });
+});

--- a/packages/console/src/lib/mdm-coordinator.server.ts
+++ b/packages/console/src/lib/mdm-coordinator.server.ts
@@ -63,10 +63,21 @@ import { createHash, timingSafeEqual } from "node:crypto";
 import { resolveBearerKey, type ResolvedKey } from "@/lib/api-keys.server.ts";
 import {
   getAttestationChain,
+  getExpectedAttestation,
   getExpectedAttestationKey,
   putAttestationChain,
   putExpectedAttestationKey,
 } from "@/lib/mdm-chain-store.server.ts";
+
+/** How long a DeviceInformation attestation request for a given key stays
+ *  "pending" before we'll enqueue a fresh command for that SAME key. NanoMDM's
+ *  queue is FIFO with no clear API, so re-enqueuing the same key just piles stale
+ *  commands ahead of the real one — and hammering Apple's rate-limited
+ *  DeviceAttestation makes it return a CACHED (old-key) chain. Within this window
+ *  a repeat request for the same key only RE-PUSHES the already-queued command
+ *  instead of adding another. A KEY CHANGE always enqueues immediately (bypasses
+ *  this). Comfortably under Apple's ~7-day attestation cadence. */
+const ATTEST_REQUEST_DEDUP_MS = 6 * 60 * 60_000;
 
 /** Apple's freshness-code OID — the leaf extension whose value equals the
  *  `DeviceAttestationNonce` we set (= sha256(pubkey)). Same OID the SDK/Rust/Py
@@ -861,6 +872,40 @@ export async function requestDeviceInformationAttestation(
   const root = base.replace(/\/$/, "");
   const authHeader = `Basic ${Buffer.from(`nanomdm:${apiKey}`).toString("base64")}`;
   const enc = encodeURIComponent(target);
+
+  // Idempotency: if we already requested attestation for THIS exact key recently,
+  // don't append another DeviceInformation command to NanoMDM's FIFO queue —
+  // that's what let stale old-key commands drain ahead of the real one and made
+  // Apple's rate-limited attestation return a cached (old-key) chain, so the
+  // capture was discarded forever. Instead just RE-PUSH so the device processes
+  // the command already queued for this key. A key change falls through and
+  // enqueues immediately (below).
+  const pending = getExpectedAttestation(serial);
+  const sameKeyPending =
+    pending?.pubkey === publicKeyB64 &&
+    Date.now() - Date.parse(pending.requestedAt) < ATTEST_REQUEST_DEDUP_MS;
+  if (sameKeyPending) {
+    let pushed = false;
+    try {
+      const rp = await fetch(`${root}/v1/push/${enc}`, {
+        method: "GET",
+        headers: { authorization: authHeader },
+      });
+      pushed = rp.ok;
+    } catch {
+      /* push is best-effort — the queued command is still there */
+    }
+    return {
+      queued: true,
+      commandUuid: null,
+      status: "queued",
+      stubbed: false,
+      detail: pushed
+        ? "attestation already requested for this key; re-pushed the queued command (no duplicate enqueue — avoids piling stale commands + Apple rate-limit)"
+        : "attestation already requested for this key; queued command awaits the device's next check-in",
+    };
+  }
+
   const commandUuid = crypto.randomUUID().toUpperCase();
   const enqueueBody = buildDeviceInformationAttestationCommand(
     commandUuid,


### PR DESCRIPTION
## Context
With #186 the agent-side key mismatch is fixed and proven (serve = `agent pubkey` = attestation, all `1feH…`). That isolated the **last** blocker for Secure Mode to the coordinator, which the live logs show precisely:

```
[mdm] discarding captured attestation chain … freshness does not bind the currently-requested key
(a stale queued DeviceAttestation command attested an old key)
```

## The bug
`requestDeviceInformationAttestation` **appended** a new DeviceInformation command to NanoMDM's per-device **FIFO** queue on *every* call — and NanoMDM (standard `-api` build) has **no clear-queue endpoint**. Repeated calls (agent auto-request every 6h + every wizard toggle + every restart) piled up stale commands carrying **old-key** nonces. The device drains them FIFO, each yielding an attestation bound to an old key → #178 correctly discards it → the real, current-key command never lands a fresh attestation. And hammering Apple's rate-limited DeviceAttestation (~1/device/7d) makes it return a **cached** old-key chain regardless of the new nonce.

## Fix
Make the enqueue **idempotent**. If we already requested attestation for **this exact key** within a 6h window, don't enqueue another command — just **re-push** so the device processes the one already queued. A **key change** still enqueues immediately. This stops both the pile-up and the Apple-rate-limit hammering; combined with #186's now-stable key, the single current-key command drains and finally attests the right key.

- `getExpectedAttestation(serial)` returns the requested key + timestamp for the (pubkey, recency) dedup.
- 4 new tests: first-request enqueues + pushes; same-key-recent re-pushes only (no duplicate enqueue); key-change enqueues immediately; stale-same-key (>6h) re-enqueues.

## Notes
- Console-only; deploys on Railway. No agent/app release needed.
- 29 coordinator tests pass (25 existing + 4 new), tsc + oxlint clean.
- For an already-piled-up device (like my test Mac), the next auto-request/toggle now re-pushes rather than re-enqueues, and the queued current-key command drains on subsequent check-ins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)