### PR TITLE
perf(console): cache attestation pubkeys, trim the friends loader

### DIFF
--- a/packages/console/src/lib/machine-attribution.server.ts
+++ b/packages/console/src/lib/machine-attribution.server.ts
@@ -19,11 +19,53 @@ interface ListRecordsResponse {
  *  the recent windows the dashboard shows. */
 const MAX_PAGES = 10;
 
+/**
+ * Cached pubkey maps, keyed by DID.
+ *
+ * Paging this is expensive in a way that is easy to miss: each page is a
+ * `listRecords` call proxied through the AppView to the user's PDS, and they
+ * are strictly SEQUENTIAL because each needs the previous page's cursor. An
+ * account with 100+ attestations therefore pays up to MAX_PAGES round-trips —
+ * measured at 200-500ms each on /machines, so seconds of the page's TTFB, on
+ * every single load.
+ *
+ * Caching is safe here because this is a best-effort REFINEMENT: it upgrades
+ * per-machine earnings from an even split to real attribution. A slightly
+ * stale map attributes a few recent receipts to the even-split fallback,
+ * which is exactly what happens today when the fetch fails. It is not
+ * authoritative for anything — the receipts themselves are.
+ *
+ * Attestations are append-mostly (one per serve session), so a short TTL
+ * keeps a busy dashboard responsive while still picking up new machines
+ * within a few minutes.
+ */
+const PUBKEY_CACHE_TTL_MS = 5 * 60_000;
+const pubkeyCache = new Map<string, { at: number; value: Map<string, string> }>();
+
+/** Test seam: drop cached maps so cases don't leak into each other. */
+export function resetAttestationPubkeyCache(): void {
+  pubkeyCache.clear();
+}
+
 /** Map each of the signed-in user's `dev.cocore.compute.attestation`
  *  records to its `publicKey`. Best-effort: returns whatever it gathered
  *  (possibly empty) on any error, and the caller falls back to the even
- *  split when the map can't attribute the receipts. */
+ *  split when the map can't attribute the receipts. Cached per DID for
+ *  {@link PUBKEY_CACHE_TTL_MS}. */
 export async function fetchAttestationPubkeys(session: OAuthSession): Promise<Map<string, string>> {
+  const cached = pubkeyCache.get(session.did);
+  if (cached && Date.now() - cached.at <= PUBKEY_CACHE_TTL_MS) return cached.value;
+  const fetched = await fetchAttestationPubkeysUncached(session);
+  // Don't cache an empty map: that's the shape returned on error, and
+  // remembering it would suppress attribution for the whole TTL after one
+  // transient blip.
+  if (fetched.size > 0) pubkeyCache.set(session.did, { at: Date.now(), value: fetched });
+  return fetched;
+}
+
+async function fetchAttestationPubkeysUncached(
+  session: OAuthSession,
+): Promise<Map<string, string>> {
   const out = new Map<string, string>();
   let cursor: string | undefined;
   try {

--- a/packages/console/src/lib/machine-attribution.test.ts
+++ b/packages/console/src/lib/machine-attribution.test.ts
@@ -1,0 +1,84 @@
+import type { OAuthSession } from "@atcute/oauth-node-client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  fetchAttestationPubkeys,
+  resetAttestationPubkeyCache,
+} from "@/lib/machine-attribution.server.ts";
+
+/** Minimal stand-in for the session: the module only uses `.did` and
+ *  `.handle`. Counts calls so we can assert on round-trips, which is the
+ *  whole point — each one is a listRecords page proxied to the user's PDS. */
+function fakeSession(did: string, pages: Array<{ records: unknown[]; cursor?: string }>) {
+  let calls = 0;
+  const session = {
+    did,
+    handle: (_path: string) => {
+      const page = pages[Math.min(calls, pages.length - 1)];
+      calls += 1;
+      return Promise.resolve(
+        new Response(JSON.stringify(page), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    },
+  };
+  return { session: session as unknown as OAuthSession, calls: () => calls };
+}
+
+const rec = (uri: string, publicKey: string) => ({ uri, value: { publicKey } });
+
+describe("fetchAttestationPubkeys", () => {
+  beforeEach(() => resetAttestationPubkeyCache());
+  afterEach(() => resetAttestationPubkeyCache());
+
+  it("maps attestation URIs to their publicKey", async () => {
+    const { session } = fakeSession("did:plc:a", [{ records: [rec("at://a/1", "pk-1")] }]);
+    const out = await fetchAttestationPubkeys(session);
+    expect(out.get("at://a/1")).toBe("pk-1");
+  });
+
+  it("does not re-page the PDS on a second call for the same DID", async () => {
+    // Pages are strictly sequential (each needs the previous cursor), so an
+    // account with 100+ attestations paid up to 10 proxied round-trips on
+    // EVERY /machines load. That was seconds of the page's TTFB.
+    const { session, calls } = fakeSession("did:plc:a", [{ records: [rec("at://a/1", "pk-1")] }]);
+    await fetchAttestationPubkeys(session);
+    const before = calls();
+    const second = await fetchAttestationPubkeys(session);
+    expect(calls()).toBe(before);
+    expect(second.get("at://a/1")).toBe("pk-1");
+  });
+
+  it("caches per DID, so one user's map never serves another", async () => {
+    const a = fakeSession("did:plc:a", [{ records: [rec("at://a/1", "pk-a")] }]);
+    const b = fakeSession("did:plc:b", [{ records: [rec("at://b/1", "pk-b")] }]);
+    await fetchAttestationPubkeys(a.session);
+    const outB = await fetchAttestationPubkeys(b.session);
+    expect(outB.get("at://b/1")).toBe("pk-b");
+    expect(outB.has("at://a/1")).toBe(false);
+    expect(b.calls()).toBe(1);
+  });
+
+  it("never caches an empty map, so one blip can't suppress attribution", async () => {
+    // An empty map is also the error shape. Remembering it would fall the
+    // dashboard back to the even split for the whole TTL after a single
+    // transient failure.
+    const { session, calls } = fakeSession("did:plc:a", [{ records: [] }]);
+    await fetchAttestationPubkeys(session);
+    const after = calls();
+    await fetchAttestationPubkeys(session);
+    expect(calls()).toBeGreaterThan(after);
+  });
+
+  it("follows the cursor across pages", async () => {
+    const { session } = fakeSession("did:plc:a", [
+      { records: [rec("at://a/1", "pk-1")], cursor: "c1" },
+      { records: [rec("at://a/2", "pk-2")] },
+    ]);
+    const out = await fetchAttestationPubkeys(session);
+    expect(out.get("at://a/1")).toBe("pk-1");
+    expect(out.get("at://a/2")).toBe("pk-2");
+  });
+});

--- a/packages/console/src/routes/_header-layout.friends.tsx
+++ b/packages/console/src/routes/_header-layout.friends.tsx
@@ -2,10 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 
 import { FriendsPage } from "@/components/friends/FriendsPage.tsx";
 import {
-  friendsDiscoverNewestFirstPageQueryOptions,
-  friendsDiscoverNewestProvidersFirstPageQueryOptions,
   friendsDiscoverRecentFirstPageQueryOptions,
-  friendsDiscoverRecentProvidersFirstPageQueryOptions,
   listMyFriendsQueryOptions,
 } from "@/components/friends/friends.functions.ts";
 import { authMiddleware } from "@/middleware/auth.ts";
@@ -16,9 +13,24 @@ export const Route = createFileRoute("/_header-layout/friends")({
   },
   loader: async ({ context }) => {
     const qc = context.queryClient;
-    void qc.prefetchQuery(friendsDiscoverNewestFirstPageQueryOptions);
-    void qc.prefetchQuery(friendsDiscoverRecentProvidersFirstPageQueryOptions);
-    void qc.prefetchQuery(friendsDiscoverNewestProvidersFirstPageQueryOptions);
+    // Load ONLY the two lists the page shows on arrival.
+    //
+    // The other three were `void prefetchQuery` for the sort/filter tabs the
+    // user hasn't clicked yet. Unawaited is not free: the SSR query
+    // integration streams in-flight queries as part of the dehydrated cache,
+    // so the response stays open until they settle — the same trap that made
+    // every signed-in page slow before it was removed from `_header-layout`.
+    //
+    // Worse here, because all five are `listAccounts` against the AppView,
+    // which serves them with synchronous SQLite. Firing four at once does not
+    // overlap; they serialize on its event loop, measured at 0.36 / 0.60 /
+    // 0.79 / 0.99s for the same query that takes 0.35s alone. So the tabs the
+    // user may never open were making the tab they DID open three times
+    // slower, and holding the document until all of them finished.
+    //
+    // The tab queries stay declared in the components, which fetch them on
+    // click through react-query — a beat of loading state on a tab switch, in
+    // exchange for a page that arrives.
     await Promise.all([
       qc.ensureQueryData(listMyFriendsQueryOptions),
       qc.ensureQueryData(friendsDiscoverRecentFirstPageQueryOptions),


### PR DESCRIPTION
The two signed-in pages still slow after #216. Different causes, both found by reading the per-attempt instrumentation rather than guessing.

## What the logs showed

Driving `/machines` then `/friends` and correlating against the deployed timing:

```
/machines : AppView reads all FAST (10-23ms)
            but ~15 op=proxy hops — 514, 475, 246, 224, 216, 213, 210, 209,
            204, 187, 1366ms ...
/friends  : 4x listAccounts — 511, 753, 971, 1177ms (increasing = queuing)
```

Two completely different problems wearing the same symptom.

## /machines — serial PDS paging, uncached

`fetchAttestationPubkeys` pages `listRecords` 100 at a time, and the pages are **strictly sequential** because each needs the previous cursor. Each page is proxied through the AppView to the user's PDS at 200-500ms. This account has ≥100 attestations, so it paid up to **10 serial round-trips on every load** — most of the page's TTFB.

Cached per DID for 5 minutes.

This is safe to cache because it's a best-effort **refinement**: it upgrades per-machine earnings from an even split to real attribution. A slightly stale map attributes a few recent receipts to the even-split fallback — exactly what already happens when the fetch fails. It is not authoritative for anything; the receipts are.

An **empty map is never cached**, because that's also the error shape — remembering it would suppress attribution for the whole TTL after one transient blip. Covered by a test.

## /friends — prefetching tabs nobody clicked

The loader fired three `void prefetchQuery` calls for sort/filter tabs the user hasn't touched. Unawaited is not free: the SSR query integration streams in-flight queries, so the response stays open until they settle — the same trap removed from `_header-layout` in #214.

Worse here, because all five are `listAccounts`, which the AppView serves with synchronous SQLite. Firing four concurrently doesn't overlap — they serialize:

```
alone            0.35s
4 concurrent     0.36 / 0.60 / 0.79 / 0.99s
```

So tabs the user may never open were making the tab they *did* open three times slower, and holding the document until all of them finished.

**The default view is unchanged.** The component's default filters (`sortBy: recent`, `providersOnly: false`, `offset: 0`) are exactly the query the loader still awaits, so the landing tab is still server-rendered. Only unclicked tabs move to fetch-on-click — a beat of loading state on a tab switch, in exchange for a page that arrives. I verified this against `DiscoverFriendsCard`'s `useState` defaults rather than assuming it.

## Tests

Five added for the attestation cache: maps URIs to keys, doesn't re-page on a second call, caches per DID (one user's map never serves another), never caches an empty map, and still follows the cursor across pages.

384/384 console tests · `typecheck` clean · `format:check` clean.

## Still open

`hydrateDids` makes unbounded live `public.api.bsky.app` calls on the request path — 8s+ cold after every AppView restart. And the console's 6s AppView timeout is shorter than that cold latency, so it can't succeed cold, it just retries and adds load. Also the React #418 hydration hazard on `/machines`.

Related: #214, #215, #216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)