### PR TITLE
perf(console): stop the fleet query gating every signed-in page

### DIFF
--- a/packages/console/src/routes/_header-layout.tsx
+++ b/packages/console/src/routes/_header-layout.tsx
@@ -102,21 +102,25 @@ export const Route = createFileRoute("/_header-layout")({
       });
     }
   },
-  loader: ({ context }) => {
-    // `beforeLoad` already awaited the session, so this is a cache read.
-    const session = context.queryClient.getQueryData(getSessionQueryOptions.queryKey);
-    if (!session) return;
-    // Start the fleet query but deliberately do NOT await it. This layout
-    // wraps every page in the app, so awaiting here held the whole SSR
-    // response — docs, blog, chat, everything — behind an AppView
-    // listProviders + receipts + advisor round-trip. The only thing it
-    // feeds is the machine-count badge in the navbar, which renders fine
-    // as absent; `setupRouterSsrQueryIntegration` streams the result into
-    // the dehydrated cache, so the badge fills in when the data lands.
-    // `prefetchQuery` (not `ensureQueryData`) so a failure resolves rather
-    // than becoming an unhandled rejection with nothing to catch it.
-    void context.queryClient.prefetchQuery(listMyMachinesQueryOptions);
-  },
+  // NO loader. The fleet query used to be started here, and starting it at
+  // all — even unawaited — is what made every signed-in page slow.
+  //
+  // `setupRouterSsrQueryIntegration` streams in-flight queries as part of the
+  // dehydrated cache, which means the SSR response STAYS OPEN until they
+  // settle. So an unawaited `prefetchQuery` still gated the full body; it
+  // only moved the cost off time-to-first-byte, where it was invisible.
+  // Measured on /terms, which renders identically either way:
+  //
+  //   logged out                    total 0.32-0.45s
+  //   logged in, prefetch here      TTFB 0.15-0.29s, full body 6.5-7.6s
+  //
+  // Same HTML, same route; the whole gap is the stream waiting on this one
+  // query. It feeds a machine-count badge in the navbar.
+  //
+  // `HeaderLayoutChrome` already reads it through `useQuery(..., { enabled })`,
+  // which does not fetch during SSR, so dropping the loader moves the fetch
+  // to after hydration: the badge appears a beat later and the document stops
+  // waiting on the AppView.
   component: HeaderLayoutChrome,
 });
 


### PR DESCRIPTION
This is the cause of signed-in slowness. It hid behind time-to-first-byte, including from my own earlier fix.

## The measurement

Same route, rendered identically, differing only in whether a session exists:

| `/terms` | TTFB | full body |
|---|---|---|
| logged **out** | ~0.23s | **0.32–0.45s** |
| logged **in** | 0.15–0.29s | **6.5–7.6s** |

The document starts streaming as fast as a page with no session at all, then hangs for six or seven seconds.

## Why #211's fix wasn't enough

`setupRouterSsrQueryIntegration` streams in-flight queries as part of the dehydrated cache, which means **the SSR response stays open until they settle**. So switching from `await ensureQueryData` to `void prefetchQuery` didn't remove the cost — it moved it off TTFB, where nothing was measuring it. The full body was still gated.

I was measuring with `fetch()` + `await r.text()`, which reads the whole body, so the number never improved and I kept looking upstream for a culprit that wasn't there. Splitting first-byte from full-body is what exposed it.

## The fix

Drop the loader entirely. `HeaderLayoutChrome` already reads the query through `useQuery(..., { enabled: Boolean(session) })`, which does not fetch during SSR — so the fetch moves to after hydration. The machine-count badge in the navbar appears a beat later, and the document stops waiting on an AppView `listProviders` + receipts + advisor round-trip.

## What this displaces

Three theories, each measured and eliminated rather than assumed:

```
session resolution (console)     6ms      ← after #211's dedup
OAuth restore (appview)          0-5ms    ← #212/#213 instrumentation, threshold 0
plc.directory                    243ms
the user's PDS                   235ms
```

None of them were ever the problem. The instrumentation from #212/#213 is what let me rule them out, and it stays in — `COCORE_SLOW_CALL_LOG_MS` is still the knob.

## Follow-up worth doing separately

`listMyMachines` takes ~5s. It's off the critical path now, but the navbar badge still waits on it client-side, and it calls `appviewListProviders` — which lists **every** provider and filters to yours. A `getProvidersByDid` would fix that properly.

## Verification

`typecheck` clean · 379/379 tests · `format:check` clean.

Related: #211, #212, #213.

🤖 Generated with [Claude Code](https://claude.com/claude-code)