### PR TITLE
perf(appview): stop listAccounts scanning friends per row

### DIFF
--- a/packages/appview/src/api/server.test.ts
+++ b/packages/appview/src/api/server.test.ts
@@ -604,6 +604,65 @@ test("listAccounts excludeViewerFriends omits DIDs the viewer has friended", asy
   );
 });
 
+test("listAccounts excludeViewerFriends with NO friends still returns everyone", async () => {
+  // The friend set is now read up front and turned into a literal `NOT IN`
+  // list, so the empty case has to skip the clause entirely — an empty
+  // `NOT IN ()` is a SQL syntax error, and emitting `NOT IN (NULL)` would
+  // silently match nothing and blank the directory.
+  await withAccountsStore(
+    [{ did: "did:plc:alice" }, { did: "did:plc:bob" }, { did: "did:plc:carol" }],
+    async (base) => {
+      const r = await fetch(
+        `${base}/xrpc/dev.cocore.account.listAccounts?viewerDid=${encodeURIComponent("did:plc:alice")}&excludeViewerFriends=true`,
+      );
+      const body = (await r.json()) as { accounts: AccountSummaryWire[]; total: number };
+      // alice is excluded as the viewer; bob and carol remain.
+      assert.equal(body.total, 2);
+      assert.deepEqual(body.accounts.map((a) => a.did).sort(), ["did:plc:bob", "did:plc:carol"]);
+    },
+    [],
+  );
+});
+
+test("listAccounts excludeViewerFriends excludes every friend, not just the first", async () => {
+  await withAccountsStore(
+    [
+      { did: "did:plc:alice" },
+      { did: "did:plc:bob" },
+      { did: "did:plc:carol" },
+      { did: "did:plc:dave" },
+    ],
+    async (base) => {
+      const r = await fetch(
+        `${base}/xrpc/dev.cocore.account.listAccounts?viewerDid=${encodeURIComponent("did:plc:alice")}&excludeViewerFriends=true`,
+      );
+      const body = (await r.json()) as { accounts: AccountSummaryWire[]; total: number };
+      assert.equal(body.total, 1);
+      assert.equal(body.accounts[0]!.did, "did:plc:dave");
+    },
+    [
+      { friender: "did:plc:alice", subject: "did:plc:bob" },
+      { friender: "did:plc:alice", subject: "did:plc:carol" },
+    ],
+  );
+});
+
+test("listAccounts excludeViewerFriends ignores OTHER people's friend records", async () => {
+  // The pre-read is scoped by repo; a friend edge owned by someone else must
+  // not filter the viewer's directory.
+  await withAccountsStore(
+    [{ did: "did:plc:alice" }, { did: "did:plc:bob" }, { did: "did:plc:carol" }],
+    async (base) => {
+      const r = await fetch(
+        `${base}/xrpc/dev.cocore.account.listAccounts?viewerDid=${encodeURIComponent("did:plc:alice")}&excludeViewerFriends=true`,
+      );
+      const body = (await r.json()) as { accounts: AccountSummaryWire[]; total: number };
+      assert.equal(body.total, 2);
+    },
+    [{ friender: "did:plc:bob", subject: "did:plc:carol" }],
+  );
+});
+
 test("listAccounts providersOnly=true filters to DIDs with provider records", async () => {
   await withAccountsStore(
     [

--- a/packages/appview/src/store.ts
+++ b/packages/appview/src/store.ts
@@ -344,6 +344,32 @@ export class Store {
     return r.changes;
   }
 
+  /** DIDs the viewer has friended — the `subject` of every
+   *  `dev.cocore.account.friend` record in their own repo.
+   *
+   *  Pulled out so {@link listAccounts} can exclude them with a literal set
+   *  instead of a correlated subquery that JSON-parses the viewer's friend
+   *  records once per candidate row. Scoped by `repo` + `collection`, both of
+   *  which the records table indexes, so this is a small indexed read no
+   *  matter how large the directory grows. Rows with a malformed or missing
+   *  `subject` are skipped rather than yielding nulls into the filter. */
+  listViewerFriendSubjects(viewerDid: string): string[] {
+    if (!viewerDid) return [];
+    const rows = this.db
+      .prepare(
+        `SELECT json_extract(body, '$.subject') AS subject
+           FROM records
+          WHERE repo = ?
+            AND collection = 'dev.cocore.account.friend'`,
+      )
+      .all(viewerDid) as Array<{ subject: unknown }>;
+    const out: string[] = [];
+    for (const r of rows) {
+      if (typeof r.subject === "string" && r.subject.length > 0) out.push(r.subject);
+    }
+    return out;
+  }
+
   upsert(rec: Omit<IndexedRecord, "indexedAt">): void {
     // Version guard: never let a stale, out-of-order, or replayed ingest
     // clobber a newer record body. The AppView is a cache the dashboard
@@ -478,15 +504,29 @@ export class Store {
       params.push(viewerDid);
     }
     if (excludeViewerFriends) {
-      filterClauses.push(
-        `NOT EXISTS (
-          SELECT 1 FROM records fr
-          WHERE fr.repo = ?
-            AND fr.collection = 'dev.cocore.account.friend'
-            AND json_extract(fr.body, '$.subject') = m.repo
-        )`,
-      );
-      params.push(viewerDid);
+      // Read the viewer's friend DIDs ONCE, then filter with a literal set.
+      //
+      // This used to be a correlated `NOT EXISTS` subquery running
+      // `json_extract(fr.body, '$.subject')` per candidate row. There is no
+      // index on the extracted field, so SQLite re-scanned the viewer's friend
+      // records and JSON-parsed each one for every member in the directory —
+      // O(members x friends) with a parse per pair. `better-sqlite3` is
+      // synchronous, so that pinned the AppView's single event loop for the
+      // whole query, and every other request (down to the trivial
+      // `session-info` read) queued behind it. Measured on production:
+      // listAccounts went from 0.64s to 19.5s purely by adding
+      // `excludeViewerFriends=true&viewerDid=...`, and /friends issues four of
+      // these concurrently.
+      //
+      // A viewer's friend list is small and bounded, so one query up front is
+      // strictly cheaper than a per-row subquery, and the JSON parsing happens
+      // once per friend instead of once per (member, friend) pair.
+      const friendDids = this.listViewerFriendSubjects(viewerDid);
+      if (friendDids.length > 0) {
+        filterClauses.push(`m.repo NOT IN (${friendDids.map(() => "?").join(",")})`);
+        params.push(...friendDids);
+      }
+      // No friends → nothing to exclude, so no clause at all.
     }
     if (providersOnly) {
       filterClauses.push("pc.providerCount > 0");


### PR DESCRIPTION
The cause of signed-in console latency — and it stalls far more than the one endpoint it lives in.

## The query

`excludeViewerFriends` was a correlated subquery:

```sql
NOT EXISTS (
  SELECT 1 FROM records fr
  WHERE fr.repo = ?
    AND fr.collection = 'dev.cocore.account.friend'
    AND json_extract(fr.body, '$.subject') = m.repo
)
```

Nothing indexes the extracted field, so SQLite re-scanned the viewer's friend records and JSON-parsed each one **once per member in the directory** — O(members × friends) with a parse per pair, and again for the COUNT.

## Why it hurt the whole product

`better-sqlite3` is **synchronous**. This pinned the AppView's single event loop for the duration of the query, so every other request queued behind it — down to `/internal/pds/session-info`, which is one indexed SQLite read and was measured at **10–21 seconds** while this ran.

That resolves three things that made this hard to find:

- **The AppView looked healthy when probed directly** (~340ms, even at 6× concurrency) — those probes landed between `/friends` queries.
- **CPU averages looked mild** (0.12–0.28) — an event-loop stall doesn't show up in a 60-second mean.
- **Every signed-in route was slow, not just `/friends`** — one person loading `/friends` stalled the AppView for everyone.

## Measured on production

Same endpoint, only the viewer params differing:

```
listAccounts                                    0.64s
+ excludeViewerFriends=true&viewerDid=...       19.50s
```

`/friends` issues **four** of these concurrently. The console times out at 6s and retries three times — piling more load onto the already-stalled loop — for a page TTFB of 19,431ms, right on the 18,750ms retry ceiling.

The per-attempt instrumentation from #215 is what pinned it down. The shape was unambiguous:

```
listProviders   13ms, 37ms                      ok-200
listAccounts    6001,6004,6005,6005,6002,...    ALL timeout, phase=headers
```

Same origin, same connection pool, concurrent — which also killed the pooling theory outright, since a stale socket recovers on retry and this never did.

## The change

Read the viewer's friend DIDs once through an indexed `repo` + `collection` lookup, then filter with a literal `NOT IN` set. JSON parsing happens once per friend instead of once per (member, friend) pair, and a viewer's friend list is small and bounded.

## Tests

Three added alongside the existing behaviour test:

- **no friends** → returns everyone. This is the case my change introduces: an empty `NOT IN ()` is a SQL syntax error, and `NOT IN (NULL)` would silently blank the directory. The clause is skipped entirely.
- **multiple friends** → all excluded, not just the first.
- **someone else's friend edges** → ignored, confirming the pre-read stays scoped by `repo`.

134/134 appview tests · `typecheck` clean · `format:check` clean.

## Still open after this

`hydrateDids` makes a live `public.api.bsky.app` call per un-hydrated DID with unbounded concurrency, on the request path — an 8s+ cold cost after every AppView restart. And the console's 6s timeout is shorter than that cold latency, so it can never succeed cold, it just retries and adds load. Both worth fixing separately.

Related: #211, #212, #213, #214, #215.

🤖 Generated with [Claude Code](https://claude.com/claude-code)