### PR TITLE
Enable default-on verified tool calling

### DIFF
--- a/packages/console/public/openapi.yaml
+++ b/packages/console/public/openapi.yaml
@@ -326,13 +326,51 @@ components:
   schemas:
     ChatMessage:
       type: object
-      required: [role, content]
+      required: [role]
       properties:
         role:
           type: string
+          enum: [system, user, assistant, tool]
           example: user
         content:
           type: string
+          nullable: true
+        tool_calls:
+          type: array
+          items: { $ref: "#/components/schemas/ToolCall" }
+        tool_call_id:
+          type: string
+          description: The matching tool-call id on a tool-role result message.
+
+    FunctionTool:
+      type: object
+      required: [type, function]
+      properties:
+        type: { type: string, enum: [function] }
+        function:
+          type: object
+          required: [name, parameters]
+          properties:
+            name: { type: string }
+            description: { type: string }
+            parameters:
+              type: object
+              description: JSON Schema for the function arguments.
+
+    ToolCall:
+      type: object
+      required: [id, type, function]
+      properties:
+        id: { type: string }
+        type: { type: string, enum: [function] }
+        function:
+          type: object
+          required: [name, arguments]
+          properties:
+            name: { type: string }
+            arguments:
+              type: string
+              description: JSON-encoded function arguments for the requester client to execute.
 
     ChatCompletionRequest:
       type: object
@@ -353,6 +391,21 @@ components:
           type: integer
           minimum: 1
           default: 1024
+        tools:
+          type: array
+          description: >-
+            OpenAI-compatible function definitions. Providers generate structured
+            tool-call intents but never execute tools. The exact machine/model
+            pair must pass its startup canary or the request fails with
+            `tool_calls_not_supported` while ordinary inference remains available.
+          items: { $ref: "#/components/schemas/FunctionTool" }
+        tool_choice:
+          description: OpenAI-compatible automatic or forced tool selection.
+          oneOf:
+            - type: string
+              enum: [none, auto, required]
+            - type: object
+              additionalProperties: true
         country:
           type: string
           minLength: 2
@@ -401,7 +454,11 @@ components:
             properties:
               index: { type: integer, example: 0 }
               message: { $ref: "#/components/schemas/ChatMessage" }
-              finish_reason: { type: string, nullable: true, example: stop }
+              finish_reason:
+                type: string
+                nullable: true
+                enum: [stop, tool_calls]
+                example: stop
 
     ChatCompletionChunk:
       type: object

--- a/packages/console/src/components/inference-docs/pages/api-reference.tsx
+++ b/packages/console/src/components/inference-docs/pages/api-reference.tsx
@@ -135,6 +135,53 @@ export function InferenceApiReferencePage({ baseUrl }: { baseUrl: string }) {
                   </p>
                 </>
               )}
+              {section.id === "inference-api-tool-calling" && (
+                <>
+                  <p {...stylex.props(docsStyles.prose)}>
+                    Pass OpenAI-compatible{" "}
+                    <code {...stylex.props(docsStyles.codeInline)}>tools</code> and optional{" "}
+                    <code {...stylex.props(docsStyles.codeInline)}>tool_choice</code>. A capable
+                    model may return{" "}
+                    <code {...stylex.props(docsStyles.codeInline)}>tool_calls</code> with{" "}
+                    <code {...stylex.props(docsStyles.codeInline)}>
+                      finish_reason: "tool_calls"
+                    </code>
+                    . The provider generates only the structured intent; it never executes a tool.
+                    Your client executes it and sends the result back as a tool-role message.
+                    Upgraded eligible machines with no stored preference attempt this by default;
+                    owners can opt out per machine without disabling ordinary inference.
+                  </p>
+                  <HighlightedBlock
+                    lang="json"
+                    code={`{
+  "model": "mlx-community/Qwen3.5-4B-MLX-4bit",
+  "messages": [{ "role": "user", "content": "Check Amsterdam weather" }],
+  "tools": [{
+    "type": "function",
+    "function": {
+      "name": "get_weather",
+      "parameters": {
+        "type": "object",
+        "properties": { "city": { "type": "string" } },
+        "required": ["city"]
+      }
+    }
+  }]
+}`}
+                  />
+                  <p {...stylex.props(docsStyles.prose)}>
+                    Support is live and per model, not inferred from catalog metadata. The models
+                    directory reports{" "}
+                    <code {...stylex.props(docsStyles.codeInline)}>tools: true</code> only when a
+                    connected machine passed a forced-tool startup canary for that exact model. If
+                    none did, the request fails with{" "}
+                    <code {...stylex.props(docsStyles.codeInline)}>
+                      400 tool_calls_not_supported
+                    </code>
+                    ; ordinary requests still route normally.
+                  </p>
+                </>
+              )}
               {section.id === "inference-api-provider-version" && (
                 <>
                   <p {...stylex.props(docsStyles.prose)}>

--- a/packages/console/src/components/machines/MachineDetail.tsx
+++ b/packages/console/src/components/machines/MachineDetail.tsx
@@ -820,7 +820,7 @@ export function MachineDetail({ rkey }: { rkey: string }) {
                 onSuccess: () =>
                   showToast(
                     enabled
-                      ? `${m.alias}: tool calling on for top models on the next serve`
+                      ? `${m.alias}: tool calling on for eligible models on the next serve`
                       : `${m.alias}: tool calling off`,
                   ),
                 onError: (e) =>

--- a/packages/console/src/components/machines/MachinesDashboard.tsx
+++ b/packages/console/src/components/machines/MachinesDashboard.tsx
@@ -1524,10 +1524,10 @@ export function AdvancedSettingsDialogContent({
               Tool calling
             </Switch>
             <SmallBody variant="secondary">
-              Lets this machine serve tool/function calls. It's enabled only for the curated top
-              models a tool-call parser is known for; each is verified with a startup check before
-              it's advertised, and any other model keeps serving exactly as it does now. Picked up
-              the next time the machine serves.
+              Eligible models generate structured tool-call intents by default and must pass a
+              startup check before they're advertised. This provider never executes tools; requester
+              clients execute them and may return results in a follow-up turn. Turning this off
+              leaves ordinary inference unchanged. Picked up the next time the machine serves.
             </SmallBody>
           </Flex>
 

--- a/packages/console/src/components/machines/machines-data.ts
+++ b/packages/console/src/components/machines/machines-data.ts
@@ -165,11 +165,9 @@ export interface Machine {
   /** Requester DIDs served pro bono under `direct` mode. Empty/absent under
    *  `direct` means no one is currently served free. */
   proBonoDids?: string[];
-  /** Whether the owner opted this machine into serving tool/function calls
-   *  (the provider record's `toolCalls` switch). When on, the agent enables
-   *  vLLM automatic tool choice for the curated top models it knows a parser
-   *  pairing for and verifies each with a startup canary before advertising it.
-   *  Drives the "Tool calling" toggle in per-machine settings. Absent ≡ off. */
+  /** Effective tool-calling policy shown by the per-machine switch. Eligible
+   *  models default on; `toolCallsDisabled: true` on the provider record turns
+   *  them off, while legacy `toolCalls: true` remains compatible. */
   toolCalls?: boolean;
 }
 

--- a/packages/console/src/components/machines/machines.functions.ts
+++ b/packages/console/src/components/machines/machines.functions.ts
@@ -468,10 +468,9 @@ const setMyProviderToolCallsServerFn = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
   .inputValidator(setProviderToolCallsSchema)
   .handler(async ({ context, data }) => {
-    // Owner INTENT only. The agent reads `toolCalls` off its own record at
-    // serve start and, when on, enables vLLM automatic tool choice for the
-    // curated top models, verifying each with a forced-tool startup canary
-    // before advertising it. Turning it on can only ADD capability.
+    // Owner INTENT only. The atomic write keeps legacy agents compatible and
+    // sets/clears the new default-on opt-out. The agent still advertises only
+    // exact model/backend pairs that pass the startup canary.
     await setProviderRecordToolCalls(context.oauthSession, data.rkey, data.enabled);
     await nudgeAdvisorControl(context.did);
     return { ok: true as const };

--- a/packages/console/src/components/machines/machines.server.test.ts
+++ b/packages/console/src/components/machines/machines.server.test.ts
@@ -165,6 +165,19 @@ function providerRow(body: Record<string, unknown>): AppviewIndexedRecord {
   };
 }
 
+function machineFrom(body: Record<string, unknown>): Machine {
+  return providerRowsToMachines([providerRow(body)], ZERO_STATS, new Map()).at(0)!;
+}
+
+test("tool calling renders default-on with additive opt-out precedence", () => {
+  assert.equal(machineFrom({}).toolCalls, true);
+  assert.equal(machineFrom({ toolCalls: true }).toolCalls, true);
+  assert.equal(machineFrom({ toolCalls: false }).toolCalls, true);
+  assert.equal(machineFrom({ toolCallsDisabled: false }).toolCalls, true);
+  assert.equal(machineFrom({ toolCallsDisabled: true }).toolCalls, false);
+  assert.equal(machineFrom({ toolCalls: true, toolCallsDisabled: true }).toolCalls, false);
+});
+
 test("engineFault is mapped onto the machine when the record carries it", () => {
   const m = providerRowsToMachines(
     [

--- a/packages/console/src/components/machines/machines.server.ts
+++ b/packages/console/src/components/machines/machines.server.ts
@@ -61,6 +61,7 @@ type ProviderRecordBody = {
   region?: string;
   proBono?: { mode?: string; dids?: string[] };
   toolCalls?: boolean;
+  toolCallsDisabled?: boolean;
   attestationPubKey?: string;
 };
 
@@ -117,6 +118,7 @@ function parseProviderBody(body: unknown): ProviderRecordBody {
     region: typeof o.region === "string" ? o.region : undefined,
     proBono: parseProBono(o.proBono),
     toolCalls: typeof o.toolCalls === "boolean" ? o.toolCalls : undefined,
+    toolCallsDisabled: typeof o.toolCallsDisabled === "boolean" ? o.toolCallsDisabled : undefined,
     attestationPubKey:
       typeof o.attestationPubKey === "string" && o.attestationPubKey.length > 0
         ? o.attestationPubKey
@@ -765,7 +767,9 @@ export function providerRowsToMachines(
           ? body.proBono.mode
           : undefined,
       proBonoDids: body.proBono?.dids,
-      toolCalls: body.toolCalls,
+      // New agents default on; the additive opt-out wins even if a stale
+      // legacy opt-in is also present.
+      toolCalls: body.toolCallsDisabled !== true,
     };
 
     if (body.active === false) {

--- a/packages/console/src/lib/inference-docs/catalog.ts
+++ b/packages/console/src/lib/inference-docs/catalog.ts
@@ -215,6 +215,13 @@ export const INFERENCE_API_TOPIC_SECTIONS = [
       "Vision-capable models accept images alongside text using OpenAI's multimodal content parts. Carried inline as base64 or fetched from a URL; no separate upload step.",
   },
   {
+    id: "inference-api-tool-calling",
+    navLabel: "tool calling",
+    title: "Tool calling",
+    description:
+      "Send standard OpenAI tools and receive structured tool-call intents from canary-verified provider/model pairs; requester clients execute every tool.",
+  },
+  {
     id: "inference-api-provider-version",
     navLabel: "provider version",
     title: "Provider version",

--- a/packages/console/src/lib/model-directory.server.ts
+++ b/packages/console/src/lib/model-directory.server.ts
@@ -322,6 +322,16 @@ interface AdvisorOnline {
   toolCallModels?: string[];
 }
 
+export function hasVerifiedToolCallSupport(
+  online: Pick<AdvisorOnline, "supportsToolCalls" | "toolCallModels"> | undefined,
+  modelId: string,
+): boolean {
+  if (!online) return false;
+  return Array.isArray(online.toolCallModels)
+    ? online.toolCallModels.includes(modelId)
+    : online.supportsToolCalls;
+}
+
 interface AdvisorOnlineResult {
   /** Keyed by "${did}:${machineId}" for machines that report a machineId,
    *  or just "${did}" for legacy agents. Used for per-machine online checks
@@ -526,12 +536,7 @@ export async function buildModelDirectory(): Promise<ModelDirectoryResponse> {
       const seen = onlineInfo?.lastSeen ?? lastSeen;
       // OR in tool calling support from this machine. New agents report the
       // exact verified model subset; legacy agents only reported a coarse bool.
-      if (
-        onlineInfo &&
-        (Array.isArray(onlineInfo.toolCallModels)
-          ? onlineInfo.toolCallModels.includes(modelId)
-          : onlineInfo.supportsToolCalls)
-      ) {
+      if (hasVerifiedToolCallSupport(onlineInfo, modelId)) {
         entry.tools = true;
       }
       const attestationPubKey = safeString(body.attestationPubKey);

--- a/packages/console/src/lib/model-directory.test.ts
+++ b/packages/console/src/lib/model-directory.test.ts
@@ -10,6 +10,34 @@ describe("hasVerifiedToolCallSupport", () => {
     assert.equal(hasVerifiedToolCallSupport(online, "model-b"), true);
   });
 
+  test("prefers the exact list even when the legacy bool is false", () => {
+    assert.equal(
+      hasVerifiedToolCallSupport(
+        { supportsToolCalls: false, toolCallModels: ["model-a"] },
+        "model-a",
+      ),
+      true,
+    );
+  });
+
+  test("empty or non-array toolCallModels falls back to the legacy bool", () => {
+    assert.equal(
+      hasVerifiedToolCallSupport({ supportsToolCalls: true, toolCallModels: [] }, "model-a"),
+      false,
+    );
+    assert.equal(
+      hasVerifiedToolCallSupport(
+        { supportsToolCalls: true, toolCallModels: "bad" as unknown as string[] },
+        "model-a",
+      ),
+      true,
+    );
+    assert.equal(
+      hasVerifiedToolCallSupport({ supportsToolCalls: false, toolCallModels: [] }, "model-a"),
+      false,
+    );
+  });
+
   test("falls back only for legacy registrations", () => {
     assert.equal(hasVerifiedToolCallSupport({ supportsToolCalls: true }, "model-a"), true);
     assert.equal(hasVerifiedToolCallSupport({ supportsToolCalls: false }, "model-a"), false);

--- a/packages/console/src/lib/model-directory.test.ts
+++ b/packages/console/src/lib/model-directory.test.ts
@@ -1,7 +1,21 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 
-import { isVisionModel } from "./model-directory.server.ts";
+import { hasVerifiedToolCallSupport, isVisionModel } from "./model-directory.server.ts";
+
+describe("hasVerifiedToolCallSupport", () => {
+  test("uses the exact canary-verified model list when present", () => {
+    const online = { supportsToolCalls: true, toolCallModels: ["model-b"] };
+    assert.equal(hasVerifiedToolCallSupport(online, "model-a"), false);
+    assert.equal(hasVerifiedToolCallSupport(online, "model-b"), true);
+  });
+
+  test("falls back only for legacy registrations", () => {
+    assert.equal(hasVerifiedToolCallSupport({ supportsToolCalls: true }, "model-a"), true);
+    assert.equal(hasVerifiedToolCallSupport({ supportsToolCalls: false }, "model-a"), false);
+    assert.equal(hasVerifiedToolCallSupport(undefined, "model-a"), false);
+  });
+});
 
 describe("isVisionModel", () => {
   test("flags vision / multimodal models", () => {

--- a/packages/console/src/lib/provider-record-pds.server.ts
+++ b/packages/console/src/lib/provider-record-pds.server.ts
@@ -249,27 +249,32 @@ export async function setProviderRecordShareLocation(
   });
 }
 
-/** Set (or clear) a machine's tool-calling opt-in by writing `toolCalls` onto
- *  its provider record — the owner's INTENT, like `shareLocation`/`desiredTier`.
- *  The agent reconciles toward it: when on it enables vLLM automatic tool choice
- *  for the curated top models it knows a parser pairing for, and verifies each
- *  with a forced-tool startup canary before advertising it. `false` DELETES the
- *  key (absent ≡ off), so the machine serves exactly as before. Same
- *  get→put-with-swap→bridge-mirror path as {@link setProviderRecordShareLocation}. */
+/** Apply the additive default-on tool policy atomically. The legacy opt-in is
+ * retained for older agents; new agents read `toolCallsDisabled` as the opt-out. */
+export function applyProviderRecordToolCalls(
+  value: Record<string, unknown>,
+  enabled: boolean,
+): Record<string, unknown> {
+  const next = { ...value };
+  if (enabled) {
+    delete next["toolCallsDisabled"];
+    next["toolCalls"] = true;
+  } else {
+    next["toolCallsDisabled"] = true;
+    delete next["toolCalls"];
+  }
+  return next;
+}
+
+/** Persist a machine's tool-calling policy onto its provider record. */
 export async function setProviderRecordToolCalls(
   session: OAuthSession,
   rkey: string,
   enabled: boolean,
 ): Promise<void> {
-  await transactProviderRecord(session, rkey, (value) => {
-    const next = { ...value };
-    if (enabled) {
-      next["toolCalls"] = true;
-    } else {
-      delete next["toolCalls"];
-    }
-    return next;
-  });
+  await transactProviderRecord(session, rkey, (value) =>
+    applyProviderRecordToolCalls(value, enabled),
+  );
 }
 
 /** The owner's pro-bono election for a machine, mirroring the lexicon

--- a/packages/console/src/lib/provider-record-tool-calls.test.ts
+++ b/packages/console/src/lib/provider-record-tool-calls.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+
+import { applyProviderRecordToolCalls } from "./provider-record-pds.server.ts";
+
+test("tool calling on clears the opt-out and keeps legacy agents enabled", () => {
+  const next = applyProviderRecordToolCalls({ machineLabel: "mac", toolCallsDisabled: true }, true);
+  assert.equal(next["toolCalls"], true);
+  assert.equal(next["toolCallsDisabled"], undefined);
+  assert.equal(next["machineLabel"], "mac");
+});
+
+test("tool calling off writes the opt-out and clears the legacy opt-in", () => {
+  const next = applyProviderRecordToolCalls({ machineLabel: "mac", toolCalls: true }, false);
+  assert.equal(next["toolCalls"], undefined);
+  assert.equal(next["toolCallsDisabled"], true);
+  assert.equal(next["machineLabel"], "mac");
+});

--- a/packages/console/src/lib/provider-record-tool-calls.test.ts
+++ b/packages/console/src/lib/provider-record-tool-calls.test.ts
@@ -16,3 +16,30 @@ test("tool calling off writes the opt-out and clears the legacy opt-in", () => {
   assert.equal(next["toolCallsDisabled"], true);
   assert.equal(next["machineLabel"], "mac");
 });
+
+test("tool calling on is idempotent", () => {
+  const first = applyProviderRecordToolCalls({ toolCalls: true }, true);
+  const second = applyProviderRecordToolCalls(first, true);
+  assert.equal(second["toolCalls"], true);
+  assert.equal(second["toolCallsDisabled"], undefined);
+});
+
+test("tool calling off is idempotent", () => {
+  const first = applyProviderRecordToolCalls({ toolCallsDisabled: true }, false);
+  const second = applyProviderRecordToolCalls(first, false);
+  assert.equal(second["toolCalls"], undefined);
+  assert.equal(second["toolCallsDisabled"], true);
+});
+
+test("tool calling preserves unrelated fields and empty records", () => {
+  const next = applyProviderRecordToolCalls({}, true);
+  assert.equal(next["toolCalls"], true);
+  assert.equal(next["toolCallsDisabled"], undefined);
+  assert.equal(next["machineLabel"], undefined);
+});
+
+test("tool calling ignores corrupt values defensively", () => {
+  const next = applyProviderRecordToolCalls({ toolCalls: "yes", toolCallsDisabled: 42 }, false);
+  assert.equal(next["toolCalls"], undefined);
+  assert.equal(next["toolCallsDisabled"], true);
+});

--- a/packages/sdk/src/types.gen.ts
+++ b/packages/sdk/src/types.gen.ts
@@ -212,6 +212,7 @@ export interface ProviderRecord {
   attestationFault?: { code: string; message: string; at: string };
   advisorFault?: { code: string; message: string; observedAt: string };
   toolCalls?: boolean;
+  toolCallsDisabled?: boolean;
   shareLocation?: boolean;
   region?: string;
   regionSource?: string;

--- a/provider/src/advisor.rs
+++ b/provider/src/advisor.rs
@@ -499,7 +499,7 @@ impl AdvisorClient {
                         ctx.engines.terminate_all();
                         std::process::exit(3);
                     }
-                    if tool_policy_changed(tool_calls, tool_calls_at_start) {
+                    if tool_calls != tool_calls_at_start {
                         // Owner flipped the tool-calling switch on the console.
                         // The per-model tool-call parser is chosen at engine
                         // build time, so reload the same way a model-set edit
@@ -779,12 +779,12 @@ async fn read_provider_control(
 ) -> Option<(bool, Vec<String>, Option<String>, bool)> {
     pds.get_provider_control(rkey)
         .await
-        .map(|(active, desired, tier, legacy, disabled)| {
+        .map(|(active, desired, tier, _legacy, disabled)| {
             (
                 active,
                 desired,
                 tier,
-                effective_tool_calls(tool_calls_env_override, legacy, disabled),
+                effective_tool_calls(tool_calls_env_override, disabled),
             )
         })
 }
@@ -812,10 +812,6 @@ fn models_changed(a: &[String], b: &[String]) -> bool {
         s.into_iter().map(str::to_string).collect::<Vec<_>>()
     };
     norm(a) != norm(b)
-}
-
-fn tool_policy_changed(next: bool, at_start: bool) -> bool {
-    next != at_start
 }
 
 /// Environment escape hatch that permits a plaintext (`ws://`) advisor URL.
@@ -2270,14 +2266,6 @@ mod tests {
         assert!(models_changed(&a(&["x", "y"]), &a(&["x"]))); // removed
         assert!(models_changed(&a(&["x"]), &[])); // cleared → local default
         assert!(models_changed(&[], &a(&["x"]))); // newly pinned
-    }
-
-    #[test]
-    fn effective_tool_policy_reloads_only_when_behavior_changes() {
-        assert!(tool_policy_changed(false, true));
-        assert!(tool_policy_changed(true, false));
-        assert!(!tool_policy_changed(true, true));
-        assert!(!tool_policy_changed(false, false));
     }
 
     #[test]

--- a/provider/src/advisor.rs
+++ b/provider/src/advisor.rs
@@ -24,7 +24,7 @@ use crate::crypto::{EncryptionKey, ProviderKeypair};
 use crate::engines::{DeltaChannel, Engine, EngineRegistry};
 use crate::error::{ProviderError, Result};
 use crate::hypervisor;
-use crate::pds::{PdsClient, ProBonoPolicy};
+use crate::pds::{effective_tool_calls, PdsClient, ProBonoPolicy};
 use crate::pricing;
 use crate::protocol::{
     AdvisorMessage, AttestationChallenge, AttestationResponse, ChunkChannel,
@@ -154,12 +154,11 @@ impl AdvisorClient {
         // record at serve start. Threaded into `ServeContext` so each job
         // can decide, per requester, whether to serve free + unmetered.
         pro_bono: &ProBonoPolicy,
-        // The owner's `toolCalls` opt-in this serve loaded against. If the
-        // owner flips it on the console we detect the change in the control
-        // re-read below and restart to rebuild engines — the same reload path
-        // as a `desiredModels` edit (engines are built once per serve, and the
-        // per-model tool-call parser is chosen at build time).
+        // The effective tool policy this serve loaded against. Live control
+        // reads use the same captured operator override, so owner edits only
+        // restart engines when they actually change effective behavior.
         tool_calls_at_start: bool,
+        tool_calls_env_override: Option<bool>,
     ) -> Result<()> {
         // Reject a plaintext advisor URL before we connect. A `ws://` link lets
         // a network attacker read/inject job dispatch and control frames
@@ -436,7 +435,11 @@ impl AdvisorClient {
                     }
                     if active_reads.is_empty() {
                         if let Some(rk) = provider_rkey {
-                            active_reads.push(read_provider_control(pds, rk));
+                            active_reads.push(read_provider_control(
+                                pds,
+                                rk,
+                                tool_calls_env_override,
+                            ));
                         }
                     }
                 }
@@ -496,7 +499,7 @@ impl AdvisorClient {
                         ctx.engines.terminate_all();
                         std::process::exit(3);
                     }
-                    if tool_calls != tool_calls_at_start {
+                    if tool_policy_changed(tool_calls, tool_calls_at_start) {
                         // Owner flipped the tool-calling switch on the console.
                         // The per-model tool-call parser is chosen at engine
                         // build time, so reload the same way a model-set edit
@@ -675,7 +678,11 @@ impl AdvisorClient {
                                     // now (off-loop) so it takes effect in ~a
                                     // second instead of at the next 30s poll.
                                     if let Some(rk) = provider_rkey {
-                                        active_reads.push(read_provider_control(pds, rk));
+                                        active_reads.push(read_provider_control(
+                                            pds,
+                                            rk,
+                                            tool_calls_env_override,
+                                        ));
                                     }
                                 }
                                 Ok(AdvisorMessage::RecoverRequest(rr)) => {
@@ -768,8 +775,18 @@ impl AdvisorClient {
 async fn read_provider_control(
     pds: &PdsClient,
     rkey: &str,
+    tool_calls_env_override: Option<bool>,
 ) -> Option<(bool, Vec<String>, Option<String>, bool)> {
-    pds.get_provider_control(rkey).await
+    pds.get_provider_control(rkey)
+        .await
+        .map(|(active, desired, tier, legacy, disabled)| {
+            (
+                active,
+                desired,
+                tier,
+                effective_tool_calls(tool_calls_env_override, legacy, disabled),
+            )
+        })
 }
 
 /// Whether two `desiredTier` values differ, normalising `None` to the
@@ -795,6 +812,10 @@ fn models_changed(a: &[String], b: &[String]) -> bool {
         s.into_iter().map(str::to_string).collect::<Vec<_>>()
     };
     norm(a) != norm(b)
+}
+
+fn tool_policy_changed(next: bool, at_start: bool) -> bool {
+    next != at_start
 }
 
 /// Environment escape hatch that permits a plaintext (`ws://`) advisor URL.
@@ -2249,6 +2270,14 @@ mod tests {
         assert!(models_changed(&a(&["x", "y"]), &a(&["x"]))); // removed
         assert!(models_changed(&a(&["x"]), &[])); // cleared → local default
         assert!(models_changed(&[], &a(&["x"]))); // newly pinned
+    }
+
+    #[test]
+    fn effective_tool_policy_reloads_only_when_behavior_changes() {
+        assert!(tool_policy_changed(false, true));
+        assert!(tool_policy_changed(true, false));
+        assert!(!tool_policy_changed(true, true));
+        assert!(!tool_policy_changed(false, false));
     }
 
     #[test]

--- a/provider/src/engines/subprocess.rs
+++ b/provider/src/engines/subprocess.rs
@@ -1841,6 +1841,33 @@ mod tests {
         assert!(!tool_canary_passed(&serde_json::json!({
             "choices": [{ "message": {} }]
         })));
+        assert!(!tool_canary_passed(&response(
+            Some("report_status"),
+            Some("not json")
+        )));
+        assert!(!tool_canary_passed(&response(
+            Some("report_status"),
+            Some("{\"status\": \"not ok\"}")
+        )));
+        assert!(!tool_canary_passed(&response(
+            Some("report_status"),
+            Some(r#"{"status":"ok","extra":"x"}"#),
+        )));
+        assert!(!tool_canary_passed(&serde_json::json!({
+            "choices": [{ "message": { "tool_calls": [] } }]
+        })));
+        assert!(!tool_canary_passed(&serde_json::json!({
+            "choices": [{ "message": { "tool_calls": [{ "function": { "name": "wrong", "arguments": "{\"status\":\"ok\"}" } }] } }]
+        })));
+        assert!(tool_canary_passed(&serde_json::json!({
+            "choices": [{ "message": { "tool_calls": [
+                { "function": { "name": "wrong", "arguments": "{\"status\":\"ok\"}" } },
+                { "function": { "name": "report_status", "arguments": "{\"status\":\"ok\"}" } }
+            ]}}]
+        })));
+        assert!(!tool_canary_passed(&serde_json::json!({
+            "choices": [{ "message": { "tool_calls": [{ "function": { "name": "report_status", "arguments": { "status": "ok" } } }] } }]
+        })));
     }
 
     #[test]

--- a/provider/src/engines/subprocess.rs
+++ b/provider/src/engines/subprocess.rs
@@ -552,6 +552,21 @@ pub struct SubprocessEngine {
     verified_tool_calls: Mutex<bool>,
 }
 
+fn tool_canary_passed(resp: &serde_json::Value) -> bool {
+    resp.pointer("/choices/0/message/tool_calls")
+        .and_then(|v| v.as_array())
+        .is_some_and(|calls| {
+            calls.iter().any(|call| {
+                call.pointer("/function/name").and_then(|v| v.as_str()) == Some("report_status")
+                    && call
+                        .pointer("/function/arguments")
+                        .and_then(|v| v.as_str())
+                        .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok())
+                        == Some(serde_json::json!({ "status": "ok" }))
+            })
+        })
+}
+
 impl SubprocessEngine {
     /// Construct an engine bound to `model_id`. Does not spawn the
     /// child — call `start()` to do that. `venv_python` is the
@@ -1008,17 +1023,7 @@ impl SubprocessEngine {
                 resp_bytes.len()
             )
         })?;
-        let Some(tool_calls) = resp
-            .pointer("/choices/0/message/tool_calls")
-            .and_then(|v| v.as_array())
-        else {
-            return Ok(false);
-        };
-        Ok(tool_calls.iter().any(|tc| {
-            tc.pointer("/function/name")
-                .and_then(|v| v.as_str())
-                .is_some_and(|name| name == "report_status")
-        }))
+        Ok(tool_canary_passed(&resp))
     }
 
     /// Probe `GET /v1/models` to confirm the FastAPI app under
@@ -1778,17 +1783,17 @@ mod tests {
         };
         let top = on.for_model("mlx-community/Qwen3.5-4B-MLX-4bit");
         assert!(top.enabled);
-        assert_eq!(top.tool_call_parser.as_deref(), Some("hermes"));
+        assert_eq!(top.tool_call_parser.as_deref(), Some("qwen3_xml"));
         let llama = on.for_model("mlx-community/Llama-4-Scout-17B-16E-Instruct-4bit");
         assert!(llama.enabled);
         assert_eq!(llama.tool_call_parser.as_deref(), Some("llama4_pythonic"));
 
-        // …a legacy / off-catalog model with no vetted pairing stays OFF
-        // (served exactly as before — never a wrong-parser guess).
-        assert!(
-            !on.for_model("mlx-community/Qwen2.5-7B-Instruct-4bit")
-                .enabled
-        );
+        // …Qwen 2.5 uses Hermes, while an unpaired legacy/off-catalog model
+        // stays off (never a wrong-parser guess).
+        let qwen25 = on.for_model("mlx-community/Qwen2.5-7B-Instruct-4bit");
+        assert!(qwen25.enabled);
+        assert_eq!(qwen25.tool_call_parser.as_deref(), Some("hermes"));
+        assert!(!on.for_model("mlx-community/gemma-3-4b-it-qat-4bit").enabled);
         assert!(!on.for_model("some/custom-model").enabled);
 
         // An explicit operator parser override applies to EVERY model verbatim,
@@ -1801,6 +1806,41 @@ mod tests {
         let any = forced.for_model("some/custom-model");
         assert!(any.enabled);
         assert_eq!(any.tool_call_parser.as_deref(), Some("mistral"));
+    }
+
+    #[test]
+    fn tool_canary_requires_name_and_preserved_arguments() {
+        let response = |name: Option<&str>, arguments: Option<&str>| {
+            serde_json::json!({
+                "choices": [{
+                    "message": {
+                        "tool_calls": [{
+                            "function": {
+                                "name": name,
+                                "arguments": arguments
+                            }
+                        }]
+                    }
+                }]
+            })
+        };
+
+        assert!(tool_canary_passed(&response(
+            Some("report_status"),
+            Some(r#"{ "status": "ok" }"#),
+        )));
+        assert!(!tool_canary_passed(&response(
+            Some("wrong_name"),
+            Some(r#"{"status":"ok"}"#),
+        )));
+        assert!(!tool_canary_passed(&response(
+            Some("report_status"),
+            Some(r#"{"status":"wrong"}"#),
+        )));
+        assert!(!tool_canary_passed(&response(Some("report_status"), None)));
+        assert!(!tool_canary_passed(&serde_json::json!({
+            "choices": [{ "message": {} }]
+        })));
     }
 
     #[test]

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -4,8 +4,8 @@ use cocore_provider::{
     advisor::AdvisorClient,
     attestation, oauth,
     pds::{
-        AttestationFault, EngineFault, ModelPrice, PdsClient, ProBonoPolicy, ProviderRecord,
-        TrustLevel,
+        effective_tool_calls, AttestationFault, EngineFault, ModelPrice, PdsClient, ProBonoPolicy,
+        ProviderRecord, TrustLevel,
     },
     pricing,
     protocol::Register,
@@ -1312,7 +1312,7 @@ async fn wait_until_active(pds: &cocore_provider::pds::PdsClient, rkey: Option<&
         let read = pds
             .get_provider_control(rk)
             .await
-            .map(|(active, _, _, _)| active);
+            .map(|(active, _, _, _, _)| active);
         if active_gate_decision(read, &mut confirmed_paused) == ActiveGate::Serve {
             clear_serving_paused();
             return;
@@ -1729,6 +1729,7 @@ async fn cmd_serve(
             // stamps region (no network lookup before the engine is up).
             shareLocation: None,
             toolCalls: None,
+            toolCallsDisabled: None,
             provisioning: Some(true),
             // NOT serving yet: this record is published immediately (so the
             // machine is visible) while the engine is still loading/downloading.
@@ -1780,6 +1781,10 @@ async fn cmd_serve(
     // of an unmeasured Python child, defeating the tier). We still read
     // `desiredModels` below so a change still triggers a reload restart.
     let confidential = push_rx.is_some();
+    // Capture the operator override before filling the engine's environment
+    // from the owner record. It remains authoritative during live reconciliation.
+    let tool_calls_env_override = std::env::var_os("COCORE_ENABLE_TOOL_CALLS")
+        .map(|v| v == "1" || v.to_string_lossy().eq_ignore_ascii_case("true"));
     let (
         desired_at_start,
         desired_tier_at_start,
@@ -1813,29 +1818,34 @@ async fn cmd_serve(
                 // served job can decide per-requester whether it's free. Absent /
                 // malformed ≡ off (every job metered + billed).
                 let pro_bono = ProBonoPolicy::from_record_value(&value).unwrap_or_default();
-                // The owner's tool-calling opt-in. Absent ≡ off (no engine
-                // advertises tool calls). Gates the curated tool-call path below.
-                let tool_calls = value
-                    .get("toolCalls")
-                    .and_then(|v| v.as_bool())
-                    .unwrap_or(false);
+                let tool_calls = effective_tool_calls(
+                    tool_calls_env_override,
+                    value.get("toolCalls").and_then(|v| v.as_bool()),
+                    value.get("toolCallsDisabled").and_then(|v| v.as_bool()),
+                );
                 (models, tier, pro_bono, share_location, tool_calls)
             }
-            Err(_) => (Vec::new(), None, ProBonoPolicy::default(), false, false),
+            Err(_) => (
+                Vec::new(),
+                None,
+                ProBonoPolicy::default(),
+                false,
+                effective_tool_calls(tool_calls_env_override, None, None),
+            ),
         };
 
-    // Reconcile the owner's tool-calling intent into the env knob `build_engines`
-    // reads. An EXPLICIT operator setting always wins (a launchd plist / shell
-    // that pinned `COCORE_ENABLE_TOOL_CALLS` keeps full control, including the
-    // global-parser passthrough); we only fill it in from the console intent when
-    // the operator left it unset. `for_model` then enables automatic tool choice
-    // for just the curated top models, and the startup canary decides what's
-    // actually advertised — so flipping this on can only ADD capability.
-    if std::env::var_os("COCORE_ENABLE_TOOL_CALLS").is_none() && tool_calls_at_start {
+    // Feed the effective default into the existing engine knob only when the
+    // operator did not set it. Exact model eligibility and the startup canary
+    // still decide what is advertised.
+    if tool_calls_env_override.is_none() {
         tracing::info!(
-            "owner enabled tool calling for this machine (console toolCalls=true); curated top models will attempt tool calls and verify with a startup canary"
+            enabled = tool_calls_at_start,
+            "using provider-record default for structured tool-call intent generation"
         );
-        std::env::set_var("COCORE_ENABLE_TOOL_CALLS", "1");
+        std::env::set_var(
+            "COCORE_ENABLE_TOOL_CALLS",
+            if tool_calls_at_start { "1" } else { "0" },
+        );
     }
     match inference_models_action(confidential, &desired_at_start) {
         InferenceModelsAction::Clear => {
@@ -2090,6 +2100,7 @@ async fn cmd_serve(
         // start; this carries the switch itself through the re-publish.)
         shareLocation: None,
         toolCalls: None,
+        toolCallsDisabled: None,
         // Engine is loaded by this point — clear the provisioning flag we
         // set on the early publish above, so the console flips the row
         // from "provisioning" to live.
@@ -2356,6 +2367,7 @@ async fn cmd_serve(
                             push_rx.as_mut(),
                             &pro_bono_at_start,
                             tool_calls_at_start,
+                            tool_calls_env_override,
                         )
                         .await;
                     let lived = connected_at.elapsed();
@@ -2425,7 +2437,7 @@ async fn cmd_serve(
                         );
                         let client = AdvisorClient::new(advisor_url);
                         tokio::select! {
-                            res = client.run(register.clone(), &*signer, &*enc, &pds, attestation.clone(), &eng, provider_rkey.as_deref(), &desired_at_start, desired_tier_at_start.as_deref(), &model_schedules, &configured_models, push_rx.as_mut(), &pro_bono_at_start, tool_calls_at_start) => {
+                            res = client.run(register.clone(), &*signer, &*enc, &pds, attestation.clone(), &eng, provider_rkey.as_deref(), &desired_at_start, desired_tier_at_start.as_deref(), &model_schedules, &configured_models, push_rx.as_mut(), &pro_bono_at_start, tool_calls_at_start, tool_calls_env_override) => {
                                 match &res {
                                     Ok(()) => advisor_fault.reset(),
                                     Err(e) => {
@@ -4212,6 +4224,7 @@ mod offline_marker_tests {
             proBono: None,
             shareLocation: None,
             toolCalls: None,
+            toolCallsDisabled: None,
             provisioning: Some(false),
             serving: Some(true),
             engineFault: None,
@@ -4274,7 +4287,9 @@ mod offline_marker_tests {
             "desiredModels": ["mlx-community/Qwen2.5-3B-Instruct-4bit", "stub"],
             "desiredTier": "attested-confidential",
             "proBono": { "mode": "direct", "dids": ["did:plc:friend"] },
-            "shareLocation": true
+            "shareLocation": true,
+            "toolCalls": true,
+            "toolCallsDisabled": true
         });
 
         let merged = merge_agent_provider_fields(&live, &offline);
@@ -4297,6 +4312,11 @@ mod offline_marker_tests {
             Some(&serde_json::json!({ "mode": "direct", "dids": ["did:plc:friend"] }))
         );
         assert_eq!(merged.get("shareLocation"), Some(&serde_json::json!(true)));
+        assert_eq!(merged.get("toolCalls"), Some(&serde_json::json!(true)));
+        assert_eq!(
+            merged.get("toolCallsDisabled"),
+            Some(&serde_json::json!(true))
+        );
     }
 
     /// THE property that kills the whole bug class: a field this agent build has
@@ -4389,7 +4409,12 @@ mod offline_marker_tests {
         let mut rebuilt = agent_built_record();
         rebuilt.active = Some(true); // agent erroneously authoring an owner field
         rebuilt.desiredModels = Some(vec!["agent-should-not-set-this".into()]);
-        let live = serde_json::json!({ "active": false, "desiredModels": ["owner-choice"] });
+        rebuilt.toolCallsDisabled = Some(false);
+        let live = serde_json::json!({
+            "active": false,
+            "desiredModels": ["owner-choice"],
+            "toolCallsDisabled": true
+        });
 
         let merged = merge_agent_provider_fields(&live, &rebuilt);
 
@@ -4402,6 +4427,11 @@ mod offline_marker_tests {
             merged.get("desiredModels"),
             Some(&serde_json::json!(["owner-choice"])),
             "agent can never overwrite the owner's model pick"
+        );
+        assert_eq!(
+            merged.get("toolCallsDisabled"),
+            Some(&serde_json::json!(true)),
+            "agent can never overwrite the owner's tool opt-out"
         );
     }
 

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -4,8 +4,8 @@ use cocore_provider::{
     advisor::AdvisorClient,
     attestation, oauth,
     pds::{
-        effective_tool_calls, AttestationFault, EngineFault, ModelPrice, PdsClient, ProBonoPolicy,
-        ProviderRecord, TrustLevel,
+        effective_tool_calls, parse_tool_calls_env_override, AttestationFault, EngineFault,
+        ModelPrice, PdsClient, ProBonoPolicy, ProviderRecord, TrustLevel,
     },
     pricing,
     protocol::Register,
@@ -1783,8 +1783,8 @@ async fn cmd_serve(
     let confidential = push_rx.is_some();
     // Capture the operator override before filling the engine's environment
     // from the owner record. It remains authoritative during live reconciliation.
-    let tool_calls_env_override = std::env::var_os("COCORE_ENABLE_TOOL_CALLS")
-        .map(|v| v == "1" || v.to_string_lossy().eq_ignore_ascii_case("true"));
+    let tool_calls_env_override =
+        parse_tool_calls_env_override(std::env::var("COCORE_ENABLE_TOOL_CALLS").ok().as_deref());
     let (
         desired_at_start,
         desired_tier_at_start,
@@ -1820,7 +1820,6 @@ async fn cmd_serve(
                 let pro_bono = ProBonoPolicy::from_record_value(&value).unwrap_or_default();
                 let tool_calls = effective_tool_calls(
                     tool_calls_env_override,
-                    value.get("toolCalls").and_then(|v| v.as_bool()),
                     value.get("toolCallsDisabled").and_then(|v| v.as_bool()),
                 );
                 (models, tier, pro_bono, share_location, tool_calls)
@@ -1830,7 +1829,7 @@ async fn cmd_serve(
                 None,
                 ProBonoPolicy::default(),
                 false,
-                effective_tool_calls(tool_calls_env_override, None, None),
+                effective_tool_calls(tool_calls_env_override, None),
             ),
         };
 

--- a/provider/src/pds.rs
+++ b/provider/src/pds.rs
@@ -148,15 +148,15 @@ pub struct ProviderRecord {
     /// fields so opting out clears any previously-shared value.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shareLocation: Option<bool>,
-    /// The owner's opt-in to serving tool/function calls. Owner-written INTENT,
-    /// like `desiredModels`/`active`/`desiredTier`/`proBono`/`shareLocation`:
-    /// the agent reconciles toward it (when true it enables vLLM automatic tool
-    /// choice for the curated top models and verifies each with a forced-tool
-    /// startup canary before advertising it) but NEVER authors it, so it must
-    /// PRESERVE whatever it finds on every re-publish. Absent ≡ off (no engine
-    /// advertises tool calls; the machine serves exactly as before).
+    /// Legacy owner opt-in to tool calling. New agents default eligible models
+    /// on, but preserve this field for older agents and console compatibility.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub toolCalls: Option<bool>,
+    /// Explicit owner opt-out from default-on tool calling. `true` wins over the
+    /// legacy opt-in; absent/false leaves eligible models enabled unless the
+    /// operator explicitly overrides `COCORE_ENABLE_TOOL_CALLS`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub toolCallsDisabled: Option<bool>,
     /// True while the agent is still loading its inference engine. Set on
     /// the early "provisioning" publish at serve start so the machine
     /// appears on the console immediately; cleared (set false) on the
@@ -228,7 +228,24 @@ pub const OWNER_INTENT_KEYS: &[&str] = &[
     "proBono",
     "shareLocation",
     "toolCalls",
+    "toolCallsDisabled",
 ];
+
+/// Resolve tool calling once for startup and live reconciliation. An explicit
+/// operator setting wins; otherwise only the additive opt-out disables the
+/// default. The legacy field remains an input to make its compatibility
+/// semantics explicit: true still means on, while false is not a new opt-out.
+pub fn effective_tool_calls(
+    explicit_env: Option<bool>,
+    legacy_tool_calls: Option<bool>,
+    tool_calls_disabled: Option<bool>,
+) -> bool {
+    match (explicit_env, legacy_tool_calls, tool_calls_disabled) {
+        (Some(enabled), _, _) => enabled,
+        (None, _, Some(true)) => false,
+        (None, _, _) => true,
+    }
+}
 
 /// Agent-authored OPTIONAL fields — present some serves, absent others (a tier
 /// the machine earned then lost, an engineFault that cleared, region when the
@@ -916,7 +933,13 @@ impl PdsClient {
     pub async fn get_provider_control(
         &self,
         rkey: &str,
-    ) -> Option<(bool, Vec<String>, Option<String>, bool)> {
+    ) -> Option<(
+        bool,
+        Vec<String>,
+        Option<String>,
+        Option<bool>,
+        Option<bool>,
+    )> {
         let listed = self
             .list_my_records("dev.cocore.compute.provider")
             .await
@@ -944,14 +967,17 @@ impl PdsClient {
             .get("desiredTier")
             .and_then(|v| v.as_str())
             .map(str::to_string);
-        // The owner's tool-calling opt-in; absent ≡ off. The serve loop restarts
-        // on a change so the fresh build rebuilds engines with the new setting.
-        let tool_calls = rec
-            .value
-            .get("toolCalls")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
-        Some((active, desired, desired_tier, tool_calls))
+        // Return both owner fields so the serve loop can derive the effective
+        // policy using the same explicit-environment precedence as startup.
+        let tool_calls = rec.value.get("toolCalls").and_then(|v| v.as_bool());
+        let tool_calls_disabled = rec.value.get("toolCallsDisabled").and_then(|v| v.as_bool());
+        Some((
+            active,
+            desired,
+            desired_tier,
+            tool_calls,
+            tool_calls_disabled,
+        ))
     }
 
     /// Field-scoped patch of this machine's provider record: set (or, with
@@ -1190,6 +1216,16 @@ impl PdsClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn effective_tool_policy_defaults_on_and_honours_precedence() {
+        assert!(effective_tool_calls(None, None, None));
+        assert!(effective_tool_calls(None, Some(true), None));
+        assert!(effective_tool_calls(None, Some(false), None));
+        assert!(!effective_tool_calls(None, Some(true), Some(true)));
+        assert!(!effective_tool_calls(Some(false), Some(true), None));
+        assert!(effective_tool_calls(Some(true), None, Some(true)));
+    }
 
     fn rec(
         rkey: &str,

--- a/provider/src/pds.rs
+++ b/provider/src/pds.rs
@@ -231,19 +231,29 @@ pub const OWNER_INTENT_KEYS: &[&str] = &[
     "toolCallsDisabled",
 ];
 
-/// Resolve tool calling once for startup and live reconciliation. An explicit
-/// operator setting wins; otherwise only the additive opt-out disables the
-/// default. The legacy field remains an input to make its compatibility
-/// semantics explicit: true still means on, while false is not a new opt-out.
-pub fn effective_tool_calls(
-    explicit_env: Option<bool>,
-    legacy_tool_calls: Option<bool>,
-    tool_calls_disabled: Option<bool>,
-) -> bool {
-    match (explicit_env, legacy_tool_calls, tool_calls_disabled) {
-        (Some(enabled), _, _) => enabled,
-        (None, _, Some(true)) => false,
-        (None, _, _) => true,
+/// Resolve the effective tool-calling policy once for startup and live
+/// reconciliation. An explicit operator environment override wins; otherwise
+/// the additive owner opt-out (`toolCallsDisabled: true`) disables the
+/// default-on behaviour. The legacy `toolCalls` field is preserved for
+/// serialization and older agents but is intentionally not an input here:
+/// the new model is default-on unless explicitly opted out.
+pub fn effective_tool_calls(explicit_env: Option<bool>, tool_calls_disabled: Option<bool>) -> bool {
+    match (explicit_env, tool_calls_disabled) {
+        (Some(enabled), _) => enabled,
+        (None, Some(true)) => false,
+        (None, _) => true,
+    }
+}
+
+/// Parse the operator's `COCORE_ENABLE_TOOL_CALLS` override. Recognised values
+/// (`"1"`, `"true"` and `"0"`, `"false"`) return `Some`; anything else
+/// (including the empty string or a typo) returns `None`, so a malformed
+/// value cannot silently turn tool calling off.
+pub fn parse_tool_calls_env_override(value: Option<&str>) -> Option<bool> {
+    match value {
+        Some(v) if v.eq_ignore_ascii_case("true") || v == "1" => Some(true),
+        Some(v) if v.eq_ignore_ascii_case("false") || v == "0" => Some(false),
+        _ => None,
     }
 }
 
@@ -1219,12 +1229,33 @@ mod tests {
 
     #[test]
     fn effective_tool_policy_defaults_on_and_honours_precedence() {
-        assert!(effective_tool_calls(None, None, None));
-        assert!(effective_tool_calls(None, Some(true), None));
-        assert!(effective_tool_calls(None, Some(false), None));
-        assert!(!effective_tool_calls(None, Some(true), Some(true)));
-        assert!(!effective_tool_calls(Some(false), Some(true), None));
-        assert!(effective_tool_calls(Some(true), None, Some(true)));
+        // Default-on when no owner field and no env override.
+        assert!(effective_tool_calls(None, None));
+        // Legacy opt-in is ignored absent the opt-out.
+        assert!(effective_tool_calls(None, Some(false)));
+        // Additive opt-out disables, regardless of legacy opt-in.
+        assert!(!effective_tool_calls(None, Some(true)));
+        // Explicit env override wins over opt-out.
+        assert!(!effective_tool_calls(Some(false), Some(true)));
+        assert!(effective_tool_calls(Some(true), Some(true)));
+        // Explicit env override wins over default-on and over opt-in.
+        assert!(!effective_tool_calls(Some(false), None));
+        assert!(effective_tool_calls(Some(true), None));
+    }
+
+    #[test]
+    fn parse_tool_calls_env_override_recognises_bools_and_rejects_garbage() {
+        assert_eq!(parse_tool_calls_env_override(Some("1")), Some(true));
+        assert_eq!(parse_tool_calls_env_override(Some("true")), Some(true));
+        assert_eq!(parse_tool_calls_env_override(Some("TRUE")), Some(true));
+        assert_eq!(parse_tool_calls_env_override(Some("0")), Some(false));
+        assert_eq!(parse_tool_calls_env_override(Some("false")), Some(false));
+        assert_eq!(parse_tool_calls_env_override(Some("FALSE")), Some(false));
+        // Absent, empty, or typo => None (cannot silently disable).
+        assert_eq!(parse_tool_calls_env_override(None), None);
+        assert_eq!(parse_tool_calls_env_override(Some("")), None);
+        assert_eq!(parse_tool_calls_env_override(Some("yes")), None);
+        assert_eq!(parse_tool_calls_env_override(Some("flase")), None);
     }
 
     fn rec(

--- a/provider/src/pricing.rs
+++ b/provider/src/pricing.rs
@@ -53,10 +53,10 @@ pub struct ModelRate {
     /// floor + price) but are NOT recommended. UX-only; never on the wire.
     pub recommended: bool,
     /// The vLLM `--tool-call-parser` name this model pairs with, when cocore
-    /// knows one (`hermes` for the Qwen rotation, `llama4_pythonic` for
-    /// Llama 4, …). `None` means cocore has no vetted parser pairing for this
-    /// id, so it stays OUT of the curated tool-calling set: when the owner
-    /// flips the per-machine `toolCalls` switch the agent only enables
+    /// knows one (`qwen3_xml` for Qwen 3.5/3.6, `hermes` for Qwen 2.5,
+    /// `llama4_pythonic` for Llama 4, …). `None` means cocore has no vetted
+    /// parser pairing for this id, so it stays OUT of the curated tool-calling
+    /// set: when effective machine policy is on, the agent only enables
     /// automatic tool choice for entries that carry a parser here, then still
     /// gates advertisement behind the forced-tool startup canary. This is the
     /// "restrict to top models for now" boundary — adding a new model to the
@@ -100,7 +100,7 @@ pub const RATES: &[ModelRate] = &[
         min_ram_gb: 4,
         description: "Qwen3.5 0.8B — fast, low quality; fits any Apple Silicon",
         recommended: true,
-        tool_call_parser: Some("hermes"),
+        tool_call_parser: Some("qwen3_xml"),
     },
     ModelRate {
         model_id: "mlx-community/Qwen3.5-2B-MLX-4bit",
@@ -110,7 +110,7 @@ pub const RATES: &[ModelRate] = &[
         min_ram_gb: 6,
         description: "Qwen3.5 2B — small but coherent; good on 8GB",
         recommended: true,
-        tool_call_parser: Some("hermes"),
+        tool_call_parser: Some("qwen3_xml"),
     },
     ModelRate {
         model_id: "mlx-community/Qwen3.5-4B-MLX-4bit",
@@ -120,7 +120,7 @@ pub const RATES: &[ModelRate] = &[
         min_ram_gb: 8,
         description: "Qwen3.5 4B — balanced default for 8GB+ Macs",
         recommended: true,
-        tool_call_parser: Some("hermes"),
+        tool_call_parser: Some("qwen3_xml"),
     },
     // NOTE: `mlx-community/gemma-4-e4b-it-4bit` was previously here. It is a
     // merged/multimodal (Gemma "E4B") checkpoint whose weights are nested under
@@ -138,7 +138,7 @@ pub const RATES: &[ModelRate] = &[
         min_ram_gb: 16,
         description: "Qwen3.5 9B — strong general-purpose; 16GB+ recommended",
         recommended: true,
-        tool_call_parser: Some("hermes"),
+        tool_call_parser: Some("qwen3_xml"),
     },
     ModelRate {
         model_id: "mlx-community/Qwen3.5-27B-4bit",
@@ -148,7 +148,7 @@ pub const RATES: &[ModelRate] = &[
         min_ram_gb: 24,
         description: "Qwen3.5 27B — high-quality dense model; 24GB+",
         recommended: true,
-        tool_call_parser: Some("hermes"),
+        tool_call_parser: Some("qwen3_xml"),
     },
     ModelRate {
         model_id: "mlx-community/Qwen3.6-27B-4bit",
@@ -158,7 +158,7 @@ pub const RATES: &[ModelRate] = &[
         min_ram_gb: 24,
         description: "Qwen3.6 27B — frontier-class dense; 24GB+",
         recommended: true,
-        tool_call_parser: Some("hermes"),
+        tool_call_parser: Some("qwen3_xml"),
     },
     ModelRate {
         model_id: "mlx-community/Qwen3.5-35B-A3B-4bit",
@@ -168,7 +168,7 @@ pub const RATES: &[ModelRate] = &[
         min_ram_gb: 32,
         description: "Qwen3.5 35B-A3B MoE — fast for its size; 32GB+",
         recommended: true,
-        tool_call_parser: Some("hermes"),
+        tool_call_parser: Some("qwen3_xml"),
     },
     ModelRate {
         model_id: "mlx-community/Qwen3.6-35B-A3B-4bit",
@@ -178,7 +178,7 @@ pub const RATES: &[ModelRate] = &[
         min_ram_gb: 32,
         description: "Qwen3.6 35B-A3B MoE — fast for its size; 32GB+",
         recommended: true,
-        tool_call_parser: Some("hermes"),
+        tool_call_parser: Some("qwen3_xml"),
     },
     // DWQ re-quant of the entry above. Same architecture and chat/tool
     // template, so it pairs with the same parser — machines already serving
@@ -193,7 +193,7 @@ pub const RATES: &[ModelRate] = &[
         min_ram_gb: 32,
         description: "Qwen3.6 35B-A3B MoE (DWQ quant) — fast for its size; 32GB+",
         recommended: false,
-        tool_call_parser: Some("hermes"),
+        tool_call_parser: Some("qwen3_xml"),
     },
     ModelRate {
         model_id: "mlx-community/Llama-4-Scout-17B-16E-Instruct-4bit",
@@ -213,7 +213,7 @@ pub const RATES: &[ModelRate] = &[
         min_ram_gb: 96,
         description: "Qwen3.5 122B-A10B MoE — flagship; 96GB+ Mac Studio/Ultra",
         recommended: true,
-        tool_call_parser: Some("hermes"),
+        tool_call_parser: Some("qwen3_xml"),
     },
     ModelRate {
         model_id: "mlx-community/Qwen3.5-397B-A17B-4bit",
@@ -223,7 +223,7 @@ pub const RATES: &[ModelRate] = &[
         min_ram_gb: 256,
         description: "Qwen3.5 397B-A17B MoE — flagship; 256GB+ Ultra",
         recommended: true,
-        tool_call_parser: Some("hermes"),
+        tool_call_parser: Some("qwen3_xml"),
     },
     // ---- Legacy catalog (still servable; not recommended) -------------
     // Kept so a machine that already pinned one of these keeps its RAM
@@ -237,7 +237,7 @@ pub const RATES: &[ModelRate] = &[
         min_ram_gb: 4,
         description: "Qwen 0.5B (legacy) — fast, low quality",
         recommended: false,
-        tool_call_parser: None,
+        tool_call_parser: Some("hermes"),
     },
     ModelRate {
         model_id: "mlx-community/Qwen2.5-3B-Instruct-4bit",
@@ -247,7 +247,7 @@ pub const RATES: &[ModelRate] = &[
         min_ram_gb: 8,
         description: "Qwen 3B (legacy) — small but coherent",
         recommended: false,
-        tool_call_parser: None,
+        tool_call_parser: Some("hermes"),
     },
     ModelRate {
         model_id: "mlx-community/Qwen2.5-7B-Instruct-4bit",
@@ -257,7 +257,7 @@ pub const RATES: &[ModelRate] = &[
         min_ram_gb: 16,
         description: "Qwen 7B (legacy) — strong general-purpose",
         recommended: false,
-        tool_call_parser: None,
+        tool_call_parser: Some("hermes"),
     },
     ModelRate {
         model_id: "mlx-community/gemma-3-4b-it-qat-4bit",
@@ -277,7 +277,7 @@ pub const RATES: &[ModelRate] = &[
         min_ram_gb: 32,
         description: "Qwen 32B (legacy) — frontier-class",
         recommended: false,
-        tool_call_parser: None,
+        tool_call_parser: Some("hermes"),
     },
     ModelRate {
         model_id: "mlx-community/Llama-3.3-70B-Instruct-4bit",
@@ -315,12 +315,15 @@ pub fn min_ram_gb(model_id: &str) -> Option<u32> {
 /// The vetted vLLM `--tool-call-parser` for a model id, or `None` when cocore
 /// has no parser pairing for it (off-catalog model, or a catalog entry we
 /// haven't vetted for tool calls — every legacy entry, the stub). This is the
-/// curated "top models" boundary the per-machine `toolCalls` switch reconciles
-/// against: only a model that returns `Some` here is eligible to attempt tool
-/// calling, and even then the forced-tool startup canary still decides whether
-/// the engine actually advertises it. Adding a model to the rotation is a
-/// one-line parser pairing in `RATES`, never a code change here.
+/// curated model boundary the effective machine policy reconciles against:
+/// only a model that returns `Some` here may attempt tool calling, and the
+/// forced-tool startup canary still decides whether it is advertised. Catalog
+/// models carry their parser in `RATES`; exact off-catalog exceptions are
+/// matched explicitly here without making them picker entries.
 pub fn tool_call_parser(model_id: &str) -> Option<&'static str> {
+    if model_id == "leonsarmiento/Ornith-1.0-35B-5bit-mlx" {
+        return Some("qwen3_xml");
+    }
     RATES
         .iter()
         .find(|r| r.model_id == model_id)
@@ -700,17 +703,55 @@ mod tests {
     }
 
     #[test]
+    fn curated_tool_parsers_are_exact_and_fail_closed() {
+        for model in [
+            "mlx-community/Qwen3.5-0.8B-MLX-4bit",
+            "mlx-community/Qwen3.5-2B-MLX-4bit",
+            "mlx-community/Qwen3.5-4B-MLX-4bit",
+            "mlx-community/Qwen3.5-9B-MLX-4bit",
+            "mlx-community/Qwen3.5-27B-4bit",
+            "mlx-community/Qwen3.5-35B-A3B-4bit",
+            "mlx-community/Qwen3.5-122B-A10B-4bit",
+            "mlx-community/Qwen3.5-397B-A17B-4bit",
+            "mlx-community/Qwen3.6-27B-4bit",
+            "mlx-community/Qwen3.6-35B-A3B-4bit",
+            "mlx-community/Qwen3.6-35B-A3B-4bit-DWQ",
+            "leonsarmiento/Ornith-1.0-35B-5bit-mlx",
+        ] {
+            assert_eq!(tool_call_parser(model), Some("qwen3_xml"), "{model}");
+        }
+        for model in [
+            "mlx-community/Qwen2.5-0.5B-Instruct-4bit",
+            "mlx-community/Qwen2.5-3B-Instruct-4bit",
+            "mlx-community/Qwen2.5-7B-Instruct-4bit",
+            "mlx-community/Qwen2.5-32B-Instruct-4bit",
+        ] {
+            assert_eq!(tool_call_parser(model), Some("hermes"), "{model}");
+        }
+        for model in [
+            "mlx-community/Llama-3.3-70B-Instruct-4bit",
+            "mlx-community/gemma-3-4b-it-qat-4bit",
+            "deepseek-coder-v2-lite-instruct",
+            "text-embedding-nomic-embed-text-v1.5",
+            "stub",
+            "unknown/model",
+        ] {
+            assert_eq!(tool_call_parser(model), None, "{model}");
+        }
+    }
+
+    #[test]
     fn dwq_requant_pairs_with_same_parser_but_stays_off_the_rotation() {
         // The DWQ re-quant shares the canonical entry's chat/tool template,
         // so it must carry the same parser pairing (issue #166: a machine
         // serving it could never pass the tool-call canary)…
         assert_eq!(
             tool_call_parser("mlx-community/Qwen3.6-35B-A3B-4bit-DWQ"),
-            Some("hermes")
+            Some("qwen3_xml")
         );
         assert_eq!(
             tool_call_parser("mlx-community/Qwen3.6-35B-A3B-4bit"),
-            Some("hermes")
+            Some("qwen3_xml")
         );
         // …while the picker rotation keeps recommending only the canonical
         // quant.


### PR DESCRIPTION
## Context

Schema PR #195 added the additive `toolCallsDisabled` owner opt-out without changing the legacy `toolCalls` contract. This PR implements the generated types, provider policy, curated parser mappings, startup verification, console controls, and public documentation.

Public API terminology remains OpenAI-compatible (`tools`, `tool_calls`, and `finish_reason: "tool_calls"`). On the inference side this is structured tool-call intent generation: providers never execute tools; requester clients execute them and may return results in a follow-up turn.

## What changes

- Regenerates the SDK provider type with `toolCallsDisabled`.
- Defaults eligible provider models on when neither owner field nor an explicit environment override is present.
- Keeps explicit `COCORE_ENABLE_TOOL_CALLS` authoritative; only `"1"`/`"true"` and `"0"`/`"false"` are recognised, so a typo cannot silently disable the feature.
- Gives `toolCallsDisabled: true` precedence over legacy `toolCalls: true`; the legacy field is preserved for older agents but no longer participates in the policy decision.
- Preserves both owner fields across provisioning, republish, deduplication, attestation refresh, and shutdown writes.
- Makes live advisor reconciliation compare effective policy, avoiding restarts when the stored representation changes but behavior does not.
- Writes console settings compatibly:
  - on: remove `toolCallsDisabled`, write `toolCalls: true`;
  - off: write `toolCallsDisabled: true`, remove `toolCalls`.
- Strengthens the forced-tool startup canary to require both `report_status` and preserved JSON arguments equal to `{"status":"ok"}`.
- Keeps canary/parser failure fail-soft: ordinary inference remains available and the model is omitted from `tool_call_models`.
- Documents the standard client-side tool loop and the provider/requester execution boundary.

## Curated model audit

Immediately enabled exact pairings:

- Qwen 3.5 and 3.6 MLX catalog IDs → `qwen3_xml`.
- Qwen 2.5 Instruct 0.5B, 3B, 7B, and 32B MLX IDs → `hermes`.
- `leonsarmiento/Ornith-1.0-35B-5bit-mlx` → `qwen3_xml`, without adding the deprecated quant to the picker/catalog rotation.

Still deliberately excluded:

- `mlx-community/Llama-3.3-70B-Instruct-4bit`: its `{name, parameters}` response needs a preserving parser/adapter.
- `mlx-community/gemma-3-4b-it-qat-4bit`: no vetted parser pairing.
- `deepseek-coder-v2-lite-instruct`, `google/gemma-4-12b`, `google/gemma-4-e4b`, `mistralai/ministral-3-14b-reasoning`, `qwen/qwen3.5-9b`, `qwen/qwen2.5-coder-14b`, `text-embedding-nomic-embed-text-v1.5`, and `unsloth/gemma-4-26B-A4B-it-GGUF:UD-Q4_K_XL`: these are external/non-chat/backend-specific paths that first need structured buffered/streaming relay and startup capability verification.
- `stub` and unknown IDs remain excluded.

The runtime canary remains authoritative even for every included mapping.

## Validation

Passed locally:

- provider: 189 library tests, 61 binary tests, 5 cross-language fixture tests, OAuth tests, and doc tests;
- console: 353 tests;
- SDK: 140 tests;
- console TypeScript typecheck;
- provider `cargo fmt` and production-target clippy;
- lexicon JSON validation and `lex-codegen-check`;
- OpenAPI YAML parse and changed-file formatting checks.

A live Qwen3.5-4B plus Qwen2.5 multi-turn/streaming tool loop remains a rollout check because this branch is not deployed and no local console/provider stack or API key is running in this workspace.

## Rollout

Deploy console support first so every owner can opt out, then release the default-on provider. Existing explicit environment overrides remain unchanged. Machines whose exact model/backend fails its startup canary continue ordinary inference and never advertise tool support.

After this PR exists, separate linked issues will track the eight deferred parser/backend units; they are intentionally not bundled here.
