### PR TITLE
fix(console): don't let a mid-body AppView abort crash the whole site

### DIFF
--- a/packages/console/src/integrations/appview/appview.server.test.ts
+++ b/packages/console/src/integrations/appview/appview.server.test.ts
@@ -1,0 +1,129 @@
+// Regression coverage for the AppView read client's failure handling.
+//
+// The case that matters here is a body read that aborts *after* the response
+// headers arrive. `AbortSignal.timeout` fires on the whole exchange, so a slow
+// body leaves us holding a Response whose `text()` rejects with a DOMException
+// TimeoutError. That rejection used to escape the client entirely and kill the
+// console process (Node exits on an unhandled rejection), crash-looping
+// cocore.dev on 2026-08-11. It must surface as a transient AppviewFetchError
+// instead, so the retry + stale-cache fallback can absorb it.
+
+import { Effect } from "effect";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { AppviewClient, AppviewFetchError, appviewListProvidersEffect } from "./appview.server.ts";
+
+const BASE = "http://appview.internal";
+
+/** Run an AppView effect against a fresh client (fresh stale-cache). */
+function run<A, E>(effect: Effect.Effect<A, E, AppviewClient>) {
+  return Effect.runPromise(Effect.either(Effect.provide(effect, AppviewClient.Default)));
+}
+
+/** A Response whose headers are fine but whose body never finishes — exactly
+ *  what undici hands back when the abort lands mid-stream. */
+function bodyAbortsResponse(): Response {
+  return {
+    ok: true,
+    status: 200,
+    text: () =>
+      Promise.reject(new DOMException("The operation was aborted due to timeout", "TimeoutError")),
+  } as unknown as Response;
+}
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+let unhandled: unknown[] = [];
+const captureUnhandled = (reason: unknown) => unhandled.push(reason);
+
+beforeEach(() => {
+  process.env["COCORE_APPVIEW_URL"] = BASE;
+  unhandled = [];
+  process.on("unhandledRejection", captureUnhandled);
+});
+
+afterEach(() => {
+  process.off("unhandledRejection", captureUnhandled);
+  delete process.env["COCORE_APPVIEW_URL"];
+  vi.unstubAllGlobals();
+});
+
+describe("AppviewClient.get", () => {
+  test("a mid-body abort fails transiently instead of escaping as an unhandled rejection", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(() => Promise.resolve(bodyAbortsResponse())),
+    );
+
+    const result = await run(appviewListProvidersEffect);
+
+    expect(result._tag).toBe("Left");
+    if (result._tag !== "Left") return;
+    expect(result.left).toBeInstanceOf(AppviewFetchError);
+    // status 0 == transient, so `isTransient` retries and the stale cache applies.
+    expect(result.left.status).toBe(0);
+    expect(result.left.message).toContain("aborted due to timeout");
+    expect(result.left.message).toContain(`GET ${BASE}`);
+
+    // Let any escaped rejection reach the process handler before asserting.
+    await new Promise((r) => setImmediate(r));
+    expect(unhandled).toEqual([]);
+  });
+
+  test("a mid-body abort is retried, so a body that lands on a later attempt still succeeds", async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockImplementationOnce(() => Promise.resolve(bodyAbortsResponse()))
+      .mockImplementation(() => Promise.resolve(jsonResponse({ providers: [] })));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await run(appviewListProvidersEffect);
+
+    expect(result._tag).toBe("Right");
+    if (result._tag !== "Right") return;
+    expect(result.right).toEqual({ providers: [] });
+    expect(fetchSpy.mock.calls.length).toBeGreaterThan(1);
+    expect(unhandled).toEqual([]);
+  });
+
+  test("a connect-level failure still reports the undici cause code and the URL", async () => {
+    const err = Object.assign(new TypeError("fetch failed"), {
+      cause: { code: "ECONNREFUSED" },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(() => Promise.reject(err)),
+    );
+
+    const result = await run(appviewListProvidersEffect);
+
+    expect(result._tag).toBe("Left");
+    if (result._tag !== "Left") return;
+    expect(result.left.status).toBe(0);
+    expect(result.left.message).toContain("ECONNREFUSED");
+  });
+
+  test("a 4xx is a real answer, not transient — it is not retried", async () => {
+    const fetchSpy = vi.fn().mockImplementation(() =>
+      Promise.resolve({
+        ok: false,
+        status: 404,
+        text: () => Promise.resolve("not found"),
+      } as unknown as Response),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await run(appviewListProvidersEffect);
+
+    expect(result._tag).toBe("Left");
+    if (result._tag !== "Left") return;
+    expect(result.left.status).toBe(404);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/console/src/integrations/appview/appview.server.ts
+++ b/packages/console/src/integrations/appview/appview.server.ts
@@ -205,57 +205,82 @@ const appviewRetrySchedule = Schedule.intersect(
 
 const APPVIEW_STALE_MAX_MS = 10 * 60_000;
 
+/** Transport-level failure (no usable HTTP response, or a response whose body
+ *  never finished arriving). Undici hides the useful part ("fetch failed")
+ *  behind `cause`; surface the syscall code (ENOTFOUND, ECONNREFUSED,
+ *  ETIMEDOUT, …) and the target URL so a Railway private-networking outage is
+ *  diagnosable from the log line alone. `status: 0` marks it transient, so
+ *  `isTransient` retries it and the stale-cache fallback can absorb it. */
+function appviewTransportError(e: unknown, url: string): AppviewFetchError {
+  const message = e instanceof Error ? e.message : String(e);
+  const cause = (e as { cause?: { code?: string; message?: string } }).cause;
+  const detail = cause?.code ?? cause?.message;
+  return new AppviewFetchError({
+    status: 0,
+    message: `${message}${detail ? ` (${detail})` : ""} — GET ${url}`,
+  });
+}
+
 function appviewFetchOnceEffect<T>(url: string): Effect.Effect<T, AppviewFetchError> {
   return Effect.async((resume) => {
-    void fetch(url, {
-      headers: { accept: "application/json" },
-      signal: AbortSignal.timeout(APPVIEW_FETCH_TIMEOUT_MS),
-    }).then(
-      async (res) => {
-        const text = await res.text();
-        if (!res.ok) {
-          resume(
-            Effect.fail(
-              new AppviewFetchError({
-                status: res.status,
-                message: text.slice(0, 500) || `HTTP ${res.status}`,
-              }),
-            ),
-          );
-          return;
-        }
-        try {
-          resume(Effect.succeed(JSON.parse(text) as T));
-        } catch (e) {
-          resume(
-            Effect.fail(
-              new AppviewFetchError({
-                status: 500,
-                message: `invalid JSON from AppView: ${(e as Error).message}`,
-              }),
-            ),
-          );
-        }
-      },
-      (e: unknown) => {
-        // Network-level failure (no HTTP response). Undici hides the
-        // useful part ("fetch failed") behind `cause`; surface the
-        // syscall code (ENOTFOUND, ECONNREFUSED, ETIMEDOUT, …) and
-        // the target URL so a Railway private-networking outage is
-        // diagnosable from the log line alone.
-        const message = e instanceof Error ? e.message : String(e);
-        const cause = (e as { cause?: { code?: string; message?: string } }).cause;
-        const detail = cause?.code ?? cause?.message;
+    // Every await below is individually guarded, and the whole body runs
+    // inside one async function whose rejection can't escape.
+    //
+    // The body read is the subtle one. `AbortSignal.timeout` can fire AFTER
+    // the response headers arrive but BEFORE the body finishes streaming, so
+    // `res.text()` rejects with a DOMException TimeoutError. This used to be
+    // written as `.then(onFulfilled, onRejected)`, where the reject arm sees
+    // rejections of the *fetch* promise only — never a throw from inside the
+    // fulfilled handler. That rejection escaped unhandled and took the whole
+    // console process down (Node kills the process on an unhandled rejection),
+    // and `resume` was never called, so the fiber hung too.
+    void (async () => {
+      let res: Response;
+      try {
+        res = await fetch(url, {
+          headers: { accept: "application/json" },
+          signal: AbortSignal.timeout(APPVIEW_FETCH_TIMEOUT_MS),
+        });
+      } catch (e) {
+        resume(Effect.fail(appviewTransportError(e, url)));
+        return;
+      }
+
+      let text: string;
+      try {
+        text = await res.text();
+      } catch (e) {
+        // Aborted or truncated mid-body — we have headers but no usable
+        // payload. Same transient class as a failed connect.
+        resume(Effect.fail(appviewTransportError(e, url)));
+        return;
+      }
+
+      if (!res.ok) {
         resume(
           Effect.fail(
             new AppviewFetchError({
-              status: 0,
-              message: `${message}${detail ? ` (${detail})` : ""} — GET ${url}`,
+              status: res.status,
+              message: text.slice(0, 500) || `HTTP ${res.status}`,
             }),
           ),
         );
-      },
-    );
+        return;
+      }
+
+      try {
+        resume(Effect.succeed(JSON.parse(text) as T));
+      } catch (e) {
+        resume(
+          Effect.fail(
+            new AppviewFetchError({
+              status: 500,
+              message: `invalid JSON from AppView: ${(e as Error).message}`,
+            }),
+          ),
+        );
+      }
+    })();
   });
 }
 

--- a/packages/console/src/lib/o11y.server.ts
+++ b/packages/console/src/lib/o11y.server.ts
@@ -30,6 +30,36 @@ const runtime = makeRuntime(
   AppLayer,
 );
 
+// Don't let one stray promise take the site down. Node's default for an
+// unhandled rejection is to kill the process, so a single unguarded `await`
+// anywhere in the server — in our code or a dependency's — turns into a
+// site-wide outage plus a crash loop. The advisor and the services process
+// have had this guard since their first deploy (infra/advisor/src/main.ts,
+// infra/services/src/main.ts); the console never got one, and on 2026-08-11 a
+// mid-body fetch abort in appview.server.ts crash-looped cocore.dev for it.
+//
+// Log loudly and keep serving: a genuinely wedged process is caught by the
+// Railway healthcheck, and the console is a read-mostly cache over the PDS —
+// staying up degraded beats a restart loop that 500s every request in flight.
+// This module hosts it because it's server-only and every server I/O path
+// imports it, so the handler is installed once, early, without a custom entry.
+//
+// Registered under a symbol so a double module-eval (dev HMR, or the same
+// module loaded through two specifiers) doesn't stack duplicate listeners and
+// trip Node's MaxListenersExceededWarning.
+const GUARDS_INSTALLED = Symbol.for("cocore.console.processGuards");
+
+if (typeof process !== "undefined" && !(GUARDS_INSTALLED in globalThis)) {
+  Object.defineProperty(globalThis, GUARDS_INSTALLED, { value: true });
+  process.on("unhandledRejection", (reason) => {
+    const e = reason instanceof Error ? reason : new Error(String(reason));
+    console.error(`console: unhandledRejection — ${e.message}\n${e.stack ?? ""}`);
+  });
+  process.on("uncaughtException", (e) => {
+    console.error(`console: uncaughtException — ${e.message}\n${e.stack ?? ""}`);
+  });
+}
+
 /** Run a server-side effect wrapped in a root span named for the
  *  operation. Drop-in replacement for `Effect.runPromise(effect)`; the
  *  effect may require any service the runtime provides ({@link AppEnv}). */


### PR DESCRIPTION
## The outage

`cocore.dev` is crash-looping. The `Client` service dies every 20–90s with an unhandled rejection and no app frames:

```
node:internal/process/promises:394
    triggerUncaughtException(err, true /* fromPromise */);
DOMException [TimeoutError]: The operation was aborted due to timeout
    at new DOMException (node:internal/per_context/domexception:76:18)
    at Timeout._onTimeout (node:internal/abort_controller:155:9)
```

Every request in flight 500s until Railway restarts it. This also degrades the agent update path, since `agent.version`, `agent.dl`, and `agent.binary-hashes` all proxy GitHub through this service.

## Root cause

`appviewFetchOnceEffect` used `.then(onFulfilled, onRejected)`. The reject arm only handles rejections of the **fetch** promise — never a throw from inside the async fulfilled handler. `AbortSignal.timeout` covers the whole exchange, so when it fires *after* the headers arrive but *before* the body finishes streaming, `res.text()` rejects with a `DOMException TimeoutError`, that rejection escapes unhandled, and Node kills the process. `resume` was never called either, so the fiber hung as well.

Latent since 1b704c9 (the initial public release).

**Not** downstream slowness: measured from inside the Client container over private networking, the AppView returned 195/195 requests in 100s with a 52ms max and zero errors. This is purely our handling of a straddled deadline.

## Changes

- Guard both awaits inside one async body. A mid-body abort now fails as a transient `AppviewFetchError` (`status: 0`), so the existing `isTransient` retry and the 10-minute stale-cache fallback absorb it.
- Factor the undici `cause`-code extraction into `appviewTransportError`, so a truncated body reports the same diagnosable `code — GET url` shape as a failed connect.
- Install `unhandledRejection` / `uncaughtException` guards for the console. The advisor and services processes have had these since their first deploy; the console never got one, which is why a single stray rejection could take the whole site down. Homed in `o11y.server.ts`: server-only, imported by every server I/O path, so it installs once and early without a new entry point.

## Verification

- `vitest run` — 368 tests across 36 files pass, including 4 new ones covering the mid-body abort, retry-then-succeed, connect-level failure, and that a 4xx is still a real answer rather than retried.
- The two abort tests **fail against the pre-fix code**, timing out at 5s — that timeout is the fiber hang, confirming they'd catch a regression.
- `tsr generate && tsc -p . --noEmit` clean; `oxlint packages infra` 0 warnings/0 errors; `oxfmt --check` clean.

Note the local install needs Node 22 — `better-sqlite3@11.10.0` fails to build against the Node 26 ABI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)