### PR TITLE
fix(tray): stop a stale exit from stranding the live agent; let a confidential Mac serve the owner's model

### DIFF
--- a/packages/appview/src/api/agent-bug-report.test.ts
+++ b/packages/appview/src/api/agent-bug-report.test.ts
@@ -94,3 +94,53 @@ test("POST /api/agent/bug-report: 400 on an empty body", async () => {
     },
   );
 });
+
+test("POST /api/agent/bug-report: persists the reporter's X-Cocore-Note", async () => {
+  const { store, accountStore } = setup();
+  const did = "did:plc:provider2";
+  const { secret } = accountStore.createKey({ did, name: "m" });
+  const note = "confidential stuck on Applying and the tray keeps restarting";
+  await withAppviewServer(
+    buildAppviewApp(store, { accountStore, appviewDid: APPVIEW_DID }),
+    async (base) => {
+      const res = await fetch(`${base}/api/agent/bug-report`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${secret}`,
+          "content-type": "application/gzip",
+          "x-cocore-note": note,
+        },
+        body: bundle,
+      });
+      assert.equal(res.status, 201);
+      const { ticketId } = (await res.json()) as { ticketId: string };
+      // The reporter's own account of the problem is the whole point of the
+      // header; dropping it (as both upload routes used to) forced triage of
+      // br_57cef8d6 to infer the symptom from logs alone.
+      const row = accountStore.db
+        .prepare(`SELECT note FROM bug_reports WHERE ticket_id = ?`)
+        .get(ticketId) as { note: string };
+      assert.equal(row.note, note);
+    },
+  );
+});
+
+test("POST /api/agent/bug-report: a missing note stores an empty string", async () => {
+  const { store, accountStore } = setup();
+  const { secret } = accountStore.createKey({ did: "did:plc:provider3", name: "m" });
+  await withAppviewServer(
+    buildAppviewApp(store, { accountStore, appviewDid: APPVIEW_DID }),
+    async (base) => {
+      const res = await fetch(`${base}/api/agent/bug-report`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${secret}`, "content-type": "application/gzip" },
+        body: bundle,
+      });
+      const { ticketId } = (await res.json()) as { ticketId: string };
+      const row = accountStore.db
+        .prepare(`SELECT note FROM bug_reports WHERE ticket_id = ?`)
+        .get(ticketId) as { note: string };
+      assert.equal(row.note, "");
+    },
+  );
+});

--- a/packages/appview/src/api/agent-bug-report.ts
+++ b/packages/appview/src/api/agent-bug-report.ts
@@ -111,7 +111,11 @@ export function buildAgentBugReportRouter(
           });
         }
 
-        const stored = ctx.accounts.storeBugReport({ did: resolved.did, bytes });
+        // Persist the reporter's own description alongside the bundle. The
+        // tray has always sent it in `X-Cocore-Note`; both upload routes used
+        // to drop it, leaving triage to infer the symptom from logs.
+        const note = yield* header("x-cocore-note");
+        const stored = ctx.accounts.storeBugReport({ did: resolved.did, bytes, note });
         return HttpServerResponse.text(JSON.stringify({ ticketId: stored.ticketId }), {
           contentType: "application/json",
           status: 201,

--- a/packages/appview/src/operational/account-store.ts
+++ b/packages/appview/src/operational/account-store.ts
@@ -81,13 +81,13 @@ export interface StoredBugReport {
 
 /** Cap on the stored reporter note — it arrives in an HTTP header, so it's
  *  inherently short. Kept in sync with the console's MAX_NOTE_CHARS. */
-export const MAX_NOTE_CHARS = 2000;
+const MAX_NOTE_CHARS = 2000;
 
 /** Normalise a reporter note: drop the C0 control characters HTTP-header
  *  transport can carry, collapse whitespace runs, trim, truncate. Never
  *  returns null, so the column stays NOT NULL. Kept in sync with the
  *  console's normalizeNote in bug-reports.server.ts. */
-export function normalizeNote(raw: string | null | undefined): string {
+function normalizeNote(raw: string | null | undefined): string {
   if (!raw) return "";
   const stripped = Array.from(raw, (ch) => {
     const code = ch.codePointAt(0) ?? 0;

--- a/packages/appview/src/operational/account-store.ts
+++ b/packages/appview/src/operational/account-store.ts
@@ -50,7 +50,10 @@ CREATE TABLE IF NOT EXISTS bug_reports (
   did TEXT NOT NULL,
   file_path TEXT NOT NULL,
   size_bytes INTEGER NOT NULL,
-  created_at TEXT NOT NULL
+  created_at TEXT NOT NULL,
+  -- The reporter's own description, from the tray's X-Cocore-Note
+  -- header. Mirrors the console column; empty string when none was sent.
+  note TEXT NOT NULL DEFAULT ''
 );
 CREATE INDEX IF NOT EXISTS bug_reports_did ON bug_reports (did);
 `;
@@ -72,6 +75,25 @@ export interface StoredBugReport {
   filePath: string;
   sizeBytes: number;
   createdAt: string;
+  /** What the reporter typed, normalised + truncated; "" when absent. */
+  note: string;
+}
+
+/** Cap on the stored reporter note — it arrives in an HTTP header, so it's
+ *  inherently short. Kept in sync with the console's MAX_NOTE_CHARS. */
+export const MAX_NOTE_CHARS = 2000;
+
+/** Normalise a reporter note: drop the C0 control characters HTTP-header
+ *  transport can carry, collapse whitespace runs, trim, truncate. Never
+ *  returns null, so the column stays NOT NULL. Kept in sync with the
+ *  console's normalizeNote in bug-reports.server.ts. */
+export function normalizeNote(raw: string | null | undefined): string {
+  if (!raw) return "";
+  const stripped = Array.from(raw, (ch) => {
+    const code = ch.codePointAt(0) ?? 0;
+    return code < 0x20 || code === 0x7f ? " " : ch;
+  }).join("");
+  return stripped.replace(/\s+/g, " ").trim().slice(0, MAX_NOTE_CHARS);
 }
 
 interface DbRow {
@@ -145,6 +167,23 @@ export class AccountStore {
     this.db = new Database(path);
     this.db.pragma("journal_mode = WAL");
     this.db.exec(SCHEMA);
+    // `CREATE TABLE IF NOT EXISTS` can't add a column to a DB that predates
+    // it, and this store has no migration framework — so ALTER the one
+    // additive column in explicitly, idempotently.
+    this.addColumnIfMissing("bug_reports", "note", "TEXT NOT NULL DEFAULT ''");
+  }
+
+  /** Idempotent additive migration. Reads pragma(table_info) and ALTERs only
+   *  when the column is absent, so it's a no-op on every boot after the first. */
+  private addColumnIfMissing(table: string, column: string, defSql: string): void {
+    const cols = this.db.pragma(`table_info(${table})`) as Array<{ name: string }>;
+    if (cols.some((c) => c.name === column)) return;
+    try {
+      this.db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${defSql}`);
+      console.error(`[account-store] migrated: ${table}.${column}`);
+    } catch (e) {
+      console.error(`[account-store] migration failed for ${table}.${column}: ${String(e)}`);
+    }
   }
 
   // ---- API keys -----------------------------------------------------
@@ -257,8 +296,9 @@ export class AccountStore {
   // Mirrors the console's bug-reports.server.ts so either service can
   // accept an upload depending on where the agent's key was minted.
 
-  storeBugReport(input: { did: string; bytes: Buffer }): StoredBugReport {
+  storeBugReport(input: { did: string; bytes: Buffer; note?: string | null }): StoredBugReport {
     const { did, bytes } = input;
+    const note = normalizeNote(input.note);
     const ticketId = `br_${randomBytes(5).toString("hex").slice(0, 8)}`;
     const createdAt = new Date().toISOString();
 
@@ -273,12 +313,12 @@ export class AccountStore {
 
     this.db
       .prepare(
-        `INSERT INTO bug_reports (ticket_id, did, file_path, size_bytes, created_at)
-         VALUES (?, ?, ?, ?, ?)`,
+        `INSERT INTO bug_reports (ticket_id, did, file_path, size_bytes, created_at, note)
+         VALUES (?, ?, ?, ?, ?, ?)`,
       )
-      .run(ticketId, did, filePath, bytes.byteLength, createdAt);
+      .run(ticketId, did, filePath, bytes.byteLength, createdAt, note);
 
-    return { ticketId, did, filePath, sizeBytes: bytes.byteLength, createdAt };
+    return { ticketId, did, filePath, sizeBytes: bytes.byteLength, createdAt, note };
   }
 
   /** Rolling-window upload usage for a DID (L8): how many bundles and how many

--- a/packages/console/src/lib/bug-reports.server.ts
+++ b/packages/console/src/lib/bug-reports.server.ts
@@ -13,7 +13,8 @@
 //     SQLite file, so anywhere the DB is durable (a Railway volume, an
 //     explicit COCORE_CONSOLE_DB path) the bundles are durable too.
 //   * A single `bug_reports` row (see console-db.server.ts) records the
-//     ticket id, uploader DID, on-disk path, and size — metadata only.
+//     ticket id, uploader DID, on-disk path, size, and the reporter's
+//     own note — metadata only.
 //
 // We never read, log, or inspect bundle contents here: the bytes land
 // on disk and the row points at them. An operator triages by ticket id
@@ -35,12 +36,32 @@ export const MAX_BUNDLE_BYTES = 25 * 1024 * 1024;
  *  tarball; reject anything else at the edge. */
 export const BUNDLE_CONTENT_TYPE = "application/gzip";
 
+/** Cap on the stored reporter note. The tray sends it as an HTTP header
+ *  (`X-Cocore-Note`), so it's inherently short; truncating keeps a
+ *  hostile client from parking arbitrary text in the DB. */
+export const MAX_NOTE_CHARS = 2000;
+
+/** Normalise the reporter's note: it arrives as an HTTP header, so drop the
+ *  C0 control characters that transport can carry (CR/LF/TAB from a
+ *  multi-line note), collapse whitespace runs, trim, and truncate. Returns
+ *  "" when there's nothing usable, so the column is never null. */
+export function normalizeNote(raw: string | null | undefined): string {
+  if (!raw) return "";
+  const stripped = Array.from(raw, (ch) => {
+    const code = ch.codePointAt(0) ?? 0;
+    return code < 0x20 || code === 0x7f ? " " : ch;
+  }).join("");
+  return stripped.replace(/\s+/g, " ").trim().slice(0, MAX_NOTE_CHARS);
+}
+
 export interface StoredBugReport {
   ticketId: string;
   did: string;
   filePath: string;
   sizeBytes: number;
   createdAt: string;
+  /** What the reporter typed, normalised + truncated; "" when absent. */
+  note: string;
 }
 
 /** Resolve the directory bundles are written under. Mirrors the DB
@@ -78,8 +99,13 @@ function generateTicketId(): string {
  *
  *  Does NOT validate size/content-type — the route does that before
  *  buffering, so this stays a pure persistence step. */
-export function storeBugReport(input: { did: string; bytes: Buffer }): StoredBugReport {
+export function storeBugReport(input: {
+  did: string;
+  bytes: Buffer;
+  note?: string | null;
+}): StoredBugReport {
   const { did, bytes } = input;
+  const note = normalizeNote(input.note);
   const ticketId = generateTicketId();
   const createdAt = new Date().toISOString();
 
@@ -94,10 +120,10 @@ export function storeBugReport(input: { did: string; bytes: Buffer }): StoredBug
 
   consoleDb()
     .prepare(
-      `INSERT INTO bug_reports (ticket_id, did, file_path, size_bytes, created_at)
-       VALUES (?, ?, ?, ?, ?)`,
+      `INSERT INTO bug_reports (ticket_id, did, file_path, size_bytes, created_at, note)
+       VALUES (?, ?, ?, ?, ?, ?)`,
     )
-    .run(ticketId, did, filePath, bytes.byteLength, createdAt);
+    .run(ticketId, did, filePath, bytes.byteLength, createdAt, note);
 
-  return { ticketId, did, filePath, sizeBytes: bytes.byteLength, createdAt };
+  return { ticketId, did, filePath, sizeBytes: bytes.byteLength, createdAt, note };
 }

--- a/packages/console/src/lib/bug-reports.test.ts
+++ b/packages/console/src/lib/bug-reports.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { MAX_NOTE_CHARS, normalizeNote } from "./bug-reports.server.ts";
+
+// The reporter's note arrives as an HTTP header (X-Cocore-Note) that the tray
+// has always sent and the upload routes used to discard — triage of
+// br_57cef8d6 had to reconstruct the reported symptoms from logs alone. It's
+// now persisted, so pin the normalisation that makes header text safe to
+// store: never null (the column is NOT NULL), no control characters, bounded.
+describe("normalizeNote", () => {
+  it("returns an empty string for absent input", () => {
+    expect(normalizeNote(undefined)).toBe("");
+    expect(normalizeNote(null)).toBe("");
+    expect(normalizeNote("")).toBe("");
+  });
+
+  it("keeps ordinary prose intact", () => {
+    expect(normalizeNote("  confidential is stuck on Applying  ")).toBe(
+      "confidential is stuck on Applying",
+    );
+  });
+
+  it("replaces control characters that header transport can smuggle in", () => {
+    const raw = ["two", "lines", "and one"].join("\r\n") + "\ttabbed";
+    expect(normalizeNote(raw)).toBe("two lines and one tabbed");
+  });
+
+  it("truncates to the cap", () => {
+    expect(normalizeNote("x".repeat(MAX_NOTE_CHARS + 500)).length).toBe(MAX_NOTE_CHARS);
+  });
+});

--- a/packages/console/src/lib/console-db.server.ts
+++ b/packages/console/src/lib/console-db.server.ts
@@ -125,7 +125,14 @@ CREATE TABLE IF NOT EXISTS bug_reports (
   file_path TEXT NOT NULL,
   -- Bundle size in bytes, as received (post size-limit check).
   size_bytes INTEGER NOT NULL,
-  created_at TEXT NOT NULL
+  created_at TEXT NOT NULL,
+  -- What the reporter actually typed, from the tray's X-Cocore-Note
+  -- header (truncated at upload). This is the ONLY human account of what
+  -- looked wrong, and it used to be dropped on the floor: triage of
+  -- br_57cef8d6 had to reconstruct the reported symptoms from logs alone
+  -- because two reports arrived with no description anywhere. Empty
+  -- string when the reporter sent none.
+  note TEXT NOT NULL DEFAULT ''
 );
 
 -- Captured Apple x5c attestation chains for Secure Mode (MDA), keyed by
@@ -198,6 +205,10 @@ interface TableSpec {
 }
 
 const REQUIRED_COLUMNS: TableSpec[] = [
+  {
+    table: "bug_reports",
+    columns: [{ name: "note", defSql: "TEXT NOT NULL DEFAULT ''" }],
+  },
   {
     table: "pending_disputes",
     columns: [

--- a/packages/console/src/routes/api/agent.bug-report.ts
+++ b/packages/console/src/routes/api/agent.bug-report.ts
@@ -11,7 +11,9 @@
 //
 // The handler validates content-type + size, stores the bundle on the
 // filesystem next to the console DB (see bug-reports.server.ts), records
-// a metadata row keyed by the uploader's DID, and returns { ticketId }.
+// a metadata row keyed by the uploader's DID — including the reporter's
+// own note from `X-Cocore-Note`, which the tray has always sent and this
+// route used to discard — and returns { ticketId }.
 //
 // We deliberately never read or log the bundle's contents — the bytes
 // land on disk untouched and the response carries only the ticket id.
@@ -97,7 +99,14 @@ export const Route = createFileRoute("/api/agent/bug-report")({
           );
         }
 
-        const stored = storeBugReport({ did: resolved.did, bytes });
+        // The reporter's description of what went wrong. The tray sends it
+        // as a header alongside the bundle; persisting it is the difference
+        // between triaging a symptom and guessing at one from logs.
+        const stored = storeBugReport({
+          did: resolved.did,
+          bytes,
+          note: request.headers.get("x-cocore-note"),
+        });
 
         return new Response(JSON.stringify({ ticketId: stored.ticketId }), {
           status: 201,

--- a/provider-shell/Sources/CoCoreShell/AgentSupervisor.swift
+++ b/provider-shell/Sources/CoCoreShell/AgentSupervisor.swift
@@ -83,6 +83,18 @@ final class AgentSupervisor {
     private var intentionalStop = false
     private var restartBackoff: TimeInterval = 2
     private var lastSpawnAt: Date?
+    /// Monotonic id of the child we currently own, bumped on every spawn. A
+    /// `terminationHandler` captures the generation it was installed for and
+    /// compares on exit, so a LATE exit from a superseded child can't be
+    /// mistaken for the live one's. Without this, bug report br_57cef8d6:
+    /// `stop()` abandoned a child that outlived its wait, `start()` spawned a
+    /// replacement, and the old child's handler then nil'd `process` (the tray
+    /// lost track of a healthy, serving agent — `isServing()` false forever) and
+    /// blamed the new child for the exit ("ran 0s"). The 30s liveness
+    /// reconciler then respawned every tick, each spawn reaping the live worker,
+    /// until the circuit breaker parked the machine for 15 minutes — 59 times in
+    /// one day.
+    private var spawnGeneration = 0
 
     private let label = "dev.cocore.provider"
     private var domainTarget: String { "gui/\(getuid())/\(label)" }
@@ -134,10 +146,27 @@ final class AgentSupervisor {
         // (which fires on exit) doesn't treat this as a crash and respawn.
         intentionalStop = true
         if let p = process {
-            Self.supervisorLog("stop(): SIGINT agent pid \(p.processIdentifier) (intentional)")
+            let pid = p.processIdentifier
+            Self.supervisorLog("stop(): SIGINT agent pid \(pid) (intentional)")
             p.interrupt()
-            await waitForExit(p, timeout: 5)
-            if p.isRunning { p.terminate() }
+            // Outwait the agent's own graceful shutdown, which gives its
+            // offline-marker PDS publish a full 5s of its own before giving up
+            // (`offline-marker publish timed out after 5s`). A 5s wait here
+            // therefore expired moments BEFORE the child was actually gone
+            // whenever that publish was slow — leaving a live agent nobody
+            // tracked (br_57cef8d6). Escalate instead of abandoning it: the
+            // singleton invariant depends on this method leaving no survivor.
+            await waitForExit(p, timeout: 12)
+            if p.isRunning {
+                Self.supervisorLog("stop(): pid \(pid) outlived SIGINT+12s — SIGTERM")
+                p.terminate()
+                await waitForExit(p, timeout: 3)
+            }
+            if p.isRunning {
+                Self.supervisorLog("stop(): pid \(pid) outlived SIGTERM — SIGKILL")
+                kill(pid, SIGKILL)
+                await waitForExit(p, timeout: 2)
+            }
             process = nil
         }
         // Reap any leaked sibling workers too — not just the one we track.
@@ -309,6 +338,24 @@ final class AgentSupervisor {
         return CircuitEval(action: .allow, prunedSpawnTimes: pruned)
     }
 
+    /// What an exiting child means for the supervisor. Pure so the ordering
+    /// hazard it fixes is unit-testable without real processes.
+    ///  * `.stale`       — a superseded child (we spawned a replacement after
+    ///                     abandoning this one). Log and touch NOTHING: its
+    ///                     tracking, backoff and spawn budget belong to the
+    ///                     live child now.
+    ///  * `.intentional` — we asked it to stop and it's still the current
+    ///                     generation; stay down.
+    ///  * `.unexpected`  — a genuine crash/kill of the child we own; respawn.
+    enum ExitDisposition: Equatable { case stale, intentional, unexpected }
+
+    nonisolated static func classifyExit(
+        generation: Int, currentGeneration: Int, intentionalStop: Bool
+    ) -> ExitDisposition {
+        if generation != currentGeneration { return .stale }
+        return intentionalStop ? .intentional : .unexpected
+    }
+
     private func spawnChild() {
         guard process == nil else { return }
         // Restart circuit breaker. If we're inside a cooldown from a prior
@@ -341,11 +388,9 @@ final class AgentSupervisor {
         // A fresh deliberate start clears the stop latch so a later
         // unexpected exit is treated as a crash and respawned.
         intentionalStop = false
-        // Probe the owner's trust tier ONCE: it selects the worker binary AND
-        // gates the inference-model env below (a confidential machine is
-        // native-only, so we must not inject subprocess models).
+        // Probe the owner's trust tier ONCE: it selects the worker binary (the
+        // nested measured bundle for attested-confidential, else the default).
         let tier = Self.probeTier()
-        let confidential = (tier == "attested-confidential")
         guard let bin = Self.serveBinary(tier: tier) else {
             NSLog("cocore: provider binary not found")
             return
@@ -371,13 +416,23 @@ final class AgentSupervisor {
             // but this also enriches the stderr line we persist below.
             "RUST_BACKTRACE": "full",
         ]
-        // Best-effort machines serve the owner's subprocess models; a
-        // confidential machine is native-only (inference stays in the measured
-        // binary), so never inject subprocess models there — the agent also
-        // clears them defensively, but not passing them avoids the spawn churn.
+        // The owner's model pick, for BOTH tiers. On a best-effort machine this
+        // is the subprocess engine's model list. On a confidential machine it
+        // is the only channel this pick has: inference there stays in the
+        // measured binary, and the agent picks the ONE model its native MLX
+        // engine serves from `desiredModels` first, then this env var, then a
+        // 0.5B default (`pick_confidential_native_model`). The tray writes the
+        // pick to UserDefaults only — never to PDS `desiredModels` — so
+        // withholding it here left every app-managed confidential Mac serving
+        // the 0.5B default forever, advertising a model nobody routes work to
+        // (br_57cef8d6: zero jobs in ten days). Passing it is safe for the
+        // native-only invariant: `cmd_serve` reads it for the native pick and
+        // then CLEARS it (`inference_models_action` → `.Clear`) before
+        // `build_engines`, so a confidential machine still spawns no Python
+        // child for it.
         let models = (UserDefaults.standard.string(forKey: "inferenceModels") ?? "")
             .trimmingCharacters(in: .whitespaces)
-        if !confidential, !models.isEmpty { env["COCORE_INFERENCE_MODELS"] = models }
+        if !models.isEmpty { env["COCORE_INFERENCE_MODELS"] = models }
         // Owner-chosen display name (set in the tray during setup), so the
         // provider record shows that instead of the raw `.local` hostname.
         let label = (UserDefaults.standard.string(forKey: "machineLabel") ?? "")
@@ -423,17 +478,37 @@ final class AgentSupervisor {
                 Self.appendAgentStderr(s)
             }
         }
+        // The generation this handler speaks for. Bumped just before `run()`
+        // below, so an exit that arrives after a later spawn is recognisable as
+        // stale instead of being applied to the live child.
+        spawnGeneration += 1
+        let generation = spawnGeneration
         p.terminationHandler = { [weak self] proc in
             Task { @MainActor [weak self] in
                 guard let self else { return }
-                self.process = nil
                 NSLog("cocore agent exited with %d", proc.terminationStatus)
                 let ranForLog = self.lastSpawnAt.map { Int(Date().timeIntervalSince($0)) } ?? -1
-                // Deliberate stop → leave it down.
-                guard !self.intentionalStop else {
+                switch Self.classifyExit(
+                    generation: generation, currentGeneration: self.spawnGeneration,
+                    intentionalStop: self.intentionalStop)
+                {
+                case .stale:
+                    // A child we already stopped tracking finally exited, after
+                    // we'd spawned its replacement. Leave `process`,
+                    // `lastSpawnAt`, `spawnTimes` and `crashCount` alone — they
+                    // describe the LIVE child. (br_57cef8d6: clobbering them
+                    // here is what made the tray lose a healthy agent and
+                    // storm-restart itself into a 15-minute circuit trip.)
+                    Self.supervisorLog(
+                        "stale exit ignored (status \(proc.terminationStatus)) — superseded agent gen \(generation), current gen \(self.spawnGeneration); the live child keeps its tracking")
+                    return
+                case .intentional:
+                    self.process = nil
                     Self.supervisorLog(
                         "agent exited (status \(proc.terminationStatus), ran \(ranForLog)s) after an intentional stop — staying down")
                     return
+                case .unexpected:
+                    self.process = nil
                 }
                 Self.supervisorLog(
                     "agent exited UNEXPECTEDLY (status \(proc.terminationStatus), ran \(ranForLog)s) — will respawn")
@@ -546,6 +621,12 @@ final class AgentSupervisor {
         guard !pids.isEmpty else { return }
         NSLog("cocore: reaping %d stray agent worker(s): %@",
               pids.count, pids.map(String.init).joined(separator: ","))
+        // Durably, too: a reap means a worker outlived the bookkeeping that was
+        // supposed to own it, and NSLog ages out of the unified log long before
+        // anyone reads the diagnostic bundle. Attributing the SIGTERM/SIGKILL in
+        // br_57cef8d6 to this reaper (rather than to a crashing agent) is what
+        // separated the real bug from a phantom crash loop.
+        supervisorLog("reaping \(pids.count) stray agent worker(s): \(pids.map(String.init).joined(separator: ","))")
         for pid in pids { kill(pid, SIGTERM) }
         Thread.sleep(forTimeInterval: 0.5)
         for pid in pids where kill(pid, 0) == 0 { kill(pid, SIGKILL) }
@@ -560,6 +641,8 @@ final class AgentSupervisor {
         guard !pids.isEmpty else { return }
         NSLog("cocore: reaping %d stray agent worker(s): %@",
               pids.count, pids.map(String.init).joined(separator: ","))
+        // Same durable note as the blocking twin above.
+        supervisorLog("reaping \(pids.count) stray agent worker(s): \(pids.map(String.init).joined(separator: ","))")
         for pid in pids { kill(pid, SIGTERM) }
         try? await Task.sleep(nanoseconds: 500_000_000)
         for pid in pids where kill(pid, 0) == 0 { kill(pid, SIGKILL) }

--- a/provider-shell/Tests/CoCoreShellTests/StaleExitTests.swift
+++ b/provider-shell/Tests/CoCoreShellTests/StaleExitTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+
+@testable import CoCoreShell
+
+/// Unit coverage for `AgentSupervisor.classifyExit` — the pure decision that
+/// keeps a LATE exit from a superseded agent child from being applied to the
+/// live one.
+///
+/// Bug report br_57cef8d6 (new M5 Air, tray 0.9.52): the agent's graceful
+/// shutdown gives its offline-marker PDS publish a full 5s of its own, so
+/// `stop()`'s 5s wait routinely expired an instant before the child was gone.
+/// `stop()` then abandoned it, `start()` spawned a replacement, and the old
+/// child's `terminationHandler` fired late — nil'ing `process` (so the tray
+/// believed a healthy, serving agent was down: `isServing()` false forever) and
+/// charging the exit to the new child ("ran 0s", status 15/9 from the reaper).
+/// The 30s liveness reconciler then respawned every tick, each spawn reaping the
+/// live worker, until the circuit breaker parked the machine for 15 minutes —
+/// 279 spawns and 59 circuit trips in a single day, zero jobs served.
+///
+/// The generation check is what breaks that loop, so pin its three outcomes.
+final class StaleExitTests: XCTestCase {
+    /// The common case: the child we own crashed or was killed → respawn.
+    func testCurrentGenerationUnexpectedExitRespawns() {
+        XCTAssertEqual(
+            AgentSupervisor.classifyExit(
+                generation: 7, currentGeneration: 7, intentionalStop: false),
+            .unexpected)
+    }
+
+    /// We asked it to stop and nothing superseded it → stay down.
+    func testCurrentGenerationIntentionalStopStaysDown() {
+        XCTAssertEqual(
+            AgentSupervisor.classifyExit(
+                generation: 7, currentGeneration: 7, intentionalStop: true),
+            .intentional)
+    }
+
+    /// The regression: an abandoned child exits AFTER its replacement was
+    /// spawned. `intentionalStop` has already been cleared by that spawn, so
+    /// the old `intentionalStop` guard alone read this as a crash of the live
+    /// child. Generation mismatch must win over the latch either way.
+    func testSupersededExitIsStaleEvenWithStopLatchCleared() {
+        XCTAssertEqual(
+            AgentSupervisor.classifyExit(
+                generation: 7, currentGeneration: 8, intentionalStop: false),
+            .stale)
+        XCTAssertEqual(
+            AgentSupervisor.classifyExit(
+                generation: 7, currentGeneration: 8, intentionalStop: true),
+            .stale)
+    }
+
+    /// Several spawns can land while an old child lingers (the 30s reconciler
+    /// ticking through a storm); every one of those exits is still stale.
+    func testFarBehindGenerationIsStale() {
+        XCTAssertEqual(
+            AgentSupervisor.classifyExit(
+                generation: 1, currentGeneration: 42, intentionalStop: false),
+            .stale)
+    }
+}


### PR DESCRIPTION
Triage of the two bug reports from my new M5 Air (`br_57cef8d6`, `br_6a33f10f` — same snapshot 6s apart; `Mac17,3`, macOS 26.5.1, tray 0.9.52, machine `3mtdeliuhwq2e`). The day's damage: **279 agent (re)starts, 236 kills, 59 restart-circuit trips**, and **zero jobs served in ten days of logs**. Three distinct bugs, all fixed here.

## 1. A stale `terminationHandler` stranded a healthy agent — the storm's root cause

Smoking gun at the moment it began, 2026-08-24T20:57:57:

```
20:57:57.678  agent: graceful shutdown signal received — marking provider offline
20:58:02.680  agent: WARN offline-marker publish timed out after 5s
20:57:57Z     supervisor: stop(): SIGINT agent pid 32685 (intentional)   ← no "staying down" ever follows
20:58:21Z     supervisor: agent exited UNEXPECTEDLY (status 0, ran 0s) — will respawn
```

Two 5s timeouts collided: the agent's offline-marker publish gets a full 5s of its own, while `stop()` waited exactly `waitForExit(p, timeout: 5)` and then returned — `terminate()`, `process = nil`, no await. `start()` spawned a replacement (clearing `intentionalStop`), and the old child's handler fired late:

- `self.process = nil` clobbered tracking of the **live, serving** child → `isServing()` false forever;
- the exit was charged to the new child (`ran 0s`, computed from the new `lastSpawnAt`), inflating `crashCount` and `spawnTimes`.

Self-sustaining from there: `reconcileSupervisorLiveness()` (30s tick) spawned every tick, each spawn's pre-spawn `reapWorkers()` SIGTERM/SIGKILLing the live worker (hence every `status 15` / `status 9, ran 0s`), 5 spawns per 6 min → circuit open 15 min → repeat. The machine was up but the tray showed "auto-restart paused" for most of the day.

**Fix:** a spawn generation. A handler only applies to the child it was installed for (`classifyExit`, pure + unit-tested), and `stop()` escalates SIGINT → SIGTERM → SIGKILL instead of ever returning with a child still alive.

## 2. An app-managed confidential Mac could never serve the owner's model pick

The record and advisor advertised only `["mlx-community/Qwen2.5-0.5B-Instruct-4bit", "stub"]` — the 0.5B default — which is why nothing was ever routed to it. `spawnChild()` withheld `COCORE_INFERENCE_MODELS` from confidential machines, and on the no-LaunchAgent path the tray writes the pick only to UserDefaults, never to PDS `desiredModels`. So `pick_confidential_native_model` saw neither of its two sources and fell through to the default.

**Fix:** pass the pick for both tiers. This is safe for the native-only invariant by construction: `cmd_serve` reads it for the native pick and then CLEARS it (`inference_models_action` → `.Clear`) before `build_engines`, so a confidential machine still spawns no Python child. An incompatible pick now surfaces as an honest `engineFault` instead of silently serving a toy model — the documented intent of that code path.

Follow-up worth doing separately: have the tray write `desiredModels` on the app-managed path too, so the pick shows up in the console and across devices (today only the web picker writes it).

## 3. The reporter's note was discarded on upload

The tray has always sent the user's description in `X-Cocore-Note`; both the console and AppView upload routes dropped it, and `bug_reports` had no column for it. That's why this triage had to reconstruct the reported symptoms from logs. Now persisted in a `note` column on both stores (additive, idempotent migration; normalised for header transport and capped at 2000 chars).

Also: reaps are now written to `supervisor.log`. Attributing those SIGTERM/SIGKILLs to the reaper rather than to a crashing agent is what separated the real bug from a phantom crash loop.

## Not the problem (ruled out)

`registrationAuthenticated: true` — the session is healthy, so this is **not** the usual dead-OAuth-session case. Confidential being stuck (`codeAttested: false`, `trustTier: best-effort`, all other legs green) is downstream of bug 1: advisor logs show 48 code-challenge pushes to this DID, 18 `code-attestation OK`, plus `unsolicited code-attestation` and `re-challenge unanswered … marking unattested and closing` — the 30s kill cycle never let attestation stick.

## Verification

- `swift build` + 10 Swift tests (4 new, covering the three `classifyExit` outcomes)
- console: `tsc` clean, 374 tests (4 new)
- appview: `tsc` clean, 131 tests (2 new, note round-trip + absent-note default)
- `oxlint` + `oxfmt --check` clean on every touched file

Bug 1 and 2 need a tray release to reach the fleet; bug 3 takes effect on the next console/AppView deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
