### PR TITLE
Add Ternary Bonsai tool-calling support

### DIFF
--- a/packages/console/src/components/machines/MachinesDashboard.tsx
+++ b/packages/console/src/components/machines/MachinesDashboard.tsx
@@ -145,6 +145,7 @@ const MODEL_RAM_FLOORS: Readonly<Record<string, ModelFloor>> = {
   "mlx-community/Qwen3.5-4B-MLX-4bit": { minRamGB: 8, label: "Qwen3.5-4B" },
   "mlx-community/Qwen3.5-9B-MLX-4bit": { minRamGB: 16, label: "Qwen3.5-9B" },
   "mlx-community/Qwen3.5-27B-4bit": { minRamGB: 24, label: "Qwen3.5-27B" },
+  "prism-ml/Ternary-Bonsai-27B-mlx-2bit": { minRamGB: 24, label: "Ternary Bonsai 27B" },
   "mlx-community/Qwen3.6-27B-4bit": { minRamGB: 24, label: "Qwen3.6-27B" },
   "mlx-community/Qwen3.5-35B-A3B-4bit": { minRamGB: 32, label: "Qwen3.5-35B-A3B" },
   "mlx-community/Qwen3.6-35B-A3B-4bit": { minRamGB: 32, label: "Qwen3.6-35B-A3B" },

--- a/provider/src/engines/subprocess.rs
+++ b/provider/src/engines/subprocess.rs
@@ -1779,6 +1779,9 @@ mod tests {
         let top = on.for_model("mlx-community/Qwen3.5-4B-MLX-4bit");
         assert!(top.enabled);
         assert_eq!(top.tool_call_parser.as_deref(), Some("hermes"));
+        let bonsai = on.for_model("prism-ml/Ternary-Bonsai-27B-mlx-2bit");
+        assert!(bonsai.enabled);
+        assert_eq!(bonsai.tool_call_parser.as_deref(), Some("qwen3_xml"));
         let llama = on.for_model("mlx-community/Llama-4-Scout-17B-16E-Instruct-4bit");
         assert!(llama.enabled);
         assert_eq!(llama.tool_call_parser.as_deref(), Some("llama4_pythonic"));

--- a/provider/src/pricing.rs
+++ b/provider/src/pricing.rs
@@ -150,6 +150,21 @@ pub const RATES: &[ModelRate] = &[
         recommended: true,
         tool_call_parser: Some("hermes"),
     },
+    // Ternary Qwen 3.6-derived model. Its bundled template emits the Qwen
+    // XML tool format, which vllm-mlx exposes as `qwen3_xml`; it is not
+    // compatible with the legacy Hermes parser used by the Qwen rotation.
+    // The 24GB floor leaves room for macOS and a useful KV cache; the model
+    // itself advertises a 262K context window.
+    ModelRate {
+        model_id: "prism-ml/Ternary-Bonsai-27B-mlx-2bit",
+        input_per_mtok: 1_000_000,
+        output_per_mtok: 1_000_000,
+        currency: "CC",
+        min_ram_gb: 24,
+        description: "Ternary Bonsai 27B — 262K context; 24GB+ recommended",
+        recommended: false,
+        tool_call_parser: Some("qwen3_xml"),
+    },
     ModelRate {
         model_id: "mlx-community/Qwen3.6-27B-4bit",
         input_per_mtok: 1_000_000,


### PR DESCRIPTION
## Summary
- add `prism-ml/Ternary-Bonsai-27B-mlx-2bit` to the provider catalog with its 24 GB RAM floor
- pair its Qwen XML chat template with vLLM-MLX `qwen3_xml` tool parsing
- add the console RAM-floor warning and provider config coverage

## Validation
- `cargo fmt --check`
- `cargo test pricing --lib`
- `cargo test for_model_restricts_to_curated_top_models --lib`
- direct vLLM-MLX forced-tool canary returned `report_status({"status":"ok"})` with `finish_reason: "tool_calls"`

The model remains outside the recommended rotation; this enables owner-selected deployment and only advertises tool support after Cocore's existing forced-tool startup canary passes.