### PR TITLE
fix(tray): circuit-break the confidential restart loop + make MDA rebind observable

### DIFF
--- a/provider-shell/Package.swift
+++ b/provider-shell/Package.swift
@@ -40,5 +40,10 @@ let package = Package(
                 .process("Resources"),
             ]
         ),
+        .testTarget(
+            name: "CoCoreShellTests",
+            dependencies: ["CoCoreShell"],
+            path: "Tests/CoCoreShellTests"
+        ),
     ]
 )

--- a/provider-shell/Sources/CoCoreShell/AgentSupervisor.swift
+++ b/provider-shell/Sources/CoCoreShell/AgentSupervisor.swift
@@ -34,11 +34,46 @@ final class AgentSupervisor {
     /// machine keeps crashing — Send bug report?" affordance instead of
     /// silently respawning while the ledger stays flat.
     var onCrashLoop: ((Int) -> Void)?
+    /// Fired when the supervisor has opened the restart circuit breaker — i.e.
+    /// the agent has been (re)spawned too many times in a short window and we
+    /// have STOPPED respawning it to end the churn. The menu bar surfaces this
+    /// as "auto-restart paused — Retry" so a machine that can't stabilise
+    /// (e.g. confidential never verifies) stops burning CPU on a ~1/min bounce
+    /// loop instead of respawning behind the user's back forever.
+    var onRestartStorm: (() -> Void)?
     /// Unexpected exits since the last clean run. Reset when the agent
     /// stays up long enough to look healthy.
     private var crashCount = 0
     /// At how many rapid crashes we start nudging the user.
     private let crashLoopThreshold = 3
+
+    // Restart circuit breaker (app-supervised path). EVERY (re)spawn — a
+    // crash-respawn, a reconciler auto-bounce, a user Resume — funnels through
+    // `spawnChild()`, so gating there catches a restart storm no matter which
+    // caller drives it. This is the belt-and-suspenders backstop for the
+    // per-reconciler #90 cooldown: bug report br_ed8f257c showed ~50
+    // graceful-shutdown+respawn cycles/hour (a steady ~62s loop) while
+    // attested-confidential refused to verify, yet the machine's `active`
+    // switch was on and no single reconciler should have bounced that fast —
+    // so a path was bypassing the cooldown. A choke-point limiter can't be
+    // bypassed. When too many spawns land in the window we OPEN the circuit:
+    // refuse to respawn for a cooldown, surface it, and self-heal with a single
+    // half-open probe once the cooldown passes.
+    private var spawnTimes: [Date] = []
+    private var circuitOpenUntil: Date?
+    /// Trip once this many spawns land within `restartStormWindow`. Tuned to
+    /// catch br_ed8f257c's ~62–68s cycle: at that cadence 5 prior spawns land
+    /// inside a 6-minute window, so the circuit opens ~5–6 min into a loop —
+    /// fast enough to stop the churn, while legitimate restarts (a model
+    /// change, a user Pause/Resume, an occasional crash) never reach 5 in 6
+    /// minutes, and the user-intent paths reset the window anyway.
+    private let restartStormThreshold = 5
+    private let restartStormWindow: TimeInterval = 360   // 6 min
+    /// How long the circuit stays open (no respawns) after it trips. After it
+    /// lapses, exactly one probe spawn is allowed; if that storms again the
+    /// circuit re-opens, so a persistently-broken machine settles at one probe
+    /// per cooldown instead of ~1 restart/min.
+    private let circuitOpenDuration: TimeInterval = 15 * 60
 
     // Crash-restart bookkeeping for the app-supervised (no-LaunchAgent)
     // path. When we own the agent process, nothing else resurrects it on an
@@ -99,6 +134,7 @@ final class AgentSupervisor {
         // (which fires on exit) doesn't treat this as a crash and respawn.
         intentionalStop = true
         if let p = process {
+            Self.supervisorLog("stop(): SIGINT agent pid \(p.processIdentifier) (intentional)")
             p.interrupt()
             await waitForExit(p, timeout: 5)
             if p.isRunning { p.terminate() }
@@ -242,8 +278,66 @@ final class AgentSupervisor {
 
     // MARK: - dev-spawn fallback
 
+    // Pure decision for the restart circuit breaker, factored out of
+    // `spawnChild` so it's unit-testable without spawning real processes.
+    enum CircuitAction: Equatable { case allow, refuse, trip }
+    struct CircuitEval: Equatable {
+        let action: CircuitAction
+        /// Prior spawn instants still inside the window (already pruned).
+        /// Meaningful for `.allow` (append `now`) and `.trip` (cleared).
+        let prunedSpawnTimes: [Date]
+    }
+
+    /// Decide whether a spawn is permitted right now.
+    ///  * `.refuse` — circuit is open and still in its cooldown; stay down.
+    ///  * `.trip`   — this attempt pushes the recent spawn count to the
+    ///                threshold; open the circuit and don't spawn.
+    ///  * `.allow`  — spawn; caller appends `now` to `prunedSpawnTimes`.
+    /// A lapsed `circuitOpenUntil` (deadline in the past) is treated as closed,
+    /// so the first attempt after the cooldown is a half-open probe.
+    nonisolated static func evaluateCircuit(
+        now: Date, spawnTimes: [Date], circuitOpenUntil: Date?,
+        threshold: Int, window: TimeInterval
+    ) -> CircuitEval {
+        if let until = circuitOpenUntil, now < until {
+            return CircuitEval(action: .refuse, prunedSpawnTimes: spawnTimes)
+        }
+        let pruned = spawnTimes.filter { now.timeIntervalSince($0) < window }
+        if pruned.count >= threshold {
+            return CircuitEval(action: .trip, prunedSpawnTimes: [])
+        }
+        return CircuitEval(action: .allow, prunedSpawnTimes: pruned)
+    }
+
     private func spawnChild() {
         guard process == nil else { return }
+        // Restart circuit breaker. If we're inside a cooldown from a prior
+        // storm, refuse to respawn — the machine stays down (cleanly stopped,
+        // "Retry" in the menu) rather than churning. One probe is allowed once
+        // the cooldown lapses (half-open), so a machine whose problem cleared
+        // recovers on its own without a user click.
+        let now = Date()
+        let eval = Self.evaluateCircuit(
+            now: now, spawnTimes: spawnTimes, circuitOpenUntil: circuitOpenUntil,
+            threshold: restartStormThreshold, window: restartStormWindow)
+        switch eval.action {
+        case .refuse:
+            let mins = circuitOpenUntil.map { Int($0.timeIntervalSince(now) / 60) + 1 } ?? 0
+            Self.supervisorLog(
+                "spawn REFUSED — restart circuit open ~\(mins)m more; not respawning (waiting out a restart storm)")
+            return
+        case .trip:
+            circuitOpenUntil = now.addingTimeInterval(circuitOpenDuration)
+            spawnTimes = eval.prunedSpawnTimes
+            Self.supervisorLog(
+                "restart STORM: \(restartStormThreshold)+ spawns in \(Int(restartStormWindow))s — OPENING circuit for \(Int(circuitOpenDuration / 60))m; NOT respawning. Likely cause: a desired posture (e.g. attested-confidential) that never verifies.")
+            onRestartStorm?()
+            return
+        case .allow:
+            spawnTimes = eval.prunedSpawnTimes + [now]
+            Self.supervisorLog(
+                "spawnChild: launching agent (spawns in last \(Int(restartStormWindow))s = \(spawnTimes.count)/\(restartStormThreshold))")
+        }
         // A fresh deliberate start clears the stop latch so a later
         // unexpected exit is treated as a crash and respawned.
         intentionalStop = false
@@ -334,8 +428,15 @@ final class AgentSupervisor {
                 guard let self else { return }
                 self.process = nil
                 NSLog("cocore agent exited with %d", proc.terminationStatus)
+                let ranForLog = self.lastSpawnAt.map { Int(Date().timeIntervalSince($0)) } ?? -1
                 // Deliberate stop → leave it down.
-                guard !self.intentionalStop else { return }
+                guard !self.intentionalStop else {
+                    Self.supervisorLog(
+                        "agent exited (status \(proc.terminationStatus), ran \(ranForLog)s) after an intentional stop — staying down")
+                    return
+                }
+                Self.supervisorLog(
+                    "agent exited UNEXPECTEDLY (status \(proc.terminationStatus), ran \(ranForLog)s) — will respawn")
                 // Unexpected exit (crash/kill) and we own its lifecycle:
                 // respawn. Widen the backoff if it died soon after starting
                 // (crash loop — e.g. a misconfig), reset it if it ran a
@@ -489,6 +590,51 @@ final class AgentSupervisor {
         while p.isRunning && Date() < deadline {
             try? await Task.sleep(nanoseconds: 100_000_000)
         }
+    }
+
+    /// Durable, timestamped record of every supervisor lifecycle decision
+    /// (spawn / stop / respawn / circuit trip) at
+    /// `~/.cocore/logs/supervisor.log`. The tray's NSLog ages out of the
+    /// unified log within hours — exactly why br_ed8f257c's ~62s restart loop
+    /// couldn't be attributed to a caller after the fact. This log persists in
+    /// the diagnostic bundle so the NEXT storm is attributable to the decision
+    /// that drove it, not inferred from the agent's own boot spam.
+    nonisolated static func supervisorLog(_ msg: String) {
+        NSLog("cocore supervisor: %@", msg)
+        let dir = URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent(".cocore/logs")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let ts = ISO8601DateFormatter().string(from: Date())
+        guard let data = "\(ts) \(msg)\n".data(using: .utf8) else { return }
+        let url = dir.appendingPathComponent("supervisor.log")
+        if let h = try? FileHandle(forWritingTo: url) {
+            defer { try? h.close() }
+            _ = try? h.seekToEnd()
+            try? h.write(contentsOf: data)
+        } else {
+            try? data.write(to: url)
+        }
+    }
+
+    /// True while the restart circuit is open (in its cooldown, refusing
+    /// respawns). The menu bar mirrors this so the "auto-restart paused" row
+    /// clears on its own once the cooldown lapses and a probe succeeds.
+    var restartCircuitOpen: Bool {
+        guard let until = circuitOpenUntil else { return false }
+        return Date() < until
+    }
+
+    /// Clear the restart circuit so the next `start()` spawns immediately.
+    /// ONLY explicit user intent calls this — Resume, Retry confidential, a
+    /// tier change — so a fresh human decision always overrides a cooldown the
+    /// user can see and is deliberately acting against. Passive reconcilers
+    /// never call it, so they can't defeat the storm backstop.
+    func resetRestartCircuit() {
+        if circuitOpenUntil != nil || !spawnTimes.isEmpty {
+            Self.supervisorLog("restart circuit reset by explicit user action")
+        }
+        circuitOpenUntil = nil
+        spawnTimes.removeAll()
     }
 
     /// Write the console + advisor URLs into the LaunchAgent plist's

--- a/provider-shell/Sources/CoCoreShell/MenuBarController.swift
+++ b/provider-shell/Sources/CoCoreShell/MenuBarController.swift
@@ -39,6 +39,11 @@ final class MenuBarController {
     /// Drives a loud "keeps crashing — send a report" menu row so a flapping
     /// machine doesn't just silently respawn behind a flat ledger.
     private var crashLoopCount = 0
+    /// True once the supervisor has opened its restart circuit breaker (too
+    /// many respawns too fast — e.g. a confidential machine that never
+    /// verifies). Drives a "Auto-restart paused — Retry" row so the machine
+    /// stops churning instead of respawning ~every minute behind the user.
+    private var restartStormActive = false
     /// Bounded to ONE auto-bounce per "stuck" window so we never loop-restart
     /// the agent — see `reconcileConfidential`. Reset whenever confidential
     /// becomes verified or is turned off.
@@ -162,6 +167,21 @@ final class MenuBarController {
                 // the serve switch above.
                 await self?.reconcileConfidential()
                 self?.reconcileSecurePosture()
+                // Half-open probe for the restart circuit: if the agent is
+                // down but should be serving, ask the supervisor to start. The
+                // supervisor gates this through the circuit breaker, so while a
+                // storm cooldown is open this is a no-op, and once it lapses
+                // exactly one probe gets through — self-healing a transient
+                // storm without reopening the ~1/min loop.
+                await self?.reconcileSupervisorLiveness()
+                // Mirror the live circuit state: once the cooldown lapses and a
+                // probe brings the agent back healthy, drop the "auto-restart
+                // paused" row without waiting for a user click.
+                if let self, self.restartStormActive, !self.supervisor.restartCircuitOpen,
+                    self.supervisor.isServing() {
+                    self.restartStormActive = false
+                    self.rebuildMenu()
+                }
             }
         }
 
@@ -181,6 +201,13 @@ final class MenuBarController {
         // silent respawn-behind-a-flat-ledger failure mode).
         supervisor.onCrashLoop = { [weak self] count in
             self?.crashLoopCount = count
+            self?.rebuildMenu()
+        }
+        // The supervisor stopped auto-respawning after a restart storm. Surface
+        // it so the user gets a "Retry" instead of a silently-dead machine.
+        supervisor.onRestartStorm = { [weak self] in
+            self?.restartStormActive = true
+            self?.refreshServing()
             self?.rebuildMenu()
         }
 
@@ -283,6 +310,16 @@ final class MenuBarController {
             // The agent keeps exiting. Say so plainly and offer the one-click
             // report inline rather than letting it respawn silently.
             menu.addItem(disabled("⚠ The agent keeps crashing (\(crashLoopCount)×)"))
+            menu.addItem(action(title: "Send bug report…", #selector(sendBugReport)))
+            menu.addItem(.separator())
+        }
+        if restartStormActive {
+            // The supervisor stopped respawning after a restart storm (the
+            // agent kept bouncing ~every minute without stabilising — usually a
+            // desired posture like confidential that never verifies). Offer an
+            // explicit Retry that clears the cooldown, plus a report.
+            menu.addItem(disabled("⚠ Auto-restart paused — the agent kept restarting"))
+            menu.addItem(action(title: "Retry now", #selector(retryAfterRestartStorm)))
             menu.addItem(action(title: "Send bug report…", #selector(sendBugReport)))
             menu.addItem(.separator())
         }
@@ -474,6 +511,9 @@ final class MenuBarController {
             }
             Self.setOwnerPaused(false)
             pausedByOwner = false
+            // A deliberate Resume overrides any restart-storm cooldown.
+            restartStormActive = false
+            supervisor.resetRestartCircuit()
             await supervisor.start()
             refreshServing()
             rebuildMenu()
@@ -493,9 +533,15 @@ final class MenuBarController {
                 presentServeSwitchError(action: "pause", detail: out)
                 return
             }
-            await supervisor.stop()
+            // Arm the paused state BEFORE stopping: `supervisor.stop()`
+            // suspends while it waits for the child to exit, and during that
+            // gap `isServing()` can briefly read false. Setting the marker +
+            // `pausedByOwner` first ensures the liveness probe (which runs on
+            // the same actor between awaits) sees "owner-paused" and won't
+            // resurrect the machine we're deliberately stopping.
             Self.setOwnerPaused(true)
             pausedByOwner = true
+            await supervisor.stop()
             refreshServing()
             rebuildMenu()
         }
@@ -544,6 +590,10 @@ final class MenuBarController {
             didAutoBounceConfidential = false
             lastConfidentialActionAt = on ? Date() : nil
             lastAutoBounceAt = nil
+            // A tier change is fresh intent — clear any restart-storm cooldown
+            // so the switch-over isn't blocked by a loop the OLD tier caused.
+            restartStormActive = false
+            supervisor.resetRestartCircuit()
             // Bounce so the fresh serve reads the new desiredTier and the
             // supervisor selects the right worker (same as Restart serving).
             await supervisor.stop()
@@ -585,6 +635,8 @@ final class MenuBarController {
             didAutoBounceConfidential = false
             lastConfidentialActionAt = Date()
             lastAutoBounceAt = nil  // explicit Retry overrides the auto-bounce cooldown
+            restartStormActive = false
+            supervisor.resetRestartCircuit()  // explicit Retry overrides the storm cooldown too
             await supervisor.stop()
             await supervisor.start()
             refreshServing()
@@ -769,6 +821,27 @@ final class MenuBarController {
         }
     }
 
+    /// Half-open probe for the supervisor's restart circuit. When the agent is
+    /// down but the owner wants it serving — signed in, not owner-paused, not
+    /// remotely paused — ask the supervisor to start. It funnels through the
+    /// circuit breaker, so during an open storm cooldown this is a no-op and
+    /// after the cooldown lapses exactly one probe gets through. That both
+    /// self-heals a transient storm and closes the pre-existing gap where an
+    /// agent that exited cleanly (not a <10s crash the terminationHandler
+    /// respawns) could sit down until the next user action. LaunchAgent installs
+    /// have launchd's KeepAlive for this, so we only probe the app-supervised
+    /// (no-plist) path.
+    @MainActor
+    private func reconcileSupervisorLiveness() async {
+        guard !supervisor.isLaunchAgentManaged else { return }
+        guard state.session != nil else { return }
+        guard !pausedByOwner, !Self.isRemotelyPaused() else { return }
+        guard !supervisor.isServing() else { return }
+        // Circuit-gated: refused during an open cooldown, one probe after it.
+        await supervisor.start()
+        refreshServing()
+    }
+
     /// Bounce the agent after the advisor flagged this machine unresponsive.
     /// A clean re-register clears the bad-standing marker (the agent does
     /// this on connect), so the red ping + this row drop away once it
@@ -778,6 +851,20 @@ final class MenuBarController {
             await supervisor.stop()
             await supervisor.start()
             refreshServing()
+        }
+    }
+
+    /// Explicit "Retry now" after the supervisor tripped its restart circuit.
+    /// Clears the cooldown (a human is deliberately overriding it) and starts
+    /// the agent fresh. If the underlying problem persists the circuit will
+    /// simply re-open, so this can't reinstate an infinite loop.
+    @objc private func retryAfterRestartStorm() {
+        Task {
+            restartStormActive = false
+            supervisor.resetRestartCircuit()
+            await supervisor.start()
+            refreshServing()
+            rebuildMenu()
         }
     }
 

--- a/provider-shell/Tests/CoCoreShellTests/RestartCircuitTests.swift
+++ b/provider-shell/Tests/CoCoreShellTests/RestartCircuitTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+
+@testable import CoCoreShell
+
+/// Unit coverage for the restart circuit breaker's pure decision function
+/// (`AgentSupervisor.evaluateCircuit`). The breaker is the choke-point backstop
+/// for the confidential-restart loop in bug report br_ed8f257c: no matter which
+/// caller drives a respawn, it funnels through here, so this is where "stop the
+/// ~1/min churn" is enforced. The timing is easy to get subtly wrong (the
+/// original threshold was too high to catch a 62–68s cycle), so pin it.
+final class RestartCircuitTests: XCTestCase {
+    private let threshold = 5
+    private let window: TimeInterval = 360
+
+    private func eval(now: Date, spawns: [Date], openUntil: Date? = nil)
+        -> AgentSupervisor.CircuitEval
+    {
+        AgentSupervisor.evaluateCircuit(
+            now: now, spawnTimes: spawns, circuitOpenUntil: openUntil,
+            threshold: threshold, window: window)
+    }
+
+    /// A cold start (no prior spawns) is allowed.
+    func testFirstSpawnAllowed() {
+        let now = Date(timeIntervalSince1970: 10_000)
+        XCTAssertEqual(eval(now: now, spawns: []).action, .allow)
+    }
+
+    /// Four prior spawns in-window is still under threshold → allow the fifth.
+    func testUnderThresholdAllows() {
+        let now = Date(timeIntervalSince1970: 10_000)
+        let spawns = (1...4).map { now.addingTimeInterval(-Double($0) * 64) }
+        let e = eval(now: now, spawns: spawns)
+        XCTAssertEqual(e.action, .allow)
+        // The returned prune keeps all four (all inside the 360s window).
+        XCTAssertEqual(e.prunedSpawnTimes.count, 4)
+    }
+
+    /// The observed ~64s loop: five prior spawns land inside the 6-minute
+    /// window, so the sixth attempt trips the breaker instead of respawning.
+    func testLoopCadenceTrips() {
+        let now = Date(timeIntervalSince1970: 10_000)
+        let spawns = (1...5).map { now.addingTimeInterval(-Double($0) * 64) }  // -64…-320s
+        let e = eval(now: now, spawns: spawns)
+        XCTAssertEqual(e.action, .trip)
+        XCTAssertEqual(e.prunedSpawnTimes, [])
+    }
+
+    /// Spawns older than the window don't count — a machine that restarts a few
+    /// times an hour (well spaced) never trips.
+    func testOldSpawnsPrunedDoNotTrip() {
+        let now = Date(timeIntervalSince1970: 10_000)
+        // Five spawns, but each ~10 min apart → only the most recent is in-window.
+        let spawns = (1...5).map { now.addingTimeInterval(-Double($0) * 600) }
+        let e = eval(now: now, spawns: spawns)
+        XCTAssertEqual(e.action, .allow)
+        XCTAssertEqual(e.prunedSpawnTimes.count, 0)
+    }
+
+    /// While the circuit is open (deadline in the future) every spawn is refused,
+    /// regardless of the spawn history.
+    func testOpenCircuitRefuses() {
+        let now = Date(timeIntervalSince1970: 10_000)
+        let e = eval(now: now, spawns: [], openUntil: now.addingTimeInterval(300))
+        XCTAssertEqual(e.action, .refuse)
+    }
+
+    /// Once the cooldown deadline passes, the next attempt is a half-open probe:
+    /// treated as closed, so a machine whose problem cleared recovers on its own.
+    func testLapsedCircuitAllowsHalfOpenProbe() {
+        let now = Date(timeIntervalSince1970: 10_000)
+        let e = eval(now: now, spawns: [], openUntil: now.addingTimeInterval(-1))
+        XCTAssertEqual(e.action, .allow)
+    }
+}

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -794,12 +794,35 @@ async fn cmd_attestation(retry: bool) -> Result<()> {
     // The common point of confusion: enrolled, but still self-attested.
     if enrolled && trust_level != "hardware-attested" {
         println!();
-        println!(
-            "This Mac is MDM-enrolled but not yet hardware-attested. A key-bound \
-             attestation chain was requested and lands on the next attestation \
-             refresh (≤23h). To re-request sooner, run \
-             `cocore agent attestation --retry`."
-        );
+        // Whether a request is already outstanding for the key the SERVE signs
+        // with. Prefer the serve's published signing key over this CLI process's
+        // own: on a Secure-Enclave build the short-lived CLI can load a
+        // different software key than the long-running serve, and the MDA loader
+        // attests the serve's key. If a request is already outstanding, the
+        // machine is waiting on Apple's re-attestation window, not on us.
+        let serve_key = cocore_provider::secure_enclave::read_published_signing_pubkey();
+        let awaiting_apple = serve_key
+            .as_deref()
+            .map(cocore_provider::mda_loader::requested_for_key)
+            .unwrap_or(false);
+        if awaiting_apple {
+            println!(
+                "This Mac is MDM-enrolled but not yet hardware-attested. A key-bound \
+                 attestation was already requested for the current signing key. Apple \
+                 rate-limits device attestation to ~1 per device / 7 days, so if the \
+                 signing key changed recently the rebind only lands once that window \
+                 opens — up to several days. `--retry` re-asks but cannot beat Apple's \
+                 limit; the chain rebinds on its own once the window opens (as long as \
+                 the signing key stays stable)."
+            );
+        } else {
+            println!(
+                "This Mac is MDM-enrolled but not yet hardware-attested. A key-bound \
+                 attestation chain was requested and lands on the next attestation \
+                 refresh (≤23h). To re-request sooner, run \
+                 `cocore agent attestation --retry`."
+            );
+        }
     }
     Ok(())
 }

--- a/provider/src/mda_loader.rs
+++ b/provider/src/mda_loader.rs
@@ -445,6 +445,10 @@ pub fn acquire_auto(console_base: &str, api_key: &str, public_key_b64: &str) -> 
     // Try the already-captured chain first (reused across refreshes; rate-limit
     // friendly — we never re-request once we have a bound chain). The endpoint
     // is bearer-gated, so we MUST present the api_key (a keyless GET 401s).
+    // Track whether the coordinator holds a chain that exists but is bound to a
+    // SUPERSEDED key, so the "why isn't this rebinding" log below can be honest
+    // about the actual state instead of implying every boot re-requests.
+    let mut stale_chain_held = false;
     if let Ok(chain) = load_from_url_with_key(&chain_url, api_key) {
         if !chain.is_empty() {
             // Only trust a chain that actually binds THIS signing key. After a
@@ -459,12 +463,18 @@ pub fn acquire_auto(console_base: &str, api_key: &str, public_key_b64: &str) -> 
                 );
                 return chain;
             }
+            stale_chain_held = true;
+            // NB: this is an OBSERVATION, not the action. Whether we actually
+            // re-request is decided (and logged) below — the old copy claimed
+            // "re-requesting" here unconditionally, which read as a re-request
+            // every ~60s cycle in br_ed8f257c even when the cooldown then held
+            // us off, and cost a full triage round-trip to see through.
             tracing::warn!(
-                "MDA auto: captured chain does not bind the current signing key (rotated?); re-requesting"
+                "MDA auto: captured chain is bound to a SUPERSEDED signing key, not the current one — it can never verify, so ignoring it"
             );
         }
     }
-    // No chain yet → request one (cooldown-gated), then return empty for now.
+    // No usable chain → request one (cooldown-gated), then return empty for now.
     let Some(udid) = device_hardware_uuid() else {
         tracing::warn!("MDA auto: could not read Hardware UUID; cannot request attestation");
         return Vec::new();
@@ -481,14 +491,27 @@ pub fn acquire_auto(console_base: &str, api_key: &str, public_key_b64: &str) -> 
             mark_auto_requested(public_key_b64);
             if key_rotated {
                 tracing::info!(
-                    "MDA auto: signing key rotated — requested a fresh key-bound attestation (bypassed cooldown); chain lands on a later refresh"
+                    "MDA auto: signing key changed since the last request — requested a fresh key-bound attestation (bypassed cooldown); it lands on a later refresh"
                 );
             } else {
+                // Same key, cooldown elapsed: we DID re-request. Name Apple's
+                // limit so a stuck machine reads as "waiting on Apple", not
+                // "broken" — Apple caps DeviceInformation attestation at
+                // ~1/device/7d, so a rebind only lands after that window opens,
+                // however often we ask.
                 tracing::info!(
-                    "MDA auto: requested attestation; chain will land on a later refresh"
+                    "MDA auto: re-requested a key-bound attestation for the current signing key; Apple rate-limits device attestation to ~1/device/7d, so the rebind lands once that window opens"
                 );
             }
         }
+    } else if stale_chain_held {
+        // Honest about the hold-off: we are NOT re-requesting this boot, and the
+        // chain the coordinator holds is stale. This is the steady state of a
+        // machine whose key rotated inside Apple's 7-day attestation window.
+        tracing::info!(
+            cooldown_h = AUTO_REQUEST_COOLDOWN.as_secs() / 3600,
+            "MDA auto: stale chain, but already re-requested for the current key within the cooldown — holding off (waiting on Apple's ~7-day attestation window to rebind); not re-requesting this boot"
+        );
     } else {
         tracing::debug!("MDA auto: within request cooldown; not re-requesting this boot");
     }
@@ -608,6 +631,14 @@ fn mark_auto_requested(public_key_b64: &str) {
         }
         let _ = std::fs::write(&path, public_key_b64.as_bytes());
     }
+}
+
+/// True when we've already requested a key-bound MDA attestation for
+/// `public_key_b64`. When a machine is enrolled-but-not-attested and THIS is
+/// true, it's waiting on Apple's ~1/device/7-day DeviceInformation window — not
+/// on us to ask — so the UI should say "waiting on Apple", not "requesting".
+pub fn requested_for_key(public_key_b64: &str) -> bool {
+    last_requested_pubkey().as_deref() == Some(public_key_b64)
 }
 
 /// The signing key we last requested an MDA attestation for, if any.


### PR DESCRIPTION
## What & why

Triage of bug report `br_ed8f257c` ("tray crashed 799×"). It wasn't crashes — it was a **tray-driven ~62s graceful-shutdown+respawn loop** (~50/hr, ~391 today alone) while `attested-confidential` refused to verify. Root findings:

- No Rust panics (crash-state count 0), no agent self-restarts — every cycle was an external SIGINT from the tray, ~52s after each advisor register.
- The per-reconciler #90 cooldown (cap ~2 bounces/hr) was being **bypassed** by some path — the tray itself burned 64% CPU sustained (a `cpu_resource.diag`), so it was actively churning, not passively respawning a macOS-killed worker.
- Every cycle logged `MDA auto: captured chain does not bind the current signing key … re-requesting`.
- The tray's own NSLog had aged out of the unified log, so the driving caller couldn't be attributed after the fact — the core triage blind spot.

The loop self-resolved when confidential eligibility finally held; the machine is healthy now. These changes stop it recurring and make both the restart driver and the attestation state observable.

## (1) Restart circuit breaker + durable logging

Rather than chase the one bypassing caller, the backstop lives at the **single choke point every app-supervised restart funnels through** — `AgentSupervisor.spawnChild()` — so no caller can bypass it.

- **Circuit breaker**: trips at **5 spawns / 6 min** (tuned to the observed 62–68s cadence — opens ~5–6 min into a loop), stays open 15 min, then allows one **half-open probe**. A healthy machine spawns once and never trips.
- **`~/.cocore/logs/supervisor.log`**: durable, timestamped record of every spawn / stop / respawn / trip — survives in the diag bundle so the *next* storm is attributable.
- **UX**: `onRestartStorm` → "⚠ Auto-restart paused — Retry now" menu row. User-intent paths (Resume / Retry / tier change) call `resetRestartCircuit()`. New 30s `reconcileSupervisorLiveness()` does the circuit-gated half-open probe and closes a latent gap where a cleanly-exited agent could sit down until the next click.
- **Tested**: extracted a pure `evaluateCircuit()` and added the package's first test target (`CoCoreShellTests`); `swift test` → 6/6, including a test that the 64s cadence trips.

## (2) MDA chain rebind — observability, not a logic bug

The rebind isn't broken: the server guard (`ingestAttestationChain`) only stores a chain that binds the *currently-requested* key, so it rebinds automatically once Apple's window opens **as long as the signing key stays stable** (it is). The blocker is **Apple's ~1/device/7-day** DeviceInformation rate limit after a key rotation — inherent.

The defect was that the agent logged `re-requesting` every cycle even when cooldown-gated (doing nothing), which is exactly why triage was blind.

- `mda_loader.rs`: honest per-cycle log (observation vs. actual decision), naming Apple's 7-day window; new `requested_for_key()`.
- `main.rs`: `cocore agent attestation` reads the **serve's published key** (dodging the SE-vs-software CLI split) and prints "waiting on Apple's ~7-day window… `--retry` can't beat Apple's limit; it rebinds on its own." **Verified live** on the affected machine.

## Verification
- `swift build` + `swift test` (6/6) in `provider-shell`.
- `cargo build --features secure_enclave` clean; `cargo test --lib` 185/185.
- `cocore agent attestation` run live on the affected machine → correctly prints the Apple-window explanation.

## Note
These are tray-app changes — landing on a machine requires a new release build (release runbook). No lexicon or wire changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)