### PR TITLE
Add native LFM tool-call parser

### DIFF
--- a/provider/python/cocore_inference_server.py
+++ b/provider/python/cocore_inference_server.py
@@ -99,6 +99,7 @@ import vllm_mlx.server as srv  # noqa: E402
 # bundled parser registers it with the same ToolParserManager used by the
 # server before request handling starts.
 import cocore_lfm_tool_parser as _lfm_tool_parser  # noqa: E402,F401
+_lfm_tool_parser.LFMToolParser.register_streaming_markers(srv)
 
 
 def _unlink_if_owned(socket_path: Path, owned_ino: "int | None") -> None:

--- a/provider/python/cocore_inference_server.py
+++ b/provider/python/cocore_inference_server.py
@@ -95,6 +95,10 @@ except Exception:
 
 import uvicorn  # noqa: E402  (after logging config — intentional)
 import vllm_mlx.server as srv  # noqa: E402
+# LFM is not present in every installed vllm-mlx release. Importing the
+# bundled parser registers it with the same ToolParserManager used by the
+# server before request handling starts.
+import cocore_lfm_tool_parser as _lfm_tool_parser  # noqa: E402,F401
 
 
 def _unlink_if_owned(socket_path: Path, owned_ino: "int | None") -> None:
@@ -356,7 +360,7 @@ def main() -> None:
             _known_parsers = {
                 "auto", "hermes", "nous", "mistral", "qwen", "qwen3_xml",
                 "llama", "deepseek", "kimi", "granite", "harmony", "nemotron",
-                "xlam", "functionary", "glm47", "gemma4", "minimax",
+                "xlam", "functionary", "glm47", "gemma4", "minimax", "lfm",
             }
             _parser = srv._tool_call_parser
             if _parser not in _known_parsers:

--- a/provider/python/cocore_lfm_tool_parser.py
+++ b/provider/python/cocore_lfm_tool_parser.py
@@ -31,6 +31,10 @@ _START = "<|tool_call_start|>"
 _END = "<|tool_call_end|>"
 _BLOCK_RE = re.compile(re.escape(_START) + r"(.*?)" + re.escape(_END), re.DOTALL)
 _START_PREFIXES = tuple(_START[:index] for index in range(2, len(_START)))
+_THINK_MARKERS = ("<think>", "</think>")
+_THINK_PREFIXES = tuple(
+    marker[:index] for marker in _THINK_MARKERS for index in range(2, len(marker))
+)
 
 
 class LFMToolParser(ToolParser):
@@ -156,16 +160,27 @@ class LFMToolParser(ToolParser):
     def _clean_text(text: str) -> str | None:
         return text.strip() or None
 
+    @staticmethod
+    def _strip_streaming_think_tags(text: str) -> str:
+        """Remove complete think tags and withhold an incomplete tag suffix."""
+        for marker in _THINK_MARKERS:
+            text = text.replace(marker, "")
+        for prefix in sorted(_THINK_PREFIXES, key=len, reverse=True):
+            if text.endswith(prefix):
+                return text[: -len(prefix)]
+        return text
+
     @classmethod
     def _stream_visible_text(cls, text: str, request: dict[str, Any] | None) -> str:
         """Return text that is safe to emit while a response is still streaming."""
+        del request
         pieces: list[str] = []
         cursor = 0
         for match in _BLOCK_RE.finditer(text):
-            block_calls = cls._parse_block(match.group(1), request)
+            # Tool markers delimit protocol control output, not assistant text.
+            # Drop every completed block, including malformed or unapproved ones:
+            # parsing failures must not become rendered Pythonic-call syntax.
             pieces.append(text[cursor : match.start()])
-            if not block_calls:
-                pieces.append(text[match.start() : match.end()])
             cursor = match.end()
 
         trailing = text[cursor:]
@@ -178,7 +193,7 @@ class LFMToolParser(ToolParser):
             if incomplete_start >= 0:
                 trailing = trailing[:incomplete_start]
         pieces.append(trailing)
-        return "".join(pieces)
+        return cls._strip_streaming_think_tags("".join(pieces))
 
     def extract_tool_calls(
         self, model_output: str, request: dict[str, Any] | None = None
@@ -240,7 +255,7 @@ class LFMToolParser(ToolParser):
         if current_visible.startswith(previous_visible):
             visible_delta = current_visible[len(previous_visible) :]
         elif not (_START in delta_text or _END in delta_text):
-            visible_delta = delta_text
+            visible_delta = self._strip_streaming_think_tags(delta_text)
         else:
             visible_delta = ""
 

--- a/provider/python/cocore_lfm_tool_parser.py
+++ b/provider/python/cocore_lfm_tool_parser.py
@@ -91,7 +91,7 @@ class LFMToolParser(ToolParser):
     def _parse_block(cls, block: str, request: dict[str, Any] | None) -> list[dict[str, str]]:
         try:
             expression = ast.parse(block.strip(), mode="eval").body
-        except (SyntaxError, ValueError):
+        except (SyntaxError, ValueError, RecursionError):
             return []
         if not isinstance(expression, ast.List):
             return []
@@ -107,16 +107,20 @@ class LFMToolParser(ToolParser):
         calls: list[dict[str, str]] = []
         for item in expression.elts:
             if not isinstance(item, ast.Call) or not isinstance(item.func, ast.Name):
-                continue
+                return []
             name = item.func.id
             if not name.isidentifier() or keyword.iskeyword(name):
-                continue
+                return []
             if allowed_names is not None and name not in allowed_names:
-                continue
+                return []
             if item.args or any(argument.arg is None for argument in item.keywords):
                 # The wire format has named function arguments. Rejecting
                 # positional args avoids inventing parameter names.
-                continue
+                return []
+            argument_names = [argument.arg for argument in item.keywords]
+            if len(argument_names) != len(set(argument_names)):
+                # Duplicate keyword names have ambiguous wire semantics.
+                return []
             try:
                 arguments = {
                     argument.arg: cls._literal(argument.value)
@@ -129,8 +133,8 @@ class LFMToolParser(ToolParser):
                     separators=(",", ":"),
                     allow_nan=False,
                 )
-            except (TypeError, ValueError, OverflowError):
-                continue
+            except (TypeError, ValueError, OverflowError, RecursionError):
+                return []
             calls.append(
                 {
                     "id": f"call_{uuid.uuid4().hex}",

--- a/provider/python/cocore_lfm_tool_parser.py
+++ b/provider/python/cocore_lfm_tool_parser.py
@@ -30,6 +30,7 @@ from vllm_mlx.tool_parsers.abstract_tool_parser import (
 _START = "<|tool_call_start|>"
 _END = "<|tool_call_end|>"
 _BLOCK_RE = re.compile(re.escape(_START) + r"(.*?)" + re.escape(_END), re.DOTALL)
+_START_PREFIXES = tuple(_START[:index] for index in range(2, len(_START)))
 
 
 class LFMToolParser(ToolParser):
@@ -37,6 +38,13 @@ class LFMToolParser(ToolParser):
 
     # LFM's chat template handles role=tool messages and assistant tool_calls.
     SUPPORTS_NATIVE_TOOL_FORMAT = True
+
+    @staticmethod
+    def register_streaming_markers(server_module: Any) -> None:
+        """Teach vllm-mlx's streaming fast path about LFM marker prefixes."""
+        existing = tuple(getattr(server_module, "_STREAMING_TOOL_MARKERS", ()))
+        markers = (*existing, *_START_PREFIXES, _START, _END)
+        server_module._STREAMING_TOOL_MARKERS = tuple(dict.fromkeys(markers))
 
     @staticmethod
     def _literal(node: ast.AST) -> Any:
@@ -148,6 +156,30 @@ class LFMToolParser(ToolParser):
     def _clean_text(text: str) -> str | None:
         return text.strip() or None
 
+    @classmethod
+    def _stream_visible_text(cls, text: str, request: dict[str, Any] | None) -> str:
+        """Return text that is safe to emit while a response is still streaming."""
+        pieces: list[str] = []
+        cursor = 0
+        for match in _BLOCK_RE.finditer(text):
+            block_calls = cls._parse_block(match.group(1), request)
+            pieces.append(text[cursor : match.start()])
+            if not block_calls:
+                pieces.append(text[match.start() : match.end()])
+            cursor = match.end()
+
+        trailing = text[cursor:]
+        for prefix in reversed(_START_PREFIXES):
+            if trailing.endswith(prefix):
+                trailing = trailing[: -len(prefix)]
+                break
+        else:
+            incomplete_start = trailing.find(_START)
+            if incomplete_start >= 0:
+                trailing = trailing[:incomplete_start]
+        pieces.append(trailing)
+        return "".join(pieces)
+
     def extract_tool_calls(
         self, model_output: str, request: dict[str, Any] | None = None
     ) -> ExtractedToolCallInformation:
@@ -203,35 +235,21 @@ class LFMToolParser(ToolParser):
     ) -> dict[str, Any] | None:
         del previous_token_ids, current_token_ids, delta_token_ids
 
-        start = current_text.find(_START)
-        if start < 0:
-            return {"content": delta_text}
-
-        # A tokenizer chunk can contain ordinary text immediately before the
-        # marker or immediately after the closing marker. Keep those visible
-        # fragments while suppressing the control syntax and incomplete call.
-        prefix = ""
-        if start >= len(previous_text):
-            prefix = current_text[len(previous_text) : start]
-
-        def visible_suffix() -> str:
-            end = current_text.rfind(_END)
-            if end < 0 or current_text.count(_END) <= previous_text.count(_END):
-                return ""
-            return current_text[end + len(_END) :]
-
-        def visible_content() -> str:
-            return prefix + visible_suffix()
+        previous_visible = self._stream_visible_text(previous_text, request)
+        current_visible = self._stream_visible_text(current_text, request)
+        if current_visible.startswith(previous_visible):
+            visible_delta = current_visible[len(previous_visible) :]
+        elif not (_START in delta_text or _END in delta_text):
+            visible_delta = delta_text
+        else:
+            visible_delta = ""
 
         previous_end_count = previous_text.count(_END)
         current_end_count = current_text.count(_END)
         if current_end_count <= previous_end_count:
             # Do not stream the control marker or an incomplete Python list as
             # assistant content. The completed block is emitted below.
-            if current_text.count(_START) > current_end_count:
-                content = visible_content()
-                return {"content": content} if content else None
-            return {"content": delta_text}
+            return {"content": visible_delta} if visible_delta else None
 
         result = self.extract_tool_calls(current_text, request)
         # A single completed block may contain multiple calls, and a malformed
@@ -240,13 +258,11 @@ class LFMToolParser(ToolParser):
         emitted_count = len(self.prev_tool_call_arr)
         new_calls = result.tool_calls[emitted_count:]
         if not new_calls:
-            content = visible_content()
-            return {"content": content} if content else {"content": delta_text}
+            return {"content": visible_delta} if visible_delta else None
         self.prev_tool_call_arr = result.tool_calls
         response = self._format_streaming_tool_calls(new_calls, emitted_count)
-        content = visible_content()
-        if content:
-            response["content"] = content
+        if visible_delta:
+            response["content"] = visible_delta
         return response
 
 

--- a/provider/python/cocore_lfm_tool_parser.py
+++ b/provider/python/cocore_lfm_tool_parser.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Tool-call parser for Liquid AI LFM models.
+
+LFM2.5 emits Pythonic calls inside a single list::
+
+    <|tool_call_start|>[get_weather(city='Rotterdam', units='metric')]<|tool_call_end|>
+
+This parser is bundled with Cocore because the format is specific to LFM and
+may not be available in the installed vllm-mlx release. Values are decoded
+with a deliberately small, safe AST interpreter; model output is never
+executed.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import keyword
+import re
+import uuid
+from collections.abc import Sequence
+from typing import Any
+
+from vllm_mlx.tool_parsers.abstract_tool_parser import (
+    ExtractedToolCallInformation,
+    ToolParser,
+    ToolParserManager,
+)
+
+_START = "<|tool_call_start|>"
+_END = "<|tool_call_end|>"
+_BLOCK_RE = re.compile(re.escape(_START) + r"(.*?)" + re.escape(_END), re.DOTALL)
+
+
+class LFMToolParser(ToolParser):
+    """Parse LFM's ``[function(keyword=value), ...]`` tool-call format."""
+
+    # LFM's chat template handles role=tool messages and assistant tool_calls.
+    SUPPORTS_NATIVE_TOOL_FORMAT = True
+
+    @staticmethod
+    def _literal(node: ast.AST) -> Any:
+        """Decode the supported literal subset without evaluating code."""
+        if isinstance(node, ast.Constant):
+            if node.value is None or isinstance(node.value, (str, int, float, bool)):
+                return node.value
+            raise ValueError("unsupported constant")
+
+        # LFM documentation/examples use Python's None/True/False, while some
+        # checkpoints also emit JSON spellings. Accept both explicitly.
+        if isinstance(node, ast.Name) and node.id in {
+            "None",
+            "True",
+            "False",
+            "null",
+            "true",
+            "false",
+        }:
+            return {
+                "None": None,
+                "null": None,
+                "True": True,
+                "true": True,
+                "False": False,
+                "false": False,
+            }[node.id]
+
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.USub, ast.UAdd)):
+            value = LFMToolParser._literal(node.operand)
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                return -value if isinstance(node.op, ast.USub) else value
+            raise ValueError("unary operators are only allowed on numbers")
+
+        if isinstance(node, (ast.List, ast.Tuple)):
+            return [LFMToolParser._literal(element) for element in node.elts]
+
+        if isinstance(node, ast.Dict):
+            result: dict[str, Any] = {}
+            for key_node, value_node in zip(node.keys, node.values):
+                if key_node is None:
+                    raise ValueError("dictionary unpacking is not supported")
+                key = LFMToolParser._literal(key_node)
+                if not isinstance(key, str):
+                    raise ValueError("tool argument object keys must be strings")
+                result[key] = LFMToolParser._literal(value_node)
+            return result
+
+        raise ValueError(f"unsupported AST node: {type(node).__name__}")
+
+    @classmethod
+    def _parse_block(cls, block: str, request: dict[str, Any] | None) -> list[dict[str, str]]:
+        try:
+            expression = ast.parse(block.strip(), mode="eval").body
+        except (SyntaxError, ValueError):
+            return []
+        if not isinstance(expression, ast.List):
+            return []
+
+        allowed_names: set[str] | None = None
+        if request and isinstance(request.get("tools"), list):
+            allowed_names = {
+                tool.get("function", {}).get("name", "")
+                for tool in request["tools"]
+                if isinstance(tool, dict) and isinstance(tool.get("function"), dict)
+            }
+
+        calls: list[dict[str, str]] = []
+        for item in expression.elts:
+            if not isinstance(item, ast.Call) or not isinstance(item.func, ast.Name):
+                continue
+            name = item.func.id
+            if not name.isidentifier() or keyword.iskeyword(name):
+                continue
+            if allowed_names is not None and name not in allowed_names:
+                continue
+            if item.args or any(argument.arg is None for argument in item.keywords):
+                # The wire format has named function arguments. Rejecting
+                # positional args avoids inventing parameter names.
+                continue
+            try:
+                arguments = {
+                    argument.arg: cls._literal(argument.value)
+                    for argument in item.keywords
+                    if argument.arg is not None
+                }
+                arguments_json = json.dumps(
+                    arguments,
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                    allow_nan=False,
+                )
+            except (TypeError, ValueError, OverflowError):
+                continue
+            calls.append(
+                {
+                    "id": f"call_{uuid.uuid4().hex}",
+                    "name": name,
+                    "arguments": arguments_json,
+                }
+            )
+        return calls
+
+    @staticmethod
+    def _clean_text(text: str) -> str | None:
+        return text.strip() or None
+
+    def extract_tool_calls(
+        self, model_output: str, request: dict[str, Any] | None = None
+    ) -> ExtractedToolCallInformation:
+        cleaned = self.strip_think_tags(model_output)
+        calls: list[dict[str, str]] = []
+        pieces: list[str] = []
+        cursor = 0
+        for match in _BLOCK_RE.finditer(cleaned):
+            block_calls = self._parse_block(match.group(1), request)
+            if block_calls:
+                calls.extend(block_calls)
+                pieces.append(cleaned[cursor : match.start()])
+                cursor = match.end()
+            else:
+                # Preserve malformed/unsupported model output rather than
+                # silently deleting text or fabricating a call.
+                pieces.append(cleaned[cursor : match.end()])
+                cursor = match.end()
+        pieces.append(cleaned[cursor:])
+        content = self._clean_text("".join(pieces))
+        return ExtractedToolCallInformation(
+            tools_called=bool(calls),
+            tool_calls=calls,
+            content=content,
+        )
+
+    @staticmethod
+    def _format_streaming_tool_calls(calls: list[dict[str, str]], start_index: int) -> dict[str, Any]:
+        return {
+            "tool_calls": [
+                {
+                    "index": start_index + index,
+                    "id": call["id"],
+                    "type": "function",
+                    "function": {
+                        "name": call["name"],
+                        "arguments": call["arguments"],
+                    },
+                }
+                for index, call in enumerate(calls)
+            ]
+        }
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int] | None = None,
+        current_token_ids: Sequence[int] | None = None,
+        delta_token_ids: Sequence[int] | None = None,
+        request: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        del previous_token_ids, current_token_ids, delta_token_ids
+
+        start = current_text.find(_START)
+        if start < 0:
+            return {"content": delta_text}
+
+        # A tokenizer chunk can contain ordinary text immediately before the
+        # marker or immediately after the closing marker. Keep those visible
+        # fragments while suppressing the control syntax and incomplete call.
+        prefix = ""
+        if start >= len(previous_text):
+            prefix = current_text[len(previous_text) : start]
+
+        def visible_suffix() -> str:
+            end = current_text.rfind(_END)
+            if end < 0 or current_text.count(_END) <= previous_text.count(_END):
+                return ""
+            return current_text[end + len(_END) :]
+
+        def visible_content() -> str:
+            return prefix + visible_suffix()
+
+        previous_end_count = previous_text.count(_END)
+        current_end_count = current_text.count(_END)
+        if current_end_count <= previous_end_count:
+            # Do not stream the control marker or an incomplete Python list as
+            # assistant content. The completed block is emitted below.
+            if current_text.count(_START) > current_end_count:
+                content = visible_content()
+                return {"content": content} if content else None
+            return {"content": delta_text}
+
+        result = self.extract_tool_calls(current_text, request)
+        # A single completed block may contain multiple calls, and a malformed
+        # block may contain none. Track calls actually emitted rather than
+        # assuming one call per closing marker.
+        emitted_count = len(self.prev_tool_call_arr)
+        new_calls = result.tool_calls[emitted_count:]
+        if not new_calls:
+            content = visible_content()
+            return {"content": content} if content else {"content": delta_text}
+        self.prev_tool_call_arr = result.tool_calls
+        response = self._format_streaming_tool_calls(new_calls, emitted_count)
+        content = visible_content()
+        if content:
+            response["content"] = content
+        return response
+
+
+# Registration is intentionally performed at import time. The Cocore wrapper
+# imports this module before vllm-mlx handles any chat-completion request.
+ToolParserManager.register_module("lfm", LFMToolParser)
+
+
+__all__ = ["LFMToolParser"]

--- a/provider/python/test_cocore_lfm_tool_parser.py
+++ b/provider/python/test_cocore_lfm_tool_parser.py
@@ -130,6 +130,47 @@ class LFMToolParserTests(unittest.TestCase):
         self.assertEqual(emitted["content"], "before  after")
         self.assertEqual(emitted["tool_calls"][0]["function"]["name"], "search")
 
+    def test_streaming_preserves_reasoning_text_without_think_or_tool_tags(self) -> None:
+        parser = LFMToolParser()
+        current = (
+            "I should search first.</think>"
+            "<|tool_call_start|>[search(query='LFM streaming')]<|tool_call_end|>"
+        )
+        emitted = parser.extract_tool_calls_streaming("", current, current, request=TOOLS)
+        self.assertIsNotNone(emitted)
+        assert emitted is not None
+        self.assertEqual(emitted["content"], "I should search first.")
+        self.assertNotIn("think", emitted["content"])
+        self.assertNotIn("tool_call", emitted["content"])
+        self.assertEqual(emitted["tool_calls"][0]["function"]["name"], "search")
+
+    def test_streaming_withholds_split_think_close_until_it_can_be_removed(self) -> None:
+        parser = LFMToolParser()
+        partial = "I should search first.</thi"
+        self.assertEqual(
+            parser.extract_tool_calls_streaming("", partial, partial, request=TOOLS),
+            {"content": "I should search first."},
+        )
+
+        complete = (
+            partial
+            + "nk><|tool_call_start|>[search(query='LFM streaming')]<|tool_call_end|>"
+        )
+        emitted = parser.extract_tool_calls_streaming(
+            partial, complete, complete[len(partial) :], request=TOOLS
+        )
+        self.assertIsNotNone(emitted)
+        assert emitted is not None
+        self.assertNotIn("content", emitted)
+        self.assertEqual(emitted["tool_calls"][0]["function"]["name"], "search")
+
+    def test_streaming_sanitizes_think_tags_in_nonprefix_fallback_delta(self) -> None:
+        parser = LFMToolParser()
+        emitted = parser.extract_tool_calls_streaming(
+            "earlier text", "replacement text", "new reasoning</think>", request=TOOLS
+        )
+        self.assertEqual(emitted, {"content": "new reasoning"})
+
     def test_streaming_emits_all_calls_in_one_block(self) -> None:
         parser = LFMToolParser()
         previous = "<|tool_call_start|>["
@@ -157,13 +198,13 @@ class LFMToolParserTests(unittest.TestCase):
         self.assertEqual(second_result["content"], "after")  # type: ignore[index]
         self.assertEqual(second_result["tool_calls"][0]["index"], 1)  # type: ignore[index]
 
-    def test_streaming_preserves_completed_malformed_block(self) -> None:
+    def test_streaming_suppresses_completed_malformed_block(self) -> None:
         parser = LFMToolParser()
         incomplete = "before <|tool_call_start|>[delete_everything()]"
         parser.extract_tool_calls_streaming("", incomplete, incomplete, request=TOOLS)
         complete = incomplete + "<|tool_call_end|>after"
         emitted = parser.extract_tool_calls_streaming(incomplete, complete, complete[len(incomplete) :], request=TOOLS)
-        self.assertEqual(emitted, {"content": "<|tool_call_start|>[delete_everything()]<|tool_call_end|>after"})
+        self.assertEqual(emitted, {"content": "after"})
 
 
 if __name__ == "__main__":

--- a/provider/python/test_cocore_lfm_tool_parser.py
+++ b/provider/python/test_cocore_lfm_tool_parser.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Deterministic tests for Cocore's LFM tool parser."""
+
+from __future__ import annotations
+
+import json
+import unittest
+
+from cocore_lfm_tool_parser import LFMToolParser
+from vllm_mlx.tool_parsers import ToolParserManager
+
+
+TOOLS = {
+    "tools": [
+        {"type": "function", "function": {"name": "get_weather"}},
+        {"type": "function", "function": {"name": "search"}},
+    ]
+}
+
+
+class LFMToolParserTests(unittest.TestCase):
+    def test_registers_with_vllm_parser_manager(self) -> None:
+        self.assertIs(ToolParserManager.get_tool_parser("lfm"), LFMToolParser)
+
+    def test_extracts_single_call_and_preserves_prefix(self) -> None:
+        result = LFMToolParser().extract_tool_calls(
+            "I will check. <|tool_call_start|>[get_weather(city='Rotterdam')]<|tool_call_end|>",
+            TOOLS,
+        )
+        self.assertTrue(result.tools_called)
+        self.assertEqual(result.content, "I will check.")
+        self.assertEqual(result.tool_calls[0]["name"], "get_weather")
+        self.assertTrue(result.tool_calls[0]["id"].startswith("call_"))
+        self.assertEqual(json.loads(result.tool_calls[0]["arguments"]), {"city": "Rotterdam"})
+
+    def test_handles_multiple_calls_and_nested_literals(self) -> None:
+        result = LFMToolParser().extract_tool_calls(
+            "<|tool_call_start|>[search(query='a,b [c]', filters={'lang': 'nl', 'k': [1, True, None]}), get_weather(city='Tokyo')]<|tool_call_end|>",
+            TOOLS,
+        )
+        self.assertEqual([call["name"] for call in result.tool_calls], ["search", "get_weather"])
+        self.assertEqual(
+            json.loads(result.tool_calls[0]["arguments"]),
+            {"query": "a,b [c]", "filters": {"lang": "nl", "k": [1, True, None]}},
+        )
+
+    def test_accepts_json_literal_spellings(self) -> None:
+        result = LFMToolParser().extract_tool_calls(
+            "<|tool_call_start|>[search(enabled=true, missing=null, ratio=-1.5)]<|tool_call_end|>",
+            TOOLS,
+        )
+        self.assertEqual(
+            json.loads(result.tool_calls[0]["arguments"]),
+            {"enabled": True, "missing": None, "ratio": -1.5},
+        )
+
+    def test_rejects_unsafe_or_unknown_calls(self) -> None:
+        output = (
+            "<|tool_call_start|>[__import__('os').system('touch /tmp/pwned')]"
+            "<|tool_call_end|>"
+        )
+        result = LFMToolParser().extract_tool_calls(output, TOOLS)
+        self.assertFalse(result.tools_called)
+        self.assertEqual(result.tool_calls, [])
+        self.assertIn("tool_call_start", result.content)
+
+        unknown = LFMToolParser().extract_tool_calls(
+            "<|tool_call_start|>[delete_everything()]<|tool_call_end|>", TOOLS
+        )
+        self.assertFalse(unknown.tools_called)
+
+    def test_strips_thinking_tags(self) -> None:
+        result = LFMToolParser().extract_tool_calls(
+            "<think>private reasoning</think>answer <|tool_call_start|>[search(query='x')]<|tool_call_end|>",
+            TOOLS,
+        )
+        self.assertEqual(result.content, "answer")
+
+    def test_streaming_suppresses_incomplete_block_then_emits_calls(self) -> None:
+        parser = LFMToolParser()
+        incomplete = "I will check. <|tool_call_start|>[get_weather(city='Rotterdam')]"
+        suppressed = parser.extract_tool_calls_streaming("", incomplete, incomplete, request=TOOLS)
+        self.assertEqual(suppressed, {"content": "I will check. "})
+
+        complete = incomplete + "<|tool_call_end|>"
+        delta = "<|tool_call_end|>"
+        emitted = parser.extract_tool_calls_streaming(incomplete, complete, delta, request=TOOLS)
+        self.assertIsNotNone(emitted)
+        assert emitted is not None
+        self.assertEqual(emitted["tool_calls"][0]["function"]["name"], "get_weather")
+        self.assertEqual(emitted["tool_calls"][0]["index"], 0)
+
+    def test_streaming_preserves_text_adjacent_to_control_block(self) -> None:
+        parser = LFMToolParser()
+        current = (
+            "before <|tool_call_start|>[search(query='x')]<|tool_call_end|> after"
+        )
+        emitted = parser.extract_tool_calls_streaming("", current, current, request=TOOLS)
+        self.assertIsNotNone(emitted)
+        assert emitted is not None
+        self.assertEqual(emitted["content"], "before  after")
+        self.assertEqual(emitted["tool_calls"][0]["function"]["name"], "search")
+
+    def test_streaming_emits_all_calls_in_one_block(self) -> None:
+        parser = LFMToolParser()
+        previous = "<|tool_call_start|>["
+        current = previous + "search(query='x'), get_weather(city='Tokyo')]<|tool_call_end|>"
+        emitted = parser.extract_tool_calls_streaming(previous, current, current[len(previous):], request=TOOLS)
+        self.assertIsNotNone(emitted)
+        assert emitted is not None
+        self.assertEqual([c["function"]["name"] for c in emitted["tool_calls"]], ["search", "get_weather"])
+        self.assertEqual([c["index"] for c in emitted["tool_calls"]], [0, 1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/provider/python/test_cocore_lfm_tool_parser.py
+++ b/provider/python/test_cocore_lfm_tool_parser.py
@@ -68,6 +68,26 @@ class LFMToolParserTests(unittest.TestCase):
             "<|tool_call_start|>[delete_everything()]<|tool_call_end|>", TOOLS
         )
         self.assertFalse(unknown.tools_called)
+        self.assertIn("delete_everything", unknown.content or "")
+
+        mixed = LFMToolParser().extract_tool_calls(
+            "<|tool_call_start|>[search(query='ok'), __import__('os').system('x')]<|tool_call_end|>",
+            TOOLS,
+        )
+        self.assertFalse(mixed.tools_called)
+        self.assertIn("__import__", mixed.content or "")
+
+        duplicate = LFMToolParser().extract_tool_calls(
+            "<|tool_call_start|>[search(query='first', query='second')]<|tool_call_end|>",
+            TOOLS,
+        )
+        self.assertFalse(duplicate.tools_called)
+        self.assertIn("query='first'", duplicate.content or "")
+
+        deep = "<|tool_call_start|>[search(filters=" + ("[" * 400) + "0" + ("]" * 400)
+        deep += ")]<|tool_call_end|>"
+        result = LFMToolParser().extract_tool_calls(deep, TOOLS)
+        self.assertFalse(result.tools_called)
 
     def test_strips_thinking_tags(self) -> None:
         result = LFMToolParser().extract_tool_calls(

--- a/provider/python/test_cocore_lfm_tool_parser.py
+++ b/provider/python/test_cocore_lfm_tool_parser.py
@@ -22,6 +22,15 @@ class LFMToolParserTests(unittest.TestCase):
     def test_registers_with_vllm_parser_manager(self) -> None:
         self.assertIs(ToolParserManager.get_tool_parser("lfm"), LFMToolParser)
 
+    def test_registers_lfm_marker_prefixes_with_streaming_gate(self) -> None:
+        class FakeServer:
+            _STREAMING_TOOL_MARKERS = ("<tool_call>",)
+
+        LFMToolParser.register_streaming_markers(FakeServer)
+        self.assertIn("<|tool_call_", FakeServer._STREAMING_TOOL_MARKERS)
+        self.assertIn("<|tool_call_start|>", FakeServer._STREAMING_TOOL_MARKERS)
+        self.assertIn("<|tool_call_end|>", FakeServer._STREAMING_TOOL_MARKERS)
+
     def test_extracts_single_call_and_preserves_prefix(self) -> None:
         result = LFMToolParser().extract_tool_calls(
             "I will check. <|tool_call_start|>[get_weather(city='Rotterdam')]<|tool_call_end|>",
@@ -130,6 +139,31 @@ class LFMToolParserTests(unittest.TestCase):
         assert emitted is not None
         self.assertEqual([c["function"]["name"] for c in emitted["tool_calls"]], ["search", "get_weather"])
         self.assertEqual([c["index"] for c in emitted["tool_calls"]], [0, 1])
+
+    def test_streaming_handles_split_markers_and_multiple_blocks(self) -> None:
+        parser = LFMToolParser()
+        partial = "before <|tool_call_"
+        self.assertEqual(
+            parser.extract_tool_calls_streaming("", partial, partial, request=TOOLS),
+            {"content": "before "},
+        )
+
+        first = partial + "start|>[search(query='x')]<|tool_call_end|>middle "
+        first_result = parser.extract_tool_calls_streaming(partial, first, first[len(partial) :], request=TOOLS)
+        self.assertEqual(first_result["content"], "middle ")  # type: ignore[index]
+
+        second = first + "<|tool_call_start|>[get_weather(city='Tokyo')]<|tool_call_end|>after"
+        second_result = parser.extract_tool_calls_streaming(first, second, second[len(first) :], request=TOOLS)
+        self.assertEqual(second_result["content"], "after")  # type: ignore[index]
+        self.assertEqual(second_result["tool_calls"][0]["index"], 1)  # type: ignore[index]
+
+    def test_streaming_preserves_completed_malformed_block(self) -> None:
+        parser = LFMToolParser()
+        incomplete = "before <|tool_call_start|>[delete_everything()]"
+        parser.extract_tool_calls_streaming("", incomplete, incomplete, request=TOOLS)
+        complete = incomplete + "<|tool_call_end|>after"
+        emitted = parser.extract_tool_calls_streaming(incomplete, complete, complete[len(incomplete) :], request=TOOLS)
+        self.assertEqual(emitted, {"content": "<|tool_call_start|>[delete_everything()]<|tool_call_end|>after"})
 
 
 if __name__ == "__main__":

--- a/provider/src/engines/mod.rs
+++ b/provider/src/engines/mod.rs
@@ -433,14 +433,14 @@ const THINK_CLOSE: &str = "</think>";
 
 /// Heuristic: does this model's chat template prefill the opening `<think>`, so
 /// generation begins inside the reasoning block and the stream carries only the
-/// closing `</think>`? True for the Qwen3-*-Thinking-2507 family and similarly
-/// named dedicated thinking models. Drives whether the [`ThinkTagSplitter`]
+/// closing `</think>`? True for the Qwen3-*-Thinking-2507 family, LFM2.5, and
+/// similarly named dedicated thinking models. Drives whether the [`ThinkTagSplitter`]
 /// starts in reasoning mode ([`ThinkTagSplitter::new_in_reasoning`]). Unlabelled
 /// thinking models can be opted in via `COCORE_THINKING_PREFILL_MODELS` (a
 /// comma-separated list of substrings matched case-insensitively against the id).
 pub fn model_prefills_think(model: &str) -> bool {
     let m = model.to_ascii_lowercase();
-    if m.contains("thinking") {
+    if m.contains("thinking") || m.contains("lfm2.5") {
         return true;
     }
     std::env::var("COCORE_THINKING_PREFILL_MODELS")
@@ -897,6 +897,7 @@ mod tests {
         assert!(model_prefills_think(
             "lmstudio-community/Qwen3-4B-Thinking-2507-MLX-4bit"
         ));
+        assert!(model_prefills_think("LiquidAI/LFM2.5-2.6B-MLX-4bit"));
         assert!(!model_prefills_think(
             "mlx-community/Qwen2.5-3B-Instruct-4bit"
         ));

--- a/provider/src/engines/subprocess.rs
+++ b/provider/src/engines/subprocess.rs
@@ -344,6 +344,9 @@ fn ready_stall_timeout() -> Duration {
 /// agent ships as a single static binary, no separate file to install
 /// alongside it.
 const WRAPPER_SCRIPT: &str = include_str!("../../python/cocore_inference_server.py");
+/// Embedded LFM parser module. The wrapper imports this alongside the
+/// embedded script, so packaged providers do not depend on a source checkout.
+const LFM_PARSER_SCRIPT: &str = include_str!("../../python/cocore_lfm_tool_parser.py");
 
 /// Where on disk we write the wrapper + sockets. Lives under
 /// `~/.cocore/` next to the venv so a `rm -rf ~/.cocore` cleans
@@ -627,6 +630,22 @@ impl SubprocessEngine {
         Ok(path)
     }
 
+    /// Write the embedded LFM parser next to the wrapper. Python puts the
+    /// script directory on `sys.path`, so the wrapper can import this module
+    /// in both source checkouts and installed single-binary providers.
+    fn ensure_lfm_parser_on_disk() -> Result<PathBuf> {
+        let path = state_dir()?.join("cocore_lfm_tool_parser.py");
+        let needs_write = !matches!(
+            std::fs::read_to_string(&path),
+            Ok(existing) if existing == LFM_PARSER_SCRIPT
+        );
+        if needs_write {
+            std::fs::write(&path, LFM_PARSER_SCRIPT)
+                .with_context(|| format!("writing LFM parser to {}", path.display()))?;
+        }
+        Ok(path)
+    }
+
     /// Remove orphaned engine sockets under `sockets_dir` that no
     /// longer have a listener.
     ///
@@ -722,6 +741,7 @@ impl SubprocessEngine {
         let _ = std::fs::remove_file(&self.socket_path);
 
         let wrapper = Self::ensure_wrapper_on_disk().context("writing embedded wrapper to disk")?;
+        Self::ensure_lfm_parser_on_disk().context("writing embedded LFM parser to disk")?;
 
         if !self.venv_python.exists() {
             bail!(
@@ -1816,6 +1836,13 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(cfg.parser_label(), "hermes");
+    }
+
+    #[test]
+    fn packaged_wrapper_embeds_lfm_parser_registration() {
+        assert!(WRAPPER_SCRIPT.contains("cocore_lfm_tool_parser"));
+        assert!(LFM_PARSER_SCRIPT.contains("ToolParserManager.register_module(\"lfm\""));
+        assert!(LFM_PARSER_SCRIPT.contains("<|tool_call_start|>"));
     }
 
     #[test]

--- a/provider/src/engines/subprocess.rs
+++ b/provider/src/engines/subprocess.rs
@@ -1841,6 +1841,7 @@ mod tests {
     #[test]
     fn packaged_wrapper_embeds_lfm_parser_registration() {
         assert!(WRAPPER_SCRIPT.contains("cocore_lfm_tool_parser"));
+        assert!(WRAPPER_SCRIPT.contains("register_streaming_markers"));
         assert!(LFM_PARSER_SCRIPT.contains("ToolParserManager.register_module(\"lfm\""));
         assert!(LFM_PARSER_SCRIPT.contains("<|tool_call_start|>"));
     }

--- a/provider/src/pricing.rs
+++ b/provider/src/pricing.rs
@@ -225,6 +225,40 @@ pub const RATES: &[ModelRate] = &[
         recommended: true,
         tool_call_parser: Some("hermes"),
     },
+    // Liquid AI LFM2.5 uses a Pythonic list-of-calls format that is handled by
+    // Cocore's bundled `lfm` parser. Keep the quantized variants separate so
+    // their RAM floors remain honest and unsupported future checkpoints do not
+    // silently inherit a parser pairing.
+    ModelRate {
+        model_id: "LiquidAI/LFM2.5-2.6B-MLX-4bit",
+        input_per_mtok: 1_000_000,
+        output_per_mtok: 1_000_000,
+        currency: "CC",
+        min_ram_gb: 8,
+        description: "LFM2.5 2.6B 4-bit — compact 131K-context model",
+        recommended: false,
+        tool_call_parser: Some("lfm"),
+    },
+    ModelRate {
+        model_id: "LiquidAI/LFM2.5-2.6B-MLX-8bit",
+        input_per_mtok: 1_000_000,
+        output_per_mtok: 1_000_000,
+        currency: "CC",
+        min_ram_gb: 12,
+        description: "LFM2.5 2.6B 8-bit — 131K context; 12GB+",
+        recommended: false,
+        tool_call_parser: Some("lfm"),
+    },
+    ModelRate {
+        model_id: "LiquidAI/LFM2.5-2.6B-MLX-bf16",
+        input_per_mtok: 1_000_000,
+        output_per_mtok: 1_000_000,
+        currency: "CC",
+        min_ram_gb: 16,
+        description: "LFM2.5 2.6B BF16 — 131K context; 16GB+",
+        recommended: false,
+        tool_call_parser: Some("lfm"),
+    },
     // ---- Legacy catalog (still servable; not recommended) -------------
     // Kept so a machine that already pinned one of these keeps its RAM
     // floor + price entry. The Secure Mode dialog nudges providers off
@@ -718,6 +752,18 @@ mod tests {
         assert!(!rec.contains(&"mlx-community/Qwen3.6-35B-A3B-4bit-DWQ"));
         // Unknown ids still resolve to "no vetted pairing".
         assert_eq!(tool_call_parser("custom/whatever-4bit"), None);
+    }
+
+    #[test]
+    fn lfm25_variants_pair_with_lfm_parser() {
+        for model_id in [
+            "LiquidAI/LFM2.5-2.6B-MLX-4bit",
+            "LiquidAI/LFM2.5-2.6B-MLX-8bit",
+            "LiquidAI/LFM2.5-2.6B-MLX-bf16",
+        ] {
+            assert_eq!(tool_call_parser(model_id), Some("lfm"), "{model_id}");
+        }
+        assert_eq!(tool_call_parser("LiquidAI/LFM2.5-3B-MLX-bf16"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add a Cocore-owned `lfm` tool parser for Liquid AI LFM2.5's native Pythonic call format
- safely decode literals with a constrained AST interpreter; never execute model output
- embed and install the parser alongside Cocore's embedded inference wrapper so packaged providers work without a separate vllm-mlx update
- add LFM2.5 2.6B MLX 4-bit, 8-bit, and BF16 catalog entries with automatic `lfm` parser pairing
- cover non-streaming, streaming, malformed/unsafe output, nested literals, model pairing, and packaged-runtime registration with tests

## Format handled

```text
<|tool_call_start|>[get_weather(city='Rotterdam')]<|tool_call_end|>
```

The parser emits standard OpenAI-compatible `tool_calls` and preserves ordinary content around the control block. Tool-call advertisement remains gated by Cocore's existing startup canary.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --manifest-path provider/Cargo.toml` — 187 library tests, 61 binary tests, 5 integration tests passed; 1 live test ignored
- `PYTHONPATH=provider/python /Users/tijs/.cocore/python/bin/python -m unittest -v provider/python/test_cocore_lfm_tool_parser.py` — 9 passed
- `python3 -m py_compile ...` — passed
- `git diff --check` — passed
- packaged-runtime smoke test from a clean temporary directory — passed

Model IDs were verified against the Hugging Face model API.
