### PR TITLE
fix(console): release proxy survives GitHub auth outages + actionable tool-calling error

### DIFF
--- a/packages/console/src/lib/github-releases.server.test.ts
+++ b/packages/console/src/lib/github-releases.server.test.ts
@@ -1,0 +1,85 @@
+// Regression tests for the GitHub release proxy's anonymous fallback.
+// 2026-07-16: GitHub served 503s to all AUTHENTICATED API calls while
+// anonymous ones succeeded, which took `/agent/version` (and every
+// installer download) down because the proxy required a token and never
+// retried without one.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { latestTag, ReleaseProxyError } from "./github-releases.server.ts";
+
+function releaseJson(tag: string): Response {
+  return new Response(JSON.stringify({ tag_name: tag, assets: [] }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe("latestTag", () => {
+  it("falls back to an anonymous request when the authenticated one fails", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "github_pat_test");
+    const calls: Array<string | undefined> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        const auth = (init?.headers as Record<string, string>)?.["Authorization"];
+        calls.push(auth);
+        return auth
+          ? new Response("<html>degraded</html>", { status: 503 })
+          : releaseJson("v9.9.9");
+      }),
+    );
+    await expect(latestTag()).resolves.toBe("v9.9.9");
+    expect(calls).toEqual(["Bearer github_pat_test", undefined]);
+  });
+
+  it("uses the authenticated response when it succeeds", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "github_pat_test");
+    const fetchMock = vi.fn(async () => releaseJson("v1.2.3"));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(latestTag()).resolves.toBe("v1.2.3");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("works with no token at all (repo is public)", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "");
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      expect((init?.headers as Record<string, string>)?.["Authorization"]).toBeUndefined();
+      return releaseJson("v0.9.50");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(latestTag()).resolves.toBe("v0.9.50");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry an authenticated 404 anonymously — it's a real answer", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "github_pat_test");
+    const fetchMock = vi.fn(async () => new Response("nope", { status: 404 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const err = await latestTag().catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ReleaseProxyError);
+    expect((err as ReleaseProxyError).status).toBe(404);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries anonymously when the authenticated fetch throws", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "github_pat_test");
+    let first = true;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        if (first) {
+          first = false;
+          throw new TypeError("fetch failed");
+        }
+        return releaseJson("v2.0.0");
+      }),
+    );
+    await expect(latestTag()).resolves.toBe("v2.0.0");
+  });
+});

--- a/packages/console/src/lib/github-releases.server.ts
+++ b/packages/console/src/lib/github-releases.server.ts
@@ -1,18 +1,18 @@
 // Server-side helpers that proxy GitHub Releases for the cocore agent
-// installer. The cocore repo is private, so an anonymous
-// `curl https://api.github.com/...` returns 404 — but the console
-// runs with a `GITHUB_TOKEN` env var that has `repo` access, so the
-// console can hand both the latest tag and the release tarball back
-// to a fresh Mac running `curl … | sh`.
+// installer, so a fresh Mac running `curl … | sh` gets the latest tag
+// and the release tarball from a stable cocore.dev URL.
 //
 // The two routes that consume this live next to each other:
 //   * `routes/agent.version.ts`  — text/plain  ←  `latestTag()`
 //   * `routes/agent.dl.ts`       — bin stream  ←  `streamAsset()`
 //
-// Token: `process.env.GITHUB_TOKEN`. We deliberately don't fall
-// back silently — if the env var is missing the routes return 503
-// with a clear message, since silent failure would just give the
-// installer the same 404 the public path produces.
+// Auth: the repo is public, so anonymous requests work — but when
+// `process.env.GITHUB_TOKEN` is set we send it first for the higher
+// authenticated rate limit. If the authenticated request fails for any
+// reason (expired token, GitHub auth-path incident — 2026-07-16 GitHub
+// served 503s to ALL authenticated API calls while anonymous ones
+// succeeded, which took the installer down), we retry anonymously
+// before giving up.
 
 const COCORE_REPO = "graze-social/cocore";
 
@@ -30,15 +30,31 @@ export class ReleaseProxyError extends Error {
   }
 }
 
-function token(): string {
+/** Fetch a GitHub API URL, preferring the authenticated path (better rate
+ *  limits) but falling back to anonymous when the authed attempt fails —
+ *  the repo is public, so anonymous is always a valid last resort. */
+async function ghFetch(url: string, accept: string): Promise<Response> {
+  const base: Record<string, string> = {
+    Accept: accept,
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "cocore-console-release-proxy",
+  };
   const t = process.env["GITHUB_TOKEN"];
-  if (!t) {
-    throw new ReleaseProxyError(
-      503,
-      "GITHUB_TOKEN env var not set on the console service; agent installer is offline",
-    );
+  if (t) {
+    try {
+      const r = await fetch(url, {
+        headers: { ...base, Authorization: `Bearer ${t}` },
+        redirect: "follow",
+      });
+      // 404 is a real answer (release/asset genuinely absent) — retrying
+      // anonymously can't improve on it. Anything else non-ok (401/403
+      // token trouble, 5xx GitHub incident) is worth the anonymous retry.
+      if (r.ok || r.status === 404) return r;
+    } catch {
+      // network-level failure — fall through to the anonymous attempt
+    }
   }
-  return t;
+  return fetch(url, { headers: base, redirect: "follow" });
 }
 
 interface ReleaseInfo {
@@ -49,18 +65,10 @@ interface ReleaseInfo {
 /** Resolve a tag (or "latest" if `tag` is null) and return the
  *  release info we need to point a downloader at. */
 async function getRelease(tag: string | null, assetName: string): Promise<ReleaseInfo> {
-  const auth = token();
   const url = tag
     ? `https://api.github.com/repos/${COCORE_REPO}/releases/tags/${encodeURIComponent(tag)}`
     : `https://api.github.com/repos/${COCORE_REPO}/releases/latest`;
-  const r = await fetch(url, {
-    headers: {
-      Accept: "application/vnd.github+json",
-      Authorization: `Bearer ${auth}`,
-      "X-GitHub-Api-Version": "2022-11-28",
-      "User-Agent": "cocore-console-release-proxy",
-    },
-  });
+  const r = await ghFetch(url, "application/vnd.github+json");
   if (r.status === 404) {
     throw new ReleaseProxyError(
       404,
@@ -100,15 +108,7 @@ export async function streamAsset(
   if (!release.assetUrl) {
     throw new ReleaseProxyError(404, `release ${release.tag} has no ${assetName} asset`);
   }
-  const r = await fetch(release.assetUrl, {
-    headers: {
-      Accept: "application/octet-stream",
-      Authorization: `Bearer ${token()}`,
-      "X-GitHub-Api-Version": "2022-11-28",
-      "User-Agent": "cocore-console-release-proxy",
-    },
-    redirect: "follow",
-  });
+  const r = await ghFetch(release.assetUrl, "application/octet-stream");
   if (!r.ok || !r.body) {
     const body = await r.text().catch(() => "");
     throw new ReleaseProxyError(502, `github asset ${r.status}: ${body.slice(0, 200)}`);

--- a/packages/console/src/lib/openai-routes.server.ts
+++ b/packages/console/src/lib/openai-routes.server.ts
@@ -220,31 +220,45 @@ async function checkToolCallSupport(
     return null; // network error — don't block the request
   }
 
-  // Filter to attested, active, model-matching providers.
-  let pool = list.filter(
-    (p) =>
-      p.attestedAt &&
-      p.active !== false &&
-      (p.supportedModels.length === 0 || p.supportedModels.includes(model)),
-  );
-
-  // Friends-only: further filter to the allowed DID set.
+  // Filter to attested, active providers (friends-only: also the allowed
+  // DID set), keeping the model-unfiltered pool around so a rejection can
+  // tell the caller which models WOULD accept their tool request.
+  let live = list.filter((p) => p.attestedAt && p.active !== false);
   if (allowedDids !== undefined) {
-    pool = pool.filter((p) => allowedDids.has(p.did));
+    live = live.filter((p) => allowedDids.has(p.did));
   }
+  const pool = live.filter(
+    (p) => p.supportedModels.length === 0 || p.supportedModels.includes(model),
+  );
 
   // Check if at least one provider in the pool has verified tool calling for
   // this exact model. Legacy providers that predate `toolCallModels` fall back
   // to the coarse boolean; new providers report a per-model canary-passed set.
-  const toolCapable = pool.some((p) => {
-    if (Array.isArray(p.toolCallModels)) return p.toolCallModels.includes(model);
+  const toolCapableFor = (p: AdvisorProviderRow, m: string): boolean => {
+    if (Array.isArray(p.toolCallModels)) return p.toolCallModels.includes(m);
     return p.supportsToolCalls === true;
-  });
-  if (!toolCapable) {
+  };
+  if (!pool.some((p) => toolCapableFor(p, model))) {
+    const alternatives = [
+      ...new Set(
+        live.flatMap((p) =>
+          Array.isArray(p.toolCallModels)
+            ? p.toolCallModels
+            : p.supportsToolCalls === true
+              ? p.supportedModels
+              : [],
+        ),
+      ),
+    ].sort();
+    const hint =
+      alternatives.length > 0
+        ? ` Models with verified tool calling online right now: ${alternatives.join(", ")}.`
+        : " No connected provider currently has verified tool calling for any model.";
     return (
-      "No connected provider supports tool calling for this model. " +
-      "The provider must be started with vLLM tool calling enabled and pass " +
-      "the startup forced-tool canary."
+      `No connected provider supports tool calling for model '${model}'.${hint}` +
+      " Tool requests only route to providers that passed the startup" +
+      " forced-tool canary, so either switch to one of those model ids or" +
+      " retry without tools."
     );
   }
   return null;


### PR DESCRIPTION
## What

Fixes both issues [zeu.dev hit on stream](https://bsky.app/profile/zeu.dev/post/3mqsd5ade7k22) (2026-07-16).

### 1. Agent downloads were completely broken (`curl cocore.dev/agent | sh` and the Mac app)

GitHub is currently serving **503s to all authenticated API calls** while anonymous calls succeed (githubstatus.com shows "Partially Degraded Service"; reproduced with two independent valid tokens). Every installer route — `/agent/version`, `/agent/dl`, `/agent/app`, `/agent/binary-hashes` — funnels through the GitHub release proxy, which *required* `GITHUB_TOKEN`, so the whole download path 502'd.

The repo is public now, so the proxy no longer hard-requires the token: it still prefers the authenticated path (rate limits), but retries anonymously when the authed request fails for any reason other than a genuine 404. Verified live: with a deliberately broken token, `latestTag()` now resolves `v0.9.50` via the fallback while GitHub's authed path is still down.

### 2. Tool-calling rejection was a dead end for opencode users

opencode always sends `tools`, and the fail-closed gate from #197 correctly rejects models with no canary-passed provider — but the message said to enable **vLLM** tool calling (wrong engine for the MLX fleet) and never said which models would work. The user had model `stub` configured (a test model every provider serves but none tool-calls).

The error now names the requested model and enumerates models with verified tool-calling currently online, e.g.:

> No connected provider supports tool calling for model 'stub'. Models with verified tool calling online right now: mlx-community/Qwen3.5-4B-MLX-4bit. Tool requests only route to providers that passed the startup forced-tool canary, so either switch to one of those model ids or retry without tools.

## Tests

- New unit suite for the proxy fallback (authed-fails→anon, authed-ok→no retry, no-token, 404-no-retry, thrown-fetch→anon).
- `npm run typecheck` and existing dispatch tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)