### PR TITLE
Upgrade native MLX engine for Qwen 3.5/3.6, mark as confidential

### DIFF
--- a/packages/console/src/components/docs/security-page.tsx
+++ b/packages/console/src/components/docs/security-page.tsx
@@ -142,10 +142,10 @@ export function SecurityDocsPage() {
         <h2 {...stylex.props(docsStyles.h2)}>The model constraint for operators</h2>
         <p {...stylex.props(docsStyles.prose)}>
           Confidential serving runs in the agent&apos;s in-process engine, which only loads certain
-          model architectures — Qwen2 / Qwen3 / Llama / Gemma / Phi / Mistral-class weights. A model
-          outside that set (for example a newer Qwen3.5+, Gemma 4, or Llama 4 architecture) can only
-          be served best-effort, in the readable helper process. The provider app marks each model
-          in the picker as <strong>“Confidential&nbsp;✓”</strong> or{" "}
+          model architectures — Qwen2 / Qwen3 / Qwen3.5 / Qwen3.6 / Llama / Gemma / Phi /
+          Mistral-class weights. A model outside that set (for example a Gemma 4 or Llama 4
+          architecture) can only be served best-effort, in the readable helper process. The provider
+          app marks each model in the picker as <strong>“Confidential”</strong> or{" "}
           <strong>“Best-effort only”</strong>: choosing a best-effort-only model means your machine
           can&apos;t offer requestors the confidential posture while serving it, even if the machine
           is otherwise confidential-capable. Pick a confidential-capable model to keep it.

--- a/packages/console/src/components/machines/MachinesDashboard.tsx
+++ b/packages/console/src/components/machines/MachinesDashboard.tsx
@@ -134,16 +134,28 @@ const FLEET_TABLE_COLUMNS: {
 interface ModelFloor {
   /** Floor RAM in GB below which the model is unlikely to load. */
   minRamGB: number;
-  /** Short human label for the warning copy (e.g. "Qwen2.5-3B"). */
+  /** Short human label for the warning copy (e.g. "Qwen3.5-4B"). */
   label: string;
 }
 
 const MODEL_RAM_FLOORS: Readonly<Record<string, ModelFloor>> = {
+  "mlx-community/Qwen3.5-0.8B-MLX-4bit": { minRamGB: 4, label: "Qwen3.5-0.8B" },
+  "mlx-community/Qwen3.5-2B-MLX-4bit": { minRamGB: 6, label: "Qwen3.5-2B" },
+  "mlx-community/Qwen3.5-4B-MLX-4bit": { minRamGB: 8, label: "Qwen3.5-4B" },
+  "mlx-community/Qwen3.5-9B-MLX-4bit": { minRamGB: 16, label: "Qwen3.5-9B" },
+  "mlx-community/Qwen3.5-27B-4bit": { minRamGB: 24, label: "Qwen3.5-27B" },
+  "mlx-community/Qwen3.6-27B-4bit": { minRamGB: 24, label: "Qwen3.6-27B" },
+  "mlx-community/Qwen3.5-35B-A3B-4bit": { minRamGB: 32, label: "Qwen3.5-35B-A3B" },
+  "mlx-community/Qwen3.6-35B-A3B-4bit": { minRamGB: 32, label: "Qwen3.6-35B-A3B" },
+  "mlx-community/Qwen3.6-35B-A3B-4bit-DWQ": { minRamGB: 32, label: "Qwen3.6-35B-A3B DWQ" },
+  "mlx-community/Qwen3.5-122B-A10B-4bit": { minRamGB: 96, label: "Qwen3.5-122B-A10B" },
+  "mlx-community/Qwen3.5-397B-A17B-4bit": { minRamGB: 256, label: "Qwen3.5-397B-A17B" },
   "mlx-community/Qwen2.5-0.5B-Instruct-4bit": { minRamGB: 4, label: "Qwen2.5-0.5B" },
   "mlx-community/Qwen2.5-3B-Instruct-4bit": { minRamGB: 8, label: "Qwen2.5-3B" },
   "mlx-community/Qwen2.5-7B-Instruct-4bit": { minRamGB: 16, label: "Qwen2.5-7B" },
   "mlx-community/gemma-3-4b-it-qat-4bit": { minRamGB: 8, label: "Gemma 3 4B" },
   "mlx-community/Qwen2.5-32B-Instruct-4bit": { minRamGB: 32, label: "Qwen2.5-32B" },
+  "mlx-community/Llama-4-Scout-17B-16E-Instruct-4bit": { minRamGB: 64, label: "Llama 4 Scout" },
   "mlx-community/Llama-3.3-70B-Instruct-4bit": { minRamGB: 64, label: "Llama 3.3 70B" },
 };
 
@@ -1281,7 +1293,7 @@ export function ManageModelsDialogContent({
               label="Add a model"
               value={draft}
               onChange={setDraft}
-              placeholder="mlx-community/Qwen2.5-3B-Instruct-4bit"
+              placeholder="mlx-community/Qwen3.5-4B-MLX-4bit"
               style={styles.modelAddField}
               onKeyDown={(e) => {
                 if (e.key === "Enter") {

--- a/provider-shell/Sources/CoCoreShell/MenuBarController.swift
+++ b/provider-shell/Sources/CoCoreShell/MenuBarController.swift
@@ -514,7 +514,7 @@ final class MenuBarController {
                 let alert = NSAlert()
                 alert.messageText = "Enable confidential serving?"
                 alert.informativeText =
-                    "Inference will run entirely inside the measured, signed agent, under a hardened runtime with no subprocess to tap — which aims to keep prompts unreadable to this machine's operator. This is experimental and not independently audited: a software-sealed posture, not a hardware enclave, so don't present it to requestors as a hard guarantee.\n\nThe confidential engine serves Qwen2 / Llama / Gemma / Phi models — an incompatible model (e.g. a Qwen3 model) will show a fault, so pick a compatible one under Models. The agent will restart to switch over."
+                    "Inference will run entirely inside the measured, signed agent, under a hardened runtime with no subprocess to tap — which aims to keep prompts unreadable to this machine's operator. This is experimental and not independently audited: a software-sealed posture, not a hardware enclave, so don't present it to requestors as a hard guarantee.\n\nThe confidential engine serves Qwen2 / Qwen3 / Qwen3.5 / Qwen3.6 / Llama / Gemma / Phi models — an incompatible model will show a fault, so pick a compatible one under Models. The agent will restart to switch over."
                 alert.addButton(withTitle: "Enable")
                 alert.addButton(withTitle: "Cancel")
                 guard alert.runModal() == .alertFirstButtonReturn else { return }

--- a/provider-shell/Sources/CoCoreShell/ModelsView.swift
+++ b/provider-shell/Sources/CoCoreShell/ModelsView.swift
@@ -512,23 +512,22 @@ final class ModelManager: ObservableObject {
     }
 
     /// Classify a model's confidential capability from its id. The confidential
-    /// engine is the vendored mlx-swift-examples LLM set, which loads
-    /// Qwen2 / Qwen3 / Llama(≤3) / Gemma(2,3) / Phi / Mistral-class archs — but
-    /// NOT the newer Qwen3.5+ / Gemma4 / Llama4 architectures. We assert
+    /// engine is the vendored mlx-swift-lm LLM set, which loads
+    /// Qwen2 / Qwen3 / Qwen3.5 / Qwen3.6 / Llama(≤3) / Gemma(2,3) / Phi /
+    /// Mistral-class archs — but NOT Gemma4 / Llama4 architectures. We assert
     /// `incapable` only for archs we KNOW it can't load, `capable` for the
     /// known-good families, and `unknown` otherwise (so we never over-claim — an
     /// unknown that can't load surfaces honestly as an engineFault at serve).
     static func confidentialCompat(_ nsid: String) -> ConfidentialCompat {
         let id = nsid.lowercased()
         // Newer than the vendored engine's arch set — definitionally best-effort.
-        let unsupported = [
-            "qwen3.5", "qwen3_5", "qwen3.6", "qwen3_6", "gemma-4", "gemma4", "llama-4", "llama4",
-        ]
+        let unsupported = ["gemma-4", "gemma4", "llama-4", "llama4"]
         if unsupported.contains(where: id.contains) { return .incapable }
         // Families the in-process engine loads.
         let supported = [
-            "qwen2", "qwen3", "gemma-2", "gemma2", "gemma-3", "gemma3", "llama-2", "llama2",
-            "llama-3", "llama3", "phi", "mistral",
+            "qwen2", "qwen3", "qwen3.5", "qwen3_5", "qwen3.6", "qwen3_6", "gemma-2",
+            "gemma2", "gemma-3", "gemma3", "llama-2", "llama2", "llama-3", "llama3",
+            "phi", "mistral",
         ]
         if supported.contains(where: id.contains) { return .capable }
         return .unknown
@@ -1197,7 +1196,7 @@ struct ModelsView: View {
                 Text("Add a model")
             } footer: {
                 sectionFooter(
-                    "Search any MLX model on HuggingFace, or pick a suggestion. co/core runs MLX weights (mlx-community/… or another 4-bit MLX conversion); a stock PyTorch repo won't load.\n\nOnly “Confidential ✓” models can serve in the confidential engine (Qwen2/Qwen3/Llama/Gemma/Phi-class). A “Best-effort only” model (newer Qwen3.5+/Gemma4/Llama4 archs) runs in a helper the operator can read — choosing one means this machine can't offer requestors the confidential posture for it."
+                    "Search any MLX model on HuggingFace, or pick a suggestion. co/core runs MLX weights (mlx-community/… or another 4-bit MLX conversion); a stock PyTorch repo won't load.\n\nOnly “Confidential” models can serve in the confidential engine (Qwen2/Qwen3/Qwen3.5/Qwen3.6/Llama/Gemma/Phi-class). A “Best-effort only” model (for example Gemma4 or Llama4) runs in a helper the operator can read — choosing one means this machine can't offer requestors the confidential posture for it."
                 )
             }
             .onChange(of: searchQuery) { query in runSearch(query) }
@@ -1255,7 +1254,7 @@ struct ModelsView: View {
     /// the other trashes stay live.
     /// A small capsule marking whether a model can serve confidentially. Shown
     /// in the picker + active list so the operator sees — before choosing — that
-    /// some models (the newer Qwen3.5+ / Gemma4 / Llama4 archs) can only serve
+    /// some models (for example Gemma4 / Llama4 archs) can only serve
     /// best-effort: picking one means this machine can't offer requestors the
     /// confidential guarantee for it.
     @ViewBuilder private func confidentialBadge(_ nsid: String) -> some View {

--- a/provider-shell/Sources/CoCoreShell/StatusView.swift
+++ b/provider-shell/Sources/CoCoreShell/StatusView.swift
@@ -206,7 +206,7 @@ struct StatusRows: View {
                     .orange)
             case .off:
                 secureCaption(
-                    "Requests run in a local helper process that you, this Mac's operator, could read — fine for non-sensitive work. Confidential mode aims to keep them unreadable to you by running inside the measured agent (experimental — a hardened-runtime posture, not a hardware enclave). The confidential engine serves Qwen2 / Qwen3 / Llama / Gemma / Phi-class models.",
+                    "Requests run in a local helper process that you, this Mac's operator, could read — fine for non-sensitive work. Confidential mode aims to keep them unreadable to you by running inside the measured agent (experimental — a hardened-runtime posture, not a hardware enclave). The confidential engine serves Qwen2 / Qwen3 / Qwen3.5 / Qwen3.6 / Llama / Gemma / Phi-class models.",
                     .secondary)
             }
             if let setConfidential = onSetConfidential {

--- a/provider/mlx-engine/Package.resolved
+++ b/provider/mlx-engine/Package.resolved
@@ -1,12 +1,12 @@
 {
   "pins" : [
     {
-      "identity" : "gzipswift",
+      "identity" : "eventsource",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/1024jp/GzipSwift",
+      "location" : "https://github.com/mattt/EventSource.git",
       "state" : {
-        "revision" : "731037f6cc2be2ec01562f6597c1d0aa3fe6fd05",
-        "version" : "6.0.1"
+        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
+        "version" : "1.4.1"
       }
     },
     {
@@ -14,17 +14,44 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift",
       "state" : {
-        "revision" : "072b684acaae80b6a463abab3a103732f33774bf",
-        "version" : "0.29.1"
+        "revision" : "0bb916c67f4b9e5c682cbe02a42c701c93ab5021",
+        "version" : "0.31.6"
       }
     },
     {
-      "identity" : "mlx-swift-examples",
+      "identity" : "mlx-swift-lm",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ml-explore/mlx-swift-examples",
+      "location" : "https://github.com/ml-explore/mlx-swift-lm",
       "state" : {
-        "revision" : "9bff95ca5f0b9e8c021acc4d71a2bbe4a7441631",
-        "version" : "2.29.1"
+        "revision" : "25b00d4e22e61ec9c41efda47990cd2084ec87ff",
+        "version" : "2.31.3"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
+        "version" : "1.3.1"
       }
     },
     {
@@ -37,12 +64,39 @@
       }
     },
     {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "swift-huggingface",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-huggingface.git",
+      "state" : {
+        "revision" : "b721959445b617d0bf03910b2b4aced345fd93bf",
+        "version" : "0.9.0"
+      }
+    },
+    {
       "identity" : "swift-jinja",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-jinja.git",
       "state" : {
         "revision" : "0b67ecb79139f6addef8699eff3622808aa6c7dc",
         "version" : "2.3.6"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "cd3e1152083706d77b223fb29110e590efcc70c0",
+        "version" : "2.101.2"
       }
     },
     {
@@ -55,12 +109,30 @@
       }
     },
     {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "38cd4aaf65feb0ef9bad77d330014f0f256577f5",
+        "version" : "1.7.3"
+      }
+    },
+    {
       "identity" : "swift-transformers",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers",
       "state" : {
-        "revision" : "a2e184dddb4757bc943e77fbe99ac6786c53f0b2",
-        "version" : "1.0.0"
+        "revision" : "58c4bc11963a140358d791f678a60a2745a23146",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "yyjson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ibireme/yyjson.git",
+      "state" : {
+        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
+        "version" : "0.12.0"
       }
     }
   ],

--- a/provider/mlx-engine/Package.swift
+++ b/provider/mlx-engine/Package.swift
@@ -22,17 +22,18 @@ let package = Package(
     ],
     dependencies: [
         // High-level LLM API (MLXLLM, MLXLMCommon) — pulls mlx-swift +
-        // swift-transformers transitively. Pinned to a release for
-        // reproducibility (the known-good set depends on a stable build).
-        .package(url: "https://github.com/ml-explore/mlx-swift-examples", from: "2.21.0"),
+        // swift-transformers transitively. Pinned to the 2.x MLX Swift LM
+        // line that adds Qwen3.5/Qwen3.5-MoE architecture support while
+        // preserving the API shape this bridge uses.
+        .package(url: "https://github.com/ml-explore/mlx-swift-lm", from: "2.31.3"),
     ],
     targets: [
         .target(
             name: "CoCoreMLX",
             dependencies: [
-                .product(name: "MLXLLM", package: "mlx-swift-examples"),
-                .product(name: "MLXVLM", package: "mlx-swift-examples"),
-                .product(name: "MLXLMCommon", package: "mlx-swift-examples"),
+                .product(name: "MLXLLM", package: "mlx-swift-lm"),
+                .product(name: "MLXVLM", package: "mlx-swift-lm"),
+                .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
             ],
             path: "Sources/CoCoreMLX",
             publicHeadersPath: "include"

--- a/provider/mlx-engine/Sources/CoCoreMLX/MLXBridge.swift
+++ b/provider/mlx-engine/Sources/CoCoreMLX/MLXBridge.swift
@@ -108,13 +108,13 @@ public func cocore_mlx_metallib_hash(
 
 /// Free the Metal allocator's cached buffers (KV cache + scratch) so a just-
 /// served prompt's generation state doesn't linger in the GPU pool between jobs.
-/// `MLX.GPU.clearCache()` is process-global, so the handle is unused (kept for
+/// `MLX.Memory.clearCache()` is process-global, so the handle is unused (kept for
 /// C-ABI symmetry). Best-effort (ADR-0005 step 3): evicts/frees, does not
 /// guarantee GPU-page zeroing — Metal exposes no memset-on-free.
 @_cdecl("cocore_mlx_clear_cache")
 public func cocore_mlx_clear_cache(_ handle: UnsafeMutableRawPointer?) {
     _ = handle
-    MLX.GPU.clearCache()
+    MLX.Memory.clearCache()
 }
 
 @_cdecl("cocore_mlx_release")
@@ -122,5 +122,5 @@ public func cocore_mlx_release(_ handle: UnsafeMutableRawPointer?) {
     guard let handle else { return }
     // Drop the model, then evict its GPU buffers from the allocator pool.
     Unmanaged<MLXEngine>.fromOpaque(handle).release()
-    MLX.GPU.clearCache()
+    MLX.Memory.clearCache()
 }

--- a/provider/mlx-engine/Sources/CoCoreMLX/MLXEngine.swift
+++ b/provider/mlx-engine/Sources/CoCoreMLX/MLXEngine.swift
@@ -120,11 +120,11 @@ public final class MLXEngine {
         let params = GenerateParameters(maxTokens: maxTokens)
         var tokensIn = 0
         var tokensOut = 0
-        let inputImages: [UserInput.Image] = images.compactMap { data in
-            CIImage(data: data).map { UserInput.Image.ciImage($0) }
-        }
         let stream: AsyncStream<Generation> = try await container.perform {
             (context: ModelContext) in
+            let inputImages: [UserInput.Image] = images.compactMap { data in
+                CIImage(data: data).map { UserInput.Image.ciImage($0) }
+            }
             let userInput =
                 inputImages.isEmpty
                 ? UserInput(chat: [.user(prompt)])

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -1381,9 +1381,9 @@ async fn cmd_serve_entry(advisor: String) -> Result<()> {
 /// returns and export the two env vars `build_engines` reads
 /// (`COCORE_NATIVE_MLX_MODEL` + `COCORE_NATIVE_MLX_MODEL_DIR`). The native
 /// engine serves exactly ONE model — the owner's first non-`stub`
-/// `desiredModels`, else a small default. An incompatible pick (a non
-/// Qwen2/Llama/Gemma/Phi arch, e.g. `qwen3_5`) downloads fine but fails native
-/// load, which `build_engines` turns into an honest engineFault.
+/// `desiredModels`, else a small default. An incompatible pick downloads fine
+/// but fails native load, which `build_engines` turns into an honest
+/// engineFault.
 #[cfg(all(target_os = "macos", feature = "apns"))]
 async fn prepare_native_confidential_model() {
     const DEFAULT_MODEL: &str = "mlx-community/Qwen2.5-0.5B-Instruct-4bit";
@@ -3029,10 +3029,10 @@ fn build_engines(
                         code: "native-load-failed".to_string(),
                         message: format!(
                             "The confidential (in-process MLX) engine couldn't load `{model}`. The \
-                             native engine supports Qwen2/Llama/Gemma/Phi-family MLX models; a \
-                             different architecture (e.g. a Qwen3 model) won't load in-process. \
-                             Pick a confidential-compatible model in the console. The machine is \
-                             online but only serving the no-op `stub` engine. ({e})"
+                             native engine supports Qwen2/Qwen3/Qwen3.5/Qwen3.6, Llama, Gemma, \
+                             Phi, and Mistral-family MLX models. Pick a confidential-compatible \
+                             model in the console. The machine is online but only serving the \
+                             no-op `stub` engine. ({e})"
                         ),
                         models: vec![model.clone()],
                         at: chrono::Utc::now(),


### PR DESCRIPTION
Move the in-process MLX engine from mlx-swift-examples (effectively mlx-swift-lm 2.29.3) to mlx-swift-lm 2.31.3 (latest 2.x), which adds Qwen3.5 and Qwen3.5-MoE architecture support used by the Qwen3.5 and Qwen3.6 model families.

Update the model selector, provider copy, and console RAM hints so Qwen3.5/Qwen3.6 are marked as confidential-capable.

Regression tested on Qwen2.5 models.

## Caveats
**Needs testing from a maintainer who develops on macOS!** I have a Macbook but it's not my dev machine, testing was done on it remotely. Not all models were tested for regression. mlx-swift-lm has a newer major version available (3.x) but it was not used in case of out-of-scope breaking changes. It should probably be updated in a separate PR.