### PR TITLE
feat(console): show machine client update status

### DIFF
--- a/packages/console/src/components/machines/MachinesDashboard.tsx
+++ b/packages/console/src/components/machines/MachinesDashboard.tsx
@@ -100,6 +100,7 @@ import { formatTokens, formatTokensCompact } from "@/lib/token-display.ts";
 
 import {
   advisorUnreachable,
+  clientVersionStatus,
   type Machine,
   type MachineState,
   machineStateLabel,
@@ -194,6 +195,15 @@ type FleetBodyRow = Machine | { id: string; kind: "empty" };
 
 function isFleetEmptyRow(row: FleetBodyRow): row is { id: string; kind: "empty" } {
   return "kind" in row && row.kind === "empty";
+}
+
+async function fetchLatestClientVersion(): Promise<string | null> {
+  const response = await fetch("/agent/policy");
+  if (!response.ok) return null;
+  const policy = (await response.json()) as unknown;
+  if (!policy || typeof policy !== "object") return null;
+  const latest = (policy as Record<string, unknown>)["latest"];
+  return typeof latest === "string" && latest.length > 0 ? latest : null;
 }
 
 const styles = stylex.create({
@@ -2719,6 +2729,15 @@ function MachineDrawer({
   onAction: (action: string, m: Machine) => void;
 }) {
   const tk = (tokens: number) => `${formatTokens(tokens)} tk`;
+  const { data: latestClientVersion } = useQuery({
+    queryKey: ["agent-policy", "latest"],
+    queryFn: fetchLatestClientVersion,
+    staleTime: 300_000,
+    enabled: Boolean(m.binaryVersion),
+  });
+  const versionStatus = clientVersionStatus(m.binaryVersion, latestClientVersion);
+  const installedVersion = m.binaryVersion?.replace(/^v/i, "");
+  const latestVersion = latestClientVersion?.replace(/^v/i, "");
   return (
     <div {...stylex.props(styles.drawer)}>
       <Flex gap="2xl" direction="column" style={styles.drawerSection}>
@@ -2831,6 +2850,20 @@ function MachineDrawer({
           </dd>
           <dt {...stylex.props(styles.kvDt)}>RAM</dt>
           <dd {...stylex.props(styles.kvDd)}>{m.ram}GB</dd>
+          <dt {...stylex.props(styles.kvDt)}>Client</dt>
+          <dd {...stylex.props(styles.kvDd)}>
+            {installedVersion ? (
+              <>
+                <InlineCode>v{installedVersion}</InlineCode>
+                {versionStatus === "latest" ? " · latest" : null}
+                {versionStatus === "outdated" && latestVersion
+                  ? ` · update available (v${latestVersion})`
+                  : null}
+              </>
+            ) : (
+              "Not reported"
+            )}
+          </dd>
           <dt {...stylex.props(styles.kvDt)}>Paired</dt>
           <dd {...stylex.props(styles.kvDd)}>{m.pairedAt}</dd>
           {m.trustLevel ? (

--- a/packages/console/src/components/machines/machines-data.ts
+++ b/packages/console/src/components/machines/machines-data.ts
@@ -112,6 +112,8 @@ export interface Machine {
    *  than the self-asserted {@link tier}. Absent/false otherwise. */
   confidential?: boolean;
   chipMeta?: string;
+  /** Version of the cocore client that last published this machine's provider record. */
+  binaryVersion?: string;
   /** Model NSIDs the agent advertises in its provider record's
    *  `supportedModels` field. Mirrors what the engine registry
    *  actually loaded — see provider/src/main.rs build_engines. The
@@ -197,4 +199,16 @@ export function machineNetworkStanding(m: Machine): "on-network" | "not-reachabl
   if (m.standingKnown === true && m.advisorConnected === true) return "on-network";
   if (advisorUnreachable(m)) return "not-reachable";
   return null;
+}
+
+export function clientVersionStatus(
+  installed: string | undefined,
+  latest: string | null | undefined,
+): "latest" | "outdated" | null {
+  if (!installed || !latest) return null;
+  return installed.replace(/^v/i, "").localeCompare(latest.replace(/^v/i, ""), undefined, {
+    numeric: true,
+  }) < 0
+    ? "outdated"
+    : "latest";
 }

--- a/packages/console/src/components/machines/machines.server.test.ts
+++ b/packages/console/src/components/machines/machines.server.test.ts
@@ -19,7 +19,12 @@ import type {
   FleetReceiptStats,
   MachineReceiptStats,
 } from "./machines.server.ts";
-import { advisorUnreachable, machineNetworkStanding, type Machine } from "./machines-data.ts";
+import {
+  advisorUnreachable,
+  clientVersionStatus,
+  machineNetworkStanding,
+  type Machine,
+} from "./machines-data.ts";
 
 const NOW = Date.UTC(2026, 5, 11, 12, 0, 0); // fixed "now"
 const minsAgo = (m: number) => new Date(NOW - m * 60_000).toISOString();
@@ -189,6 +194,19 @@ test("a healthy record produces no fault fields", () => {
   assert.equal(m.faultCode, undefined);
   assert.equal(m.faultReason, undefined);
   assert.equal(m.faultModels, undefined);
+});
+
+test("maps and compares the machine client version", () => {
+  const m = providerRowsToMachines(
+    [providerRow({ binaryVersion: "0.9.9" })],
+    ZERO_STATS,
+    new Map(),
+  )[0]!;
+  assert.equal(m.binaryVersion, "0.9.9");
+  assert.equal(clientVersionStatus(m.binaryVersion, "v0.9.10"), "outdated");
+  assert.equal(clientVersionStatus("0.9.10", "v0.9.10"), "latest");
+  assert.equal(clientVersionStatus("0.10.0", "v0.9.10"), "latest");
+  assert.equal(clientVersionStatus(undefined, "v0.9.10"), null);
 });
 
 test("a fault without a human-readable message is ignored (no empty alert)", () => {

--- a/packages/console/src/components/machines/machines.server.ts
+++ b/packages/console/src/components/machines/machines.server.ts
@@ -45,6 +45,7 @@ type ProviderRecordBody = {
   ramGB?: number;
   gpuCores?: number;
   memoryBandwidthGBs?: number;
+  binaryVersion?: string;
   createdAt?: string;
   active?: boolean;
   provisioning?: boolean;
@@ -96,6 +97,7 @@ function parseProviderBody(body: unknown): ProviderRecordBody {
     ramGB: typeof o.ramGB === "number" ? o.ramGB : undefined,
     gpuCores: typeof o.gpuCores === "number" ? o.gpuCores : undefined,
     memoryBandwidthGBs: typeof o.memoryBandwidthGBs === "number" ? o.memoryBandwidthGBs : undefined,
+    binaryVersion: typeof o.binaryVersion === "string" ? o.binaryVersion : undefined,
     createdAt: typeof o.createdAt === "string" ? o.createdAt : undefined,
     active: typeof o.active === "boolean" ? o.active : undefined,
     provisioning: typeof o.provisioning === "boolean" ? o.provisioning : undefined,
@@ -589,7 +591,7 @@ export async function fetchAdvisorStanding(did: string): Promise<AdvisorStanding
           // when COCORE_CONFIDENTIAL_REQUIRE_SE_KEY is enforced.
           secureEnclaveAvailable: r.secureEnclaveAvailable === true,
         });
-        byMachineId.set(r.machineId as string, {
+        return byMachineId.set(r.machineId as string, {
           unhealthy: r.unhealthy === true,
           unhealthyReason: typeof r.unhealthyReason === "string" ? r.unhealthyReason : null,
           silentFailure: r.silentFailure === true,
@@ -735,6 +737,7 @@ export function providerRowsToMachines(
       vram: gpuCores > 0 ? gpuCores : ram,
       chipMeta,
       ram,
+      binaryVersion: body.binaryVersion,
       pairedAt: formatMachinePairedAt(body.createdAt),
       earnings24h: earn24,
       earnings7d: earn7,


### PR DESCRIPTION
## Summary

- surface each machine's reported cocore client version in expanded metadata
- compare it with the cached latest-release policy and show `latest` or `update available`
- preserve a `Not reported` fallback for older provider records

Closes #192

## Testing

- `cd packages/console && ./node_modules/.bin/vitest run src/components/machines/machines.server.test.ts`
- `cd packages/console && ./node_modules/.bin/tsc -p . --noEmit`
- visually verified the expanded machine metadata locally against the production AppView
