### PR TITLE
obs(appview): time the OAuth session restore on PDS calls

### DIFF
--- a/packages/appview/src/pds/write.ts
+++ b/packages/appview/src/pds/write.ts
@@ -233,6 +233,40 @@ function parseDelete(b: Record<string, unknown>): DeleteArgs | string {
 interface PdsMeta {
   upstreamMs?: number;
   upstreamStatus?: number;
+  restoreMs?: number;
+}
+
+/** Slower than this and the restore almost certainly did network work — a DID
+ *  document resolve, an auth-server metadata fetch, or a token refresh with a
+ *  DPoP nonce handshake — rather than reading a still-valid stored token. */
+const SLOW_RESTORE_MS = 750;
+
+/** Time `restoreSession`, recording ms on `meta`.
+ *
+ *  Every proxied call restores before it can talk to the PDS, and nothing
+ *  caches that. `pds.upstream_ms` already isolates the PDS round-trip, so
+ *  without this the restore is invisible — folded into the span's total and
+ *  indistinguishable from our own overhead. Signed-in console pages were
+ *  measured at 3.7s best case and 8-10s worst, bimodal, against a PDS that
+ *  answers in ~235ms; this is the number that says whether restore explains
+ *  the gap. Observes only — behaviour is identical to calling it directly. */
+function timedRestore(ctx: PdsWriteContext, did: string, meta: PdsMeta) {
+  return Effect.gen(function* () {
+    const start = Date.now();
+    const restored = yield* Effect.tryPromise({
+      try: () => restoreSession(ctx.oauth, did as Did),
+      catch: (e) => e,
+    }).pipe(Effect.either);
+    const ms = Date.now() - start;
+    meta.restoreMs = ms;
+    yield* Effect.annotateCurrentSpan("pds.restore_ms", ms);
+    // Warn (not debug) so it lands in service logs without a trace backend
+    // attached — this is the live readout while we chase signed-in latency.
+    if (ms >= SLOW_RESTORE_MS) {
+      yield* logWarn("slow oauth session restore", { did, ms, outcome: restored._tag });
+    }
+    return restored;
+  });
 }
 
 /** Time one DPoP-authed call to the user's PDS, recording the upstream HTTP
@@ -417,6 +451,8 @@ function runCore(
           yield* Effect.annotateCurrentSpan("pds.upstream_ms", meta.upstreamMs);
         if (meta.upstreamStatus !== undefined)
           yield* Effect.annotateCurrentSpan("pds.upstream_status", meta.upstreamStatus);
+        if (meta.restoreMs !== undefined)
+          yield* Effect.annotateCurrentSpan("pds.restore_ms", meta.restoreMs);
       }),
     ),
   );
@@ -425,12 +461,9 @@ function runCore(
 /** Restore the session for `did`, or a non-2xx response: 401 when the
  *  session is simply gone, 502 when the restore itself throws (so a broken
  *  OAuth layer is a legible error, not an unhandled defect). */
-function sessionOr401(ctx: PdsWriteContext, did: string) {
+function sessionOr401(ctx: PdsWriteContext, did: string, meta: PdsMeta = {}) {
   return Effect.gen(function* () {
-    const restored = yield* Effect.tryPromise({
-      try: () => restoreSession(ctx.oauth, did as Did),
-      catch: (e) => e,
-    }).pipe(Effect.either);
+    const restored = yield* timedRestore(ctx, did, meta);
     if (restored._tag === "Left") {
       const e = restored.left;
       return {
@@ -470,7 +503,8 @@ function bearerRoute<A extends { collection: string }>(
     const resolved = ctx.accounts.resolveBearerKey(token);
     if (!resolved) return err(401, { error: "AuthRequired", message: "invalid API key" });
 
-    const session = yield* sessionOr401(ctx, resolved.did);
+    const meta: PdsMeta = {};
+    const session = yield* sessionOr401(ctx, resolved.did, meta);
     if (!session.ok) return session.res;
 
     const parsed = yield* Effect.either(jsonBody);
@@ -482,7 +516,6 @@ function bearerRoute<A extends { collection: string }>(
 
     yield* Effect.annotateCurrentSpan("pds.did", resolved.did);
     yield* Effect.annotateCurrentSpan("pds.collection", a.collection);
-    const meta: PdsMeta = {};
     return yield* runCore(op, meta, () => core(ctx, resolved.did, session.session, a, meta));
   }).pipe(Effect.withSpan(`appview.pds.${op}`));
 }
@@ -515,12 +548,12 @@ function internalRoute<A extends { collection: string }>(
     const a = parse(b);
     if (typeof a === "string") return err(400, { error: "InvalidRequest", message: a });
 
-    const session = yield* sessionOr401(ctx, did);
+    const meta: PdsMeta = {};
+    const session = yield* sessionOr401(ctx, did, meta);
     if (!session.ok) return session.res;
 
     yield* Effect.annotateCurrentSpan("pds.did", did);
     yield* Effect.annotateCurrentSpan("pds.collection", a.collection);
-    const meta: PdsMeta = {};
     return yield* runCore(op, meta, () => core(ctx, did, session.session, a, meta));
   }).pipe(Effect.withSpan(`appview.internal.pds.${op}`));
 }
@@ -607,10 +640,8 @@ function internalProxyRoute(ctx: PdsWriteContext, secret: string) {
     const a = parseProxy(parsed.right as Record<string, unknown>);
     if (typeof a === "string") return err(400, { error: "InvalidRequest", message: a });
 
-    const restored = yield* Effect.tryPromise({
-      try: () => restoreSession(ctx.oauth, a.did as Did),
-      catch: (e) => e,
-    }).pipe(Effect.either);
+    const meta: PdsMeta = {};
+    const restored = yield* timedRestore(ctx, a.did, meta);
     if (restored._tag === "Left") {
       const e = restored.left;
       return err(502, {
@@ -630,7 +661,6 @@ function internalProxyRoute(ctx: PdsWriteContext, secret: string) {
     const session = restored.right;
 
     yield* Effect.annotateCurrentSpan("pds.did", a.did);
-    const meta: PdsMeta = {};
     return yield* runCore("proxy", meta, async () => {
       const init = {
         method: a.method,


### PR DESCRIPTION
Instrumentation only — no behaviour change. This is the measurement that confirms or kills the leading theory for signed-in console latency.

## Why

Signed-in pages under `_header-layout` cost **3.7s at best, 8–10s at worst**, against **~285ms** for `/docs`, which uses a different layout and resolves no session. The upstreams are fast:

```
plc.directory        243ms
the user's PDS       235ms
```

`internalProxyRoute` calls `restoreSession()` on **every** proxy call, and nothing in the package caches it. `client.restore()` can resolve the DID document (the client is built with `CompositeDidDocumentResolver` over PLC + Web), fetch auth-server metadata, and refresh the access token with a DPoP nonce handshake — the last costing two round-trips when the nonce isn't cached.

That fits both the magnitude and, notably, the **bimodal** distribution: ~3.7s when the token is fresh, ~8–10s when a refresh and handshake are needed, nothing in between. Smooth contention wouldn't cluster like that.

But it's a theory. `pds.upstream_ms` already isolates the PDS round-trip, so the restore is currently invisible — folded into the span total and indistinguishable from our own overhead.

## What this adds

- `pds.restore_ms` on the span, at **both** restore sites: the internal proxy the console uses, and the bearer / internal write routes.
- A `logWarn` past 750ms, so the number is readable straight from service logs without a trace backend attached. That threshold is set where a restore has almost certainly done network work rather than read a still-valid stored token.
- `restoreMs` threaded through `PdsMeta` alongside the existing `upstreamMs` / `upstreamStatus`, annotated by `runCore` the same way.

`sessionOr401` takes an optional `meta` so the two write routes thread it too; both call sites hoist their existing `meta` above the restore. Default `{}` keeps the signature backward-compatible.

## Verification

`typecheck` clean · 131/131 appview tests pass · `format:check` clean.

## Next

Once this is deployed I'll read the live numbers and report back. If `restore_ms` is the seconds, the fix is caching the restored session per DID for a short TTL — which needs a deliberate look at the single-owner refresh invariant first, since refresh tokens are single-use. Caching the restored session object avoids redundant refreshes rather than adding a second refresher, but that's a claim worth checking against the invariant rather than assuming.

Related: #211 (removes a duplicated session-info hop on the console side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)