### PR TITLE
obs: time the console→appview hop and getSession stages

### DIFF
--- a/packages/appview/src/pds/write.ts
+++ b/packages/appview/src/pds/write.ts
@@ -238,8 +238,13 @@ interface PdsMeta {
 
 /** Slower than this and the restore almost certainly did network work — a DID
  *  document resolve, an auth-server metadata fetch, or a token refresh with a
- *  DPoP nonce handshake — rather than reading a still-valid stored token. */
-const SLOW_RESTORE_MS = 750;
+ *  DPoP nonce handshake — rather than reading a still-valid stored token.
+ *  Tunable without a deploy: set COCORE_SLOW_CALL_LOG_MS=0 to log every
+ *  restore while chasing a latency problem. */
+function slowRestoreThresholdMs(): number {
+  const raw = Number(process.env["COCORE_SLOW_CALL_LOG_MS"]);
+  return Number.isFinite(raw) && raw >= 0 ? raw : 750;
+}
 
 /** Time `restoreSession`, recording ms on `meta`.
  *
@@ -262,7 +267,7 @@ function timedRestore(ctx: PdsWriteContext, did: string, meta: PdsMeta) {
     yield* Effect.annotateCurrentSpan("pds.restore_ms", ms);
     // Warn (not debug) so it lands in service logs without a trace backend
     // attached — this is the live readout while we chase signed-in latency.
-    if (ms >= SLOW_RESTORE_MS) {
+    if (ms >= slowRestoreThresholdMs()) {
       yield* logWarn("slow oauth session restore", { did, ms, outcome: restored._tag });
     }
     return restored;

--- a/packages/console/src/integrations/auth/session.functions.ts
+++ b/packages/console/src/integrations/auth/session.functions.ts
@@ -9,7 +9,7 @@ import { readAllAuthSessionTokens } from "@/integrations/auth/cookie-parse.ts";
 import { ensureMyProfile } from "@/lib/account-profile.server.ts";
 import { deriveChatStorageKey } from "@/lib/chat-storage-key.server.ts";
 import { fetchBlueskyPublicProfileFieldsEffect } from "@/lib/bluesky-public-profile.server.ts";
-import { runTraced } from "@/lib/o11y.server.ts";
+import { runTraced, slowCallThresholdMs, warnFields } from "@/lib/o11y.server.ts";
 import { atprotoSessionForRequestEffect } from "@/middleware/auth.server.ts";
 
 const getSessionServerFn = createServerFn({ method: "GET" }).handler(() =>
@@ -17,7 +17,13 @@ const getSessionServerFn = createServerFn({ method: "GET" }).handler(() =>
     "auth.getSession",
     Effect.gen(function* () {
       const request = getRequest();
+      // Stage timings: signed-in pages measure 4-10s while every downstream
+      // we can see answers fast (PDS ~235ms, plc ~243ms, and the AppView's
+      // own handler timers stay under threshold). Splitting getSession into
+      // its two I/O stages says which one actually holds the time.
+      const sessionStart = Date.now();
       const ctx = yield* atprotoSessionForRequestEffect(request);
+      const sessionMs = Date.now() - sessionStart;
       if (!ctx) return null;
 
       // Prefer the user's cocore profile over their bsky profile so
@@ -28,10 +34,22 @@ const getSessionServerFn = createServerFn({ method: "GET" }).handler(() =>
       // forever. Wrap in `Either` so a profile-fetch failure (e.g.
       // legacy token missing the profile scope) falls back to the
       // bsky public profile instead of breaking the whole session.
+      const profileStart = Date.now();
       const cocoreEither = yield* Effect.either(
         Effect.tryPromise(() => ensureMyProfile(ctx.oauthSession)),
       );
+      const profileMs = Date.now() - profileStart;
       const cocore = Either.isRight(cocoreEither) ? cocoreEither.right : null;
+
+      const threshold = slowCallThresholdMs();
+      if (sessionMs + profileMs >= threshold) {
+        warnFields("slow getSession", {
+          did: ctx.did,
+          sessionMs,
+          profileMs,
+          totalMs: sessionMs + profileMs,
+        });
+      }
 
       // bsky is only ever a *fallback* for the three fields below, and
       // `ensureMyProfile` already provisions all of them from bsky on first

--- a/packages/console/src/lib/appview-backed-session.server.ts
+++ b/packages/console/src/lib/appview-backed-session.server.ts
@@ -23,6 +23,28 @@
 import type { Did } from "@atcute/lexicons";
 import type { OAuthSession } from "@atcute/oauth-node-client";
 
+import { slowCallThresholdMs, warnFields } from "@/lib/o11y.server.ts";
+
+/** Time one console→AppView call and log it when slow.
+ *
+ *  The AppView already records its own handler time (`pds.restore_ms`,
+ *  `pds.upstream_ms`), and both come back fast while signed-in pages take
+ *  seconds. That leaves a gap neither side measures: the round-trip over
+ *  Railway internal networking, plus any queueing before the handler runs.
+ *  This closes it by timing from the caller — `ms` here minus the AppView's
+ *  own handler time IS that gap. */
+async function timedInternalCall<T>(op: string, did: string, run: () => Promise<T>): Promise<T> {
+  const start = Date.now();
+  try {
+    return await run();
+  } finally {
+    const ms = Date.now() - start;
+    if (ms >= slowCallThresholdMs()) {
+      warnFields("slow console→appview call", { op, did, ms });
+    }
+  }
+}
+
 function base(): string | null {
   return process.env["COCORE_APPVIEW_INTERNAL_URL"]?.replace(/\/$/, "") || null;
 }
@@ -82,18 +104,20 @@ class AppviewBackedSession {
       else bodyText = String(body);
     }
 
-    const res = await fetch(`${b}/internal/pds/proxy`, {
-      method: "POST",
-      headers: { "content-type": "application/json", "x-cocore-internal-secret": s },
-      body: JSON.stringify({
-        did: this.did,
-        path,
-        method,
-        ...(bodyText !== undefined ? { bodyText } : {}),
-        ...(blobB64 !== undefined ? { blobB64 } : {}),
-        ...(contentType ? { contentType } : {}),
+    const res = await timedInternalCall("proxy", this.did, () =>
+      fetch(`${b}/internal/pds/proxy`, {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-cocore-internal-secret": s },
+        body: JSON.stringify({
+          did: this.did,
+          path,
+          method,
+          ...(bodyText !== undefined ? { bodyText } : {}),
+          ...(blobB64 !== undefined ? { blobB64 } : {}),
+          ...(contentType ? { contentType } : {}),
+        }),
       }),
-    });
+    );
     if (!res.ok) {
       // Internal-layer failure (403 secret / 502 restore-threw / network):
       // a real transport problem, not an upstream PDS status. Throw so the
@@ -149,9 +173,11 @@ async function fetchAppviewSessionInfo(did: string): Promise<AppviewSessionInfo>
   const s = secret();
   if (!b || !s) return { checked: false, present: false, aud: null };
   try {
-    const res = await fetch(`${b}/internal/pds/session-info?did=${encodeURIComponent(did)}`, {
-      headers: { "x-cocore-internal-secret": s },
-    });
+    const res = await timedInternalCall("session-info", did, () =>
+      fetch(`${b}/internal/pds/session-info?did=${encodeURIComponent(did)}`, {
+        headers: { "x-cocore-internal-secret": s },
+      }),
+    );
     if (!res.ok) return { checked: false, present: false, aud: null };
     const body = (await res.json()) as { present?: boolean; aud?: string | null };
     return { checked: true, present: body.present === true, aud: body.aud ?? null };

--- a/packages/console/src/lib/o11y.server.ts
+++ b/packages/console/src/lib/o11y.server.ts
@@ -9,7 +9,13 @@
 // This is `.server.ts` so the runtime (and the OTel SDK it pulls in)
 // never reaches the client bundle.
 
-import { makeRuntime, runTraced as runTracedWith, type SpanAttributes } from "@cocore/o11y";
+import {
+  logWarn,
+  makeRuntime,
+  record,
+  runTraced as runTracedWith,
+  type SpanAttributes,
+} from "@cocore/o11y";
 import type { Effect } from "effect";
 
 import { AppviewClient } from "@/integrations/appview/appview.server.ts";
@@ -69,4 +75,19 @@ export function runTraced<A, E>(
   attributes?: SpanAttributes,
 ): Promise<A> {
   return runTracedWith(runtime, name, effect, attributes);
+}
+
+/** Emit a structured warning from plain async code (no Effect context).
+ *  `logWarn` returns an Effect, so callers outside an effect need the
+ *  runtime to run it; this is that seam. */
+export function warnFields(message: string, fields: Record<string, string | number | boolean>) {
+  record(runtime, logWarn(message, fields));
+}
+
+/** A call slower than this almost certainly did real network work rather
+ *  than hitting a warm path. Tunable without a deploy so the threshold can
+ *  be dropped to 0 to capture every call while chasing a latency problem. */
+export function slowCallThresholdMs(): number {
+  const raw = Number(process.env["COCORE_SLOW_CALL_LOG_MS"]);
+  return Number.isFinite(raw) && raw >= 0 ? raw : 750;
 }


### PR DESCRIPTION
Instrumentation only — no behaviour change. Follow-up to #212, which **disproved** the theory it was built to test.

## What #212 ruled out

Three signed-in `/terms` loads measuring **4.5–6.1s** produced **zero** slow-restore warnings at a 750ms threshold.

That silence is meaningful, not just absent data — `logWarn` is proven to reach Railway stdout, with an unrelated WARN landing at 16:00:52 right after that traffic:

```
16:00:52.506  level=WARN  message="appview→bridge mirror publish failed; relying on relay…"
```

I also confirmed I was reading the right service: the console's `COCORE_APPVIEW_INTERNAL_URL = http://services.railway.internal:8081` resolves to the AppView's own `RAILWAY_PRIVATE_DOMAIN`, so there's no second service in the path I was missing.

**`restoreSession` is not where the time goes.** Every downstream we can see is fast:

```
plc.directory        243ms
the user's PDS       235ms
AppView restore      < 750ms (no warns fired)
```

## The gap this closes

`pds.restore_ms` and `pds.upstream_ms` both time work **inside** the AppView handler. Neither covers:

- the console→AppView round-trip over Railway internal networking
- any queueing before the handler starts

That gap is now the leading candidate, and nothing measures it today.

This times both console→AppView calls (`proxy` and `session-info`) **from the caller**, so *caller ms minus the AppView's own handler ms* is precisely that gap. It also splits `getSession` into its two I/O stages — session resolution vs profile fetch — so we can see which one holds the time rather than inferring it from route comparisons.

## Tunable without redeploying

Both thresholds (console and AppView) now read `COCORE_SLOW_CALL_LOG_MS`, defaulting to 750. Setting it to `0` logs every call, so the next round of narrowing is an env change rather than another deploy.

## Verification

379/379 console tests · 131/131 appview tests · both packages typecheck clean · `format:check` clean.

Related: #211, #212.

🤖 Generated with [Claude Code](https://claude.com/claude-code)