### PR TITLE
perf(console): stop asking the AppView for the same session twice

### DIFF
--- a/packages/console/src/lib/appview-backed-session.server.ts
+++ b/packages/console/src/lib/appview-backed-session.server.ts
@@ -117,13 +117,34 @@ class AppviewBackedSession {
   }
 }
 
-/** Liveness + PDS-URL for a DID, read from the AppView's owned session
- *  WITHOUT refreshing. `checked` distinguishes a definitive answer (the
- *  AppView responded) from "couldn't reach the AppView" — callers must only
- *  log a user out on `checked && !present`, never on a transient blip. */
-export async function appviewSessionInfo(
-  did: string,
-): Promise<{ checked: boolean; present: boolean; aud: string | null }> {
+export type AppviewSessionInfo = { checked: boolean; present: boolean; aud: string | null };
+
+/**
+ * Rendering one signed-in page asked the AppView for the SAME session-info,
+ * with the same DID, twice: once in `atprotoSessionForRequestEffect` to decide
+ * whether a live session exists, and again via `getPdsUrl` → `getTokenInfo()`
+ * to read `.aud`. Both are serial and on the critical path, so the second one
+ * was pure duplicated latency — measured at roughly a third of a signed-in
+ * page's server time.
+ *
+ * A short TTL collapses them. It is deliberately brief: this read gates
+ * logging a user out, so it must not serve a stale "present" for long. Only
+ * DEFINITIVE answers (`checked: true`) are cached — a transient AppView blip
+ * must be retried on the next call, never remembered.
+ */
+const SESSION_INFO_TTL_MS = 5_000;
+/** Bound on distinct DIDs held at once; the cache is a latency trick, not a
+ *  store, so it is cheaper to drop it wholesale than to track an LRU. */
+const SESSION_INFO_MAX_ENTRIES = 5_000;
+
+const sessionInfoCache = new Map<string, { expiresAt: number; value: AppviewSessionInfo }>();
+
+/** Test seam: drop memoized session-info so cases don't leak into each other. */
+export function resetAppviewSessionInfoCache(): void {
+  sessionInfoCache.clear();
+}
+
+async function fetchAppviewSessionInfo(did: string): Promise<AppviewSessionInfo> {
   const b = base();
   const s = secret();
   if (!b || !s) return { checked: false, present: false, aud: null };
@@ -137,6 +158,27 @@ export async function appviewSessionInfo(
   } catch {
     return { checked: false, present: false, aud: null };
   }
+}
+
+/** Liveness + PDS-URL for a DID, read from the AppView's owned session
+ *  WITHOUT refreshing. `checked` distinguishes a definitive answer (the
+ *  AppView responded) from "couldn't reach the AppView" — callers must only
+ *  log a user out on `checked && !present`, never on a transient blip.
+ *  Definitive answers are memoized for SESSION_INFO_TTL_MS. */
+export async function appviewSessionInfo(did: string): Promise<AppviewSessionInfo> {
+  const now = Date.now();
+  const hit = sessionInfoCache.get(did);
+  if (hit && hit.expiresAt > now) return hit.value;
+
+  const value = await fetchAppviewSessionInfo(did);
+  if (value.checked) {
+    if (sessionInfoCache.size >= SESSION_INFO_MAX_ENTRIES) sessionInfoCache.clear();
+    sessionInfoCache.set(did, { expiresAt: now + SESSION_INFO_TTL_MS, value });
+  } else {
+    // Never let a blip mask a later definitive answer.
+    sessionInfoCache.delete(did);
+  }
+  return value;
 }
 
 /** Build an AppView-backed session for `did`. Structurally implements the

--- a/packages/console/src/lib/appview-backed-session.test.ts
+++ b/packages/console/src/lib/appview-backed-session.test.ts
@@ -7,7 +7,11 @@
 import type { Did } from "@atcute/lexicons";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { appviewBackedSession, appviewSessionInfo } from "./appview-backed-session.server.ts";
+import {
+  appviewBackedSession,
+  appviewSessionInfo,
+  resetAppviewSessionInfoCache,
+} from "./appview-backed-session.server.ts";
 
 const DID = "did:plc:abc123" as Did;
 const BASE = "http://appview.internal:8081";
@@ -45,12 +49,17 @@ function mockFetch(reply: { ok?: boolean; status?: number; json: unknown }) {
 beforeEach(() => {
   process.env["COCORE_APPVIEW_INTERNAL_URL"] = BASE;
   process.env["COCORE_INTERNAL_SECRET"] = SECRET;
+  // session-info is memoized per DID; every case here reuses DID, so without
+  // this the second case would read the first one's answer.
+  resetAppviewSessionInfoCache();
 });
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.useRealTimers();
   delete process.env["COCORE_APPVIEW_INTERNAL_URL"];
   delete process.env["COCORE_INTERNAL_SECRET"];
+  resetAppviewSessionInfoCache();
 });
 
 describe("AppviewBackedSession.handle", () => {
@@ -149,5 +158,89 @@ describe("appviewSessionInfo", () => {
     vi.stubGlobal("fetch", f);
     expect(await appviewSessionInfo(DID)).toEqual({ checked: false, present: false, aud: null });
     expect(f).not.toHaveBeenCalled();
+  });
+});
+
+describe("appviewSessionInfo memoization", () => {
+  it("asks the AppView once when the same DID is read twice", async () => {
+    // Rendering one signed-in page reads session-info twice: once for
+    // liveness in `atprotoSessionForRequestEffect`, once for `.aud` via
+    // `getPdsUrl` → `getTokenInfo()`. Both are serial and on the critical
+    // path, so the second was pure duplicated latency.
+    const calls = mockFetch({ json: { present: true, aud: "https://pds.example" } });
+
+    const first = await appviewSessionInfo(DID);
+    const second = await appviewSessionInfo(DID);
+
+    expect(calls).toHaveLength(1);
+    expect(first).toEqual({ checked: true, present: true, aud: "https://pds.example" });
+    expect(second).toEqual(first);
+  });
+
+  it("does not let one DID's answer serve another", async () => {
+    const calls = mockFetch({ json: { present: true, aud: "https://pds.example" } });
+
+    await appviewSessionInfo(DID);
+    await appviewSessionInfo("did:plc:someoneelse");
+
+    expect(calls).toHaveLength(2);
+  });
+
+  it("re-reads once the TTL lapses, so a dead session is still noticed", async () => {
+    vi.useFakeTimers();
+    const calls = mockFetch({ json: { present: true, aud: "https://pds.example" } });
+
+    await expect(appviewSessionInfo(DID)).resolves.toMatchObject({ present: true });
+    vi.advanceTimersByTime(5_001);
+    await appviewSessionInfo(DID);
+
+    expect(calls).toHaveLength(2);
+  });
+
+  it("never caches a transient failure, so a blip can't mask a live session", async () => {
+    // `checked: false` means "couldn't reach the AppView", which callers must
+    // not act on. Remembering it would strand the user on a non-answer.
+    let attempt = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        attempt += 1;
+        if (attempt === 1) throw new Error("ECONNREFUSED");
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ present: true, aud: "https://pds.example" }),
+        } as unknown as Response;
+      }),
+    );
+
+    await expect(appviewSessionInfo(DID)).resolves.toEqual({
+      checked: false,
+      present: false,
+      aud: null,
+    });
+    await expect(appviewSessionInfo(DID)).resolves.toMatchObject({ checked: true, present: true });
+    expect(attempt).toBe(2);
+  });
+
+  it("treats a non-OK AppView response as a blip, not a definitive absence", async () => {
+    let attempt = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        attempt += 1;
+        return attempt === 1
+          ? ({ ok: false, status: 503, json: async () => ({}) } as unknown as Response)
+          : ({
+              ok: true,
+              status: 200,
+              json: async () => ({ present: true, aud: "https://pds.example" }),
+            } as unknown as Response);
+      }),
+    );
+
+    await expect(appviewSessionInfo(DID)).resolves.toMatchObject({ checked: false });
+    await expect(appviewSessionInfo(DID)).resolves.toMatchObject({ checked: true });
+    expect(attempt).toBe(2);
   });
 });


### PR DESCRIPTION
Fix #1 from the signed-in latency investigation. Removes one of three serial cross-service hops on every signed-in page.

## The measurement

Timing routes against production while signed in:

| route | layout | time |
|---|---|---|
| `/docs` | `_docs-header-layout` — **resolves no session** | **247–319ms** (tight) |
| `/terms` | `_header-layout`, skips terms + fleet queries | **3672, 3710, 8227, 9799ms** |
| `/blog` | `_header-layout` | 6103, 8429ms |
| `/machines` | `_header-layout` + fleet | 2841–6360ms |

`/docs` proves the server, SSR, and the asset path are healthy. Everything under `_header-layout` pays seconds, and `/terms` skips both the terms-state and machines queries — so that cost is **session resolution alone**.

The upstreams are not the problem:

```
plc.directory        243ms
the user's PDS       235ms
```

## What this changes

`getSession` makes three serial cross-service round-trips, and two are the same call:

1. `atprotoSessionForRequestEffect` → `appviewSessionInfo(did)`
2. `ensureMyProfile` → `getRecord`, proxied through the AppView → PDS
3. `getPdsUrl` → `getTokenInfo()` → **`appviewSessionInfo(did)` again**, identical arguments

Memoize definitive answers per DID for 5s, collapsing 1 and 3.

The TTL is deliberately short — this read gates logging a user out, so it must not serve a stale `present` for long. A transient failure (`checked: false`, "couldn't reach the AppView") is **never** cached: callers may only act on `checked && !present`, and remembering a non-answer would strand the user on it.

## Tests

Five cases added to the existing file: dedup, per-DID isolation, TTL expiry still noticing a dead session, and both flavours of blip (transport throw, non-OK response) staying uncached. The existing suite needed a cache reset in `beforeEach` — every case reuses one DID, so without it one case would read the previous one's answer.

379 tests pass (374 + 5) · `format:check` clean · `typecheck` clean.

## This is not the root cause

It removes a duplicated hop, not the seconds. The real cost looks to be in the AppView: `internalProxyRoute` calls `restoreSession()` on **every** proxy call, and there is no caching around it anywhere. That path can resolve the DID document, fetch auth-server metadata, and refresh the token with a DPoP nonce handshake — which would explain both the magnitude and the bimodal distribution (~3.7s or ~8-10s, nothing between). Written up separately; the `appview.internal.pds.proxy` span already exists and should confirm it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)