### PR TITLE
perf(console): stop paying for uncacheable assets and blocked SSR

### DIFF
--- a/packages/console/src/integrations/auth/session.functions.ts
+++ b/packages/console/src/integrations/auth/session.functions.ts
@@ -32,7 +32,22 @@ const getSessionServerFn = createServerFn({ method: "GET" }).handler(() =>
         Effect.tryPromise(() => ensureMyProfile(ctx.oauthSession)),
       );
       const cocore = Either.isRight(cocoreEither) ? cocoreEither.right : null;
-      const bsky = yield* fetchBlueskyPublicProfileFieldsEffect(ctx.did);
+
+      // bsky is only ever a *fallback* for the three fields below, and
+      // `ensureMyProfile` already provisions all of them from bsky on first
+      // sign-in (making its own call to public.api.bsky.app to do it). So on
+      // a settled account this was a second, identical, serial round-trip to
+      // an external service on every single page load, whose result was then
+      // discarded by the `??` chain. Only pay for it when a field is
+      // genuinely missing.
+      const needsBskyFallback =
+        cocore == null ||
+        cocore.displayName == null ||
+        cocore.handle == null ||
+        cocore.avatarUrl == null;
+      const bsky = needsBskyFallback
+        ? yield* fetchBlueskyPublicProfileFieldsEffect(ctx.did)
+        : null;
 
       const displayName = cocore?.displayName ?? bsky?.displayName?.trim() ?? null;
       const handle = cocore?.handle ?? bsky?.handle?.trim() ?? null;

--- a/packages/console/src/routes/_header-layout.tsx
+++ b/packages/console/src/routes/_header-layout.tsx
@@ -102,12 +102,20 @@ export const Route = createFileRoute("/_header-layout")({
       });
     }
   },
-  loader: async ({ context }) => {
-    await context.queryClient.ensureQueryData(getSessionQueryOptions);
+  loader: ({ context }) => {
+    // `beforeLoad` already awaited the session, so this is a cache read.
     const session = context.queryClient.getQueryData(getSessionQueryOptions.queryKey);
-    if (session) {
-      await context.queryClient.ensureQueryData(listMyMachinesQueryOptions);
-    }
+    if (!session) return;
+    // Start the fleet query but deliberately do NOT await it. This layout
+    // wraps every page in the app, so awaiting here held the whole SSR
+    // response — docs, blog, chat, everything — behind an AppView
+    // listProviders + receipts + advisor round-trip. The only thing it
+    // feeds is the machine-count badge in the navbar, which renders fine
+    // as absent; `setupRouterSsrQueryIntegration` streams the result into
+    // the dehydrated cache, so the badge fills in when the data lands.
+    // `prefetchQuery` (not `ensureQueryData`) so a failure resolves rather
+    // than becoming an unhandled rejection with nothing to catch it.
+    void context.queryClient.prefetchQuery(listMyMachinesQueryOptions);
   },
   component: HeaderLayoutChrome,
 });

--- a/packages/console/vite.config.ts
+++ b/packages/console/vite.config.ts
@@ -11,10 +11,83 @@ import remarkMdxFrontmatter from "remark-mdx-frontmatter";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import stylexPlugin from "@stylexjs/unplugin";
 import viteReact from "@vitejs/plugin-react";
-import { defineConfig, mergeConfig } from "vite";
+import { defineConfig, mergeConfig, type Plugin } from "vite";
 import { defineConfig as defineVitestConfig } from "vitest/config";
 
 const rootDir = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Production is served by `vite preview` (see the `start` script), and Vite's
+ * preview server hands static files to sirv, which hardcodes
+ * `Cache-Control: no-cache` on every hit regardless of filename:
+ *
+ *   headers["Cache-Control"] = isEtag ? "no-cache" : "no-store";
+ *
+ * Every file Vite emits under `/assets/` is content-hashed, so `no-cache` buys
+ * nothing and costs a great deal: the browser must revalidate ~60 files on
+ * every navigation, and Railway's edge can't cache any of them. Measured on
+ * console.cocore.dev before this plugin: a *warm* load transferred only 23KB
+ * of JS yet still spent 1.66s on 50 conditional GETs.
+ *
+ * sirv writes the header itself via `res.writeHead(code, headers)`, so a plain
+ * pre-middleware loses the race — we have to intercept the write. Unhashed
+ * files from `public/` (favicon, goobies, fonts) get a short revalidatable TTL
+ * instead of `immutable`, since their URLs are stable across deploys.
+ *
+ * Matching is a deliberate allowlist of paths that are served straight off
+ * disk, NOT a file-extension test: plenty of real routes set their own
+ * Cache-Control on purpose (`/og.png` caches for a day, `/lexicons/*` for an
+ * hour, `/agent.*` are no-store), and an extension rule silently stomped
+ * `/og.png` down to an hour.
+ */
+const IMMUTABLE_CACHE = "public, max-age=31536000, immutable";
+const PUBLIC_ASSET_CACHE = "public, max-age=3600";
+/** Everything Vite emits here is content-hashed; no route serves from it. */
+const IMMUTABLE_PREFIX = "/assets/";
+/** Static, unhashed files copied verbatim out of `public/`. */
+const PUBLIC_ASSET_PREFIXES = ["/goobies/", "/og-fonts/"];
+const PUBLIC_ASSET_PATHS = new Set(["/favicon.svg", "/app-icon.svg", "/robots.txt"]);
+
+function assetCacheHeaders(): Plugin {
+  return {
+    name: "cocore:preview-asset-cache-headers",
+    configurePreviewServer(server) {
+      // `configurePreviewServer` runs before Vite installs its own
+      // middlewares, so this sees the request first.
+      server.middlewares.use((req, res, next) => {
+        const pathname = (req.url ?? "").split("?")[0] ?? "";
+        const isPublicAsset =
+          PUBLIC_ASSET_PATHS.has(pathname) ||
+          PUBLIC_ASSET_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+        const cacheControl = pathname.startsWith(IMMUTABLE_PREFIX)
+          ? IMMUTABLE_CACHE
+          : isPublicAsset
+            ? PUBLIC_ASSET_CACHE
+            : null;
+        if (cacheControl === null) return next();
+
+        const originalWriteHead = res.writeHead.bind(res);
+        res.writeHead = function patchedWriteHead(status: number, ...rest: unknown[]) {
+          // Drop sirv's own Cache-Control from the headers object it passes
+          // positionally, then set ours — `writeHead` merges what
+          // `setHeader` has recorded with the object argument.
+          for (const arg of rest) {
+            if (arg && typeof arg === "object" && !Array.isArray(arg)) {
+              for (const key of Object.keys(arg as Record<string, unknown>)) {
+                if (key.toLowerCase() === "cache-control") {
+                  delete (arg as Record<string, unknown>)[key];
+                }
+              }
+            }
+          }
+          res.setHeader("Cache-Control", cacheControl);
+          return originalWriteHead(status, ...(rest as []));
+        } as typeof res.writeHead;
+        next();
+      });
+    },
+  };
+}
 
 export default mergeConfig(
   defineConfig({
@@ -80,6 +153,7 @@ export default mergeConfig(
       }),
       tanstackStart(),
       viteReact({ include: /\.(mdx|js|jsx|ts|tsx)$/ }),
+      assetCacheHeaders(),
     ],
   }),
   defineVitestConfig({


### PR DESCRIPTION
Cold page loads were taking several seconds. Three independent causes, none of them in the rendering path itself.

## Measurements (console.cocore.dev, before)

| | |
|---|---|
| HTML TTFB | ~314ms — **the server is fine** |
| 42 JS chunks | requested together at 716ms, last one lands at **2413ms** |
| second wave | 15 more chunks starting at ~2320ms |
| payload | 59 JS files, 312KB transferred, 905KB decoded |
| **warm** load | 50 files, only **23KB** transferred, still **1663ms** |

That last row is the tell: 50 conditional GETs that returned 304 and bought nothing.

## 1. `/assets/` was served uncacheable

Production runs `vite preview`, whose static handler (sirv) hardcodes the header regardless of filename:

```js
headers["Cache-Control"] = isEtag ? "no-cache" : "no-store";
```

All 182 files we emit under `/assets/` are content-hashed, so `no-cache` is pure waste — the browser revalidates ~60 files per navigation and Railway's edge can't cache any of them.

Adds a `configurePreviewServer` plugin stamping `immutable` on `/assets/` and a short TTL on the unhashed files from `public/`. It intercepts `res.writeHead` because sirv writes the header itself, so a plain pre-middleware loses the race.

Matching is an explicit **path allowlist, not a file-extension test** — several routes set their own `Cache-Control` on purpose, and an extension rule silently downgraded `/og.png` from a day to an hour. Verified the deliberate ones survive:

```
/assets/index-*.js   public, max-age=31536000, immutable
/goobies/heron.png   public, max-age=3600
/og.png              public, max-age=86400, s-maxage=86400   ← preserved
/lexicons            public, max-age=300                     ← preserved
HTML                 (none, unchanged)
```

## 2. Every page's SSR blocked on the fleet query

`_header-layout` wraps the entire app, and its loader awaited `listMyMachines` — so `/docs`, `/blog`, and `/chat` all held their SSR response behind an AppView `listProviders` + receipts + advisor round-trip, to populate a navbar count badge.

Prefetch instead of await. `prefetchQuery` (rather than `ensureQueryData`) also means an AppView outage degrades the badge instead of failing the whole page render. Also drops a redundant second `ensureQueryData(session)` that `beforeLoad` had already awaited.

## 3. A duplicated external round-trip per logged-in page load

`getSession` called `public.api.bsky.app` on every load, serially, for a result the `??` chain almost always discarded — `ensureMyProfile` already makes that same call internally when provisioning a profile on first sign-in. Now gated on a fallback field actually being missing, which is what that file's own comment already described as the intent.

## Verification

- Production build succeeds; headers confirmed by curl against the real preview server
- `typecheck` clean
- 374/374 tests pass (37 files)
- Landing page renders with no console errors

## Deliberately not in this PR

- **The second chunk wave (15 files at ~2.3s).** No app-level `lazy()`/`import()` causes it — it's TanStack's preload manifest not walking the full transitive graph. The fix is bundler surgery, and `vite.config.ts` carries an explicit warning that chunk/CSS ordering here is fragile enough to silently unstyle the app.
- **`appview.getProvidersByDid`.** Listing every provider to find one user's machines still won't scale, but fix 2 took it off the SSR critical path, so it's no longer urgent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)