### PR TITLE
fix(console): filter dispatch candidates by tool-calling capability

### DIFF
--- a/packages/console/src/lib/inference-dispatch.server.ts
+++ b/packages/console/src/lib/inference-dispatch.server.ts
@@ -214,6 +214,7 @@ export type DispatchErrorCode =
   | "no-providers-for-model"
   | "no-providers-for-country"
   | "no-providers-for-version"
+  | "no-providers-for-tool-calls"
   | "no-friends-available"
   | "no-friends-for-model"
   | "target-provider-not-connected"
@@ -456,6 +457,31 @@ export function filterByMinVersion<T extends { binaryVersion?: string }>(
   return candidates.filter((c) => meetsMinVersion(c.binaryVersion, minVersion));
 }
 
+/** True iff this machine passed the forced-tool canary for `model`. Mirrors
+ *  the advisor's `supportsToolCallsFor` (registry.ts): a machine that reports
+ *  the per-model `toolCallModels` set must include this model; a legacy
+ *  machine that predates the field falls back to the coarse `supportsToolCalls`
+ *  boolean. Fail-closed — neither present means "no tool-calling." */
+export function machineSupportsToolCallsFor<
+  T extends { toolCallModels?: string[]; supportsToolCalls?: boolean },
+>(row: T, model: string): boolean {
+  if (Array.isArray(row.toolCallModels)) return row.toolCallModels.includes(model);
+  return row.supportsToolCalls === true;
+}
+
+/** Pure filter for tool-calling routing. When the request carries no tools
+ *  (`wantsToolCalls` false) the list passes through verbatim. Otherwise keeps
+ *  only machines that passed the forced-tool canary for `model` — so the
+ *  candidate we pin is one the advisor will actually accept, instead of the
+ *  freshest model-matching machine that then 503s "no machine with verified
+ *  tool-calling." */
+export function filterByToolCalls<
+  T extends { toolCallModels?: string[]; supportsToolCalls?: boolean },
+>(candidates: T[], model: string, wantsToolCalls: boolean): T[] {
+  if (!wantsToolCalls) return candidates;
+  return candidates.filter((c) => machineSupportsToolCallsFor(c, model));
+}
+
 export class NoProvidersForVersionError extends Error {
   readonly minVersion: string;
   constructor(minVersion: string, detail: string) {
@@ -473,6 +499,15 @@ export class ProviderPayoutsNotEligibleError extends Error {
     );
     this.name = "ProviderPayoutsNotEligibleError";
     this.providerDid = providerDid;
+  }
+}
+
+export class NoProvidersForToolCallsError extends Error {
+  readonly model: string;
+  constructor(model: string, detail: string) {
+    super(`no provider with verified tool-calling for model '${model}': ${detail}`);
+    this.name = "NoProvidersForToolCallsError";
+    this.model = model;
   }
 }
 
@@ -495,6 +530,12 @@ async function pickProvider(
    *  pick: you can't send an image job to an old machine just because it's
    *  yours / pinned. Fail-closed: a machine reporting no version never passes. */
   minProviderVersion: string | undefined,
+  /** True when the request carries `tools`. Like `minProviderVersion` this is
+   *  a hard capability gate on EVERY path (including a pin): a machine that
+   *  didn't pass the forced-tool canary for this model will have the advisor
+   *  503 the pinned `/jobs`, so filter it out here and pin a machine the
+   *  advisor will actually accept. Fail-closed via {@link filterByToolCalls}. */
+  wantsToolCalls: boolean,
   /** Providers already tried this dispatch (a prior attempt's `/jobs`
    *  failed because they'd flapped out between the snapshot and the
    *  dispatch). Excluded from re-selection so failover lands on a
@@ -531,12 +572,25 @@ async function pickProvider(
         `pinned provider ${targetDid} reports ${hit.binaryVersion ?? "no version"}`,
       );
     }
+    // Tool-calling is a capability gate even on a pin: the advisor would 503
+    // this exact machine, so refuse up-front with the actionable reason
+    // instead of letting the dispatch fail opaquely.
+    if (filterByToolCalls([hit], model, wantsToolCalls).length === 0) {
+      throw new NoProvidersForToolCallsError(
+        model,
+        `pinned provider ${targetDid} has not passed the forced-tool canary for this model`,
+      );
+    }
     return hit;
   }
 
-  const own = filterByMinVersion(
-    ownMachineCandidates(attested, requesterDid, model, excludeDids ?? new Set()),
-    minProviderVersion,
+  const own = filterByToolCalls(
+    filterByMinVersion(
+      ownMachineCandidates(attested, requesterDid, model, excludeDids ?? new Set()),
+      minProviderVersion,
+    ),
+    model,
+    wantsToolCalls,
   );
   if (own.length > 0) return own[0]!;
 
@@ -576,7 +630,14 @@ async function pickProvider(
         `${friendInCountry.length} friend provider(s) serve model '${model}' but none at that version`,
       );
     }
-    const eligible = filterByPayoutsEligibility(friendAtVersion, options);
+    const friendToolCapable = filterByToolCalls(friendAtVersion, model, wantsToolCalls);
+    if (friendToolCapable.length === 0) {
+      throw new NoProvidersForToolCallsError(
+        model,
+        `${friendAtVersion.length} friend provider(s) serve model '${model}' but none passed the forced-tool canary`,
+      );
+    }
+    const eligible = filterByPayoutsEligibility(friendToolCapable, options);
     if (eligible.length === 0) {
       // Surface a DID from the post-country-filter list so the diagnostic
       // points at a provider that's actually both model-fit and in-country,
@@ -600,7 +661,14 @@ async function pickProvider(
       `${inCountry.length} provider(s) serve model '${model}' but none at that version`,
     );
   }
-  const eligible = filterByPayoutsEligibility(atVersion, options);
+  const toolCapable = filterByToolCalls(atVersion, model, wantsToolCalls);
+  if (toolCapable.length === 0) {
+    throw new NoProvidersForToolCallsError(
+      model,
+      `${atVersion.length} provider(s) serve model '${model}' but none passed the forced-tool canary`,
+    );
+  }
+  const eligible = filterByPayoutsEligibility(toolCapable, options);
   if (eligible.length === 0) {
     // No payouts-eligible provider serves this model. Surface the
     // first model-fit, in-country provider's DID so the caller can
@@ -668,6 +736,7 @@ export function classifyDispatchError(e: unknown): DispatchErrorCode {
   if (e instanceof NoProvidersForModelError) return "no-providers-for-model";
   if (e instanceof NoProvidersForCountryError) return "no-providers-for-country";
   if (e instanceof NoProvidersForVersionError) return "no-providers-for-version";
+  if (e instanceof NoProvidersForToolCallsError) return "no-providers-for-tool-calls";
   if (e instanceof NoFriendsAvailableError) return "no-friends-available";
   if (e instanceof NoFriendsForModelError) return "no-friends-for-model";
   if (e instanceof TargetProviderNotConnectedError) return "target-provider-not-connected";
@@ -810,6 +879,9 @@ export async function* runDispatch(input: DispatchInputs): AsyncGenerator<Dispat
         // Version IS enforced even on a pin — a capability the machine either
         // has or doesn't, not a routing preference.
         input.minProviderVersion,
+        // Tools in the request → only pin a machine that passed the forced-tool
+        // canary for this model, so the advisor doesn't 503 the dispatch.
+        Array.isArray(input.tools) && input.tools.length > 0,
         excludeDids,
       );
     } catch (e) {

--- a/packages/console/src/lib/inference-dispatch.test.ts
+++ b/packages/console/src/lib/inference-dispatch.test.ts
@@ -13,12 +13,15 @@ import {
   filterByCountry,
   filterByMinVersion,
   filterByPayoutsEligibility,
+  filterByToolCalls,
+  machineSupportsToolCallsFor,
   meetsMinVersion,
   NoFriendsAvailableError,
   NoFriendsForModelError,
   NoProvidersConnectedError,
   NoProvidersForCountryError,
   NoProvidersForModelError,
+  NoProvidersForToolCallsError,
   NoProvidersForVersionError,
   ProviderPayoutsNotEligibleError,
   TargetProviderNotConnectedError,
@@ -152,6 +155,10 @@ describe("classifyDispatchError", () => {
       classifyDispatchError(new ProviderPayoutsNotEligibleError("did:plc:alice")),
       "provider-payouts-not-eligible",
     );
+    assert.equal(
+      classifyDispatchError(new NoProvidersForToolCallsError("gemma-3", "detail")),
+      "no-providers-for-tool-calls",
+    );
   });
 
   test("unknown errors fall through to advisor-transport", () => {
@@ -243,5 +250,66 @@ describe("filterByMinVersion — version-gated routing", () => {
       classifyDispatchError(new NoProvidersForVersionError("0.9.32", "none at version")),
       "no-providers-for-version",
     );
+  });
+});
+
+describe("filterByToolCalls — tool-calling routing", () => {
+  const MODEL = "mlx-community/Qwen3.5-4B-MLX-4bit";
+  const OTHER = "mlx-community/Qwen3.5-9B-MLX-4bit";
+  // Passed the per-model forced-tool canary for MODEL.
+  const CANARY = { did: "did:plc:canary", toolCallModels: [MODEL] };
+  // Serves MODEL but reports an empty canary set (didn't pass for any model) —
+  // this is the common fleet shape that used to get pinned and then 503'd.
+  const NOCANARY = { did: "did:plc:nocanary", toolCallModels: [] as string[] };
+  // Passed the canary, but for a DIFFERENT model than the one requested.
+  const CANARY_OTHER = { did: "did:plc:other", toolCallModels: [OTHER] };
+  // Legacy machine that predates toolCallModels — falls back to the boolean.
+  const LEGACY_ON: { did: string; toolCallModels?: string[]; supportsToolCalls?: boolean } = {
+    did: "did:plc:legacy-on",
+    supportsToolCalls: true,
+  };
+  const LEGACY_OFF: { did: string; toolCallModels?: string[]; supportsToolCalls?: boolean } = {
+    did: "did:plc:legacy-off",
+  };
+
+  test("wantsToolCalls=false passes the list through verbatim", () => {
+    assert.deepEqual(filterByToolCalls([CANARY, NOCANARY, LEGACY_OFF], MODEL, false), [
+      CANARY,
+      NOCANARY,
+      LEGACY_OFF,
+    ]);
+  });
+
+  test("keeps only machines that passed the canary for the requested model", () => {
+    assert.deepEqual(
+      filterByToolCalls([CANARY, NOCANARY, CANARY_OTHER], MODEL, true),
+      [CANARY],
+    );
+  });
+
+  test("a machine whose canary set omits the model is excluded (the 503 bug)", () => {
+    // NOCANARY serves MODEL but never passed the forced-tool canary; pinning it
+    // is exactly what produced the advisor's "no machine with verified
+    // tool-calling" 503. It must not survive the filter.
+    assert.deepEqual(filterByToolCalls([NOCANARY], MODEL, true), []);
+  });
+
+  test("legacy machines fall back to the supportsToolCalls boolean", () => {
+    assert.deepEqual(filterByToolCalls([LEGACY_ON, LEGACY_OFF], MODEL, true), [LEGACY_ON]);
+  });
+
+  test("machineSupportsToolCallsFor mirrors the advisor's per-model semantics", () => {
+    assert.equal(machineSupportsToolCallsFor(CANARY, MODEL), true);
+    assert.equal(machineSupportsToolCallsFor(CANARY, OTHER), false);
+    assert.equal(machineSupportsToolCallsFor(NOCANARY, MODEL), false);
+    assert.equal(machineSupportsToolCallsFor(LEGACY_ON, MODEL), true);
+    assert.equal(machineSupportsToolCallsFor(LEGACY_OFF, MODEL), false);
+  });
+
+  test("NoProvidersForToolCallsError carries model + code", () => {
+    const e = new NoProvidersForToolCallsError(MODEL, "3 serve the model but none passed the canary");
+    assert.match(e.message, /Qwen3\.5-4B/);
+    assert.match(e.message, /verified tool-calling/);
+    assert.equal(classifyDispatchError(e), "no-providers-for-tool-calls");
   });
 });

--- a/packages/console/src/lib/inference-dispatch.test.ts
+++ b/packages/console/src/lib/inference-dispatch.test.ts
@@ -281,10 +281,7 @@ describe("filterByToolCalls — tool-calling routing", () => {
   });
 
   test("keeps only machines that passed the canary for the requested model", () => {
-    assert.deepEqual(
-      filterByToolCalls([CANARY, NOCANARY, CANARY_OTHER], MODEL, true),
-      [CANARY],
-    );
+    assert.deepEqual(filterByToolCalls([CANARY, NOCANARY, CANARY_OTHER], MODEL, true), [CANARY]);
   });
 
   test("a machine whose canary set omits the model is excluded (the 503 bug)", () => {
@@ -307,7 +304,10 @@ describe("filterByToolCalls — tool-calling routing", () => {
   });
 
   test("NoProvidersForToolCallsError carries model + code", () => {
-    const e = new NoProvidersForToolCallsError(MODEL, "3 serve the model but none passed the canary");
+    const e = new NoProvidersForToolCallsError(
+      MODEL,
+      "3 serve the model but none passed the canary",
+    );
     assert.match(e.message, /Qwen3\.5-4B/);
     assert.match(e.message, /verified tool-calling/);
     assert.equal(classifyDispatchError(e), "no-providers-for-tool-calls");

--- a/packages/console/src/lib/openai-chat-completions.server.ts
+++ b/packages/console/src/lib/openai-chat-completions.server.ts
@@ -623,6 +623,16 @@ export function dispatchErrorToHttpResponse(errorCode: DispatchErrorCode): {
         type: "service_unavailable_error",
         code: "no_providers_for_version",
       };
+    case "no-providers-for-tool-calls":
+      // The model exists but no connected provider passed the forced-tool
+      // canary for it. 400 (matches the up-front `tool_calls_not_supported`
+      // gate): tool-calling isn't a transient-capacity issue the client should
+      // blindly retry — the request needs a tool-capable model/provider.
+      return {
+        status: 400,
+        type: "invalid_request_error",
+        code: "tool_calls_not_supported",
+      };
     case "no-friends-available":
       return {
         status: 503,


### PR DESCRIPTION
## Symptom
Tool-calling / agent chat through the OpenAI-compatible `/v1/chat/completions` API fails in a repeating 3-attempt 503 loop. The Client logs on Railway show it continuously:

```
[dispatch] /jobs 503 provider=…lawc7… attempt=1/3: … has no machine with verified tool-calling for this model available
[dispatch] /jobs 503 provider=…gfrmhd… attempt=2/3: …
[dispatch] /jobs 503 provider=…zm5rb… attempt=3/3: …
```

(The built-in browser chat UI sends no `tools`, so plain chat is unaffected — this bites tool-calling/agent clients.)

## Root cause
When a request carries `tools`, the console does a **global** capability check (`checkToolCallSupport`) — "does *any* connected provider have verified tool-calling for this model?" — and if so proceeds. But the actual candidate picker, `pickProvider`, filters only by **model → country → version → payouts**, then sorts by `lastSeen` and pins the freshest machine — sealing the prompt to it and pinning that exact `targetMachineId`. The advisor narrows to that one machine, finds it never passed the forced-tool canary, and 503s ([`infra/advisor/src/jobs.ts:345`](https://github.com/graze-social/cocore/blob/main/infra/advisor/src/jobs.ts#L345)). Failover re-picks by freshness again → all attempts land on non-tool-capable machines.

With only ~2 of 19 fleet machines currently passing the per-model canary for the default model, tool-calling chat failed nearly every time. Even a DID that owns a tool-capable machine failed, because the picker pinned the owner's *other* (non-capable) machine.

## Fix
- Add `machineSupportsToolCallsFor` + `filterByToolCalls`, mirroring the advisor's `supportsToolCallsFor` (per-model `toolCallModels` set, falling back to the legacy `supportsToolCalls` boolean, fail-closed).
- Thread `wantsToolCalls` through `pickProvider` and apply the filter on **every** path — open pool, friends, own-machine, and explicit pin — so we only ever pin a machine the advisor will accept.
- New `NoProvidersForToolCallsError` → `no-providers-for-tool-calls`, mapped to HTTP `400 tool_calls_not_supported` to match the existing up-front gate (it's a capability mismatch, not transient capacity to blindly retry).

## Tests
- New `filterByToolCalls` / `machineSupportsToolCallsFor` unit coverage incl. the exact 503-bug shape (a machine that serves the model but has an empty canary set is excluded), legacy fallback, and the error/code mapping.
- `inference-dispatch` (34) + `openai-chat-completions` (48) + `openai-routes` (9) all green; typecheck clean. (Pre-existing `better-sqlite3` Node-26 ABI failures in `console-db`/`api-keys` tests are unrelated.)

## Note (separate follow-up)
Independent of this routing bug: only a couple of fleet machines pass the per-model forced-tool canary, so tool-calling capacity is thin even once selection is correct. Worth investigating why so few 0.9.50 machines report `toolCallModels` for the models they serve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)