### PR TITLE
fix(lexicons): accept the two-letter CC currency code so verifyReceipt stops rejecting every receipt

### DIFF
--- a/lexicons/dev/cocore/compute/defs.json
+++ b/lexicons/dev/cocore/compute/defs.json
@@ -15,9 +15,9 @@
         },
         "currency": {
           "type": "string",
-          "minLength": 3,
+          "minLength": 2,
           "maxLength": 8,
-          "description": "Uppercase currency code."
+          "description": "Uppercase currency code: `CC` for co/core credits, or an ISO 4217 code."
         }
       }
     },
@@ -48,8 +48,9 @@
         },
         "currency": {
           "type": "string",
-          "minLength": 3,
-          "maxLength": 8
+          "minLength": 2,
+          "maxLength": 8,
+          "description": "Uppercase currency code: `CC` for co/core credits, or an ISO 4217 code."
         }
       }
     },
@@ -70,8 +71,9 @@
         },
         "currency": {
           "type": "string",
-          "minLength": 3,
-          "maxLength": 8
+          "minLength": 2,
+          "maxLength": 8,
+          "description": "Uppercase currency code: `CC` for co/core credits, or an ISO 4217 code."
         }
       }
     },

--- a/lexicons/dev/cocore/compute/exchangePolicy.json
+++ b/lexicons/dev/cocore/compute/exchangePolicy.json
@@ -29,7 +29,7 @@
             "type": "array",
             "minLength": 1,
             "maxLength": 32,
-            "items": { "type": "string", "minLength": 3, "maxLength": 8 },
+            "items": { "type": "string", "minLength": 2, "maxLength": 8 },
             "description": "ISO 4217 (or XBT/XSAT-style) currency codes the exchange will settle in."
           },
           "selfLoop": {
@@ -104,7 +104,7 @@
         },
         "currency": {
           "type": "string",
-          "minLength": 3,
+          "minLength": 2,
           "maxLength": 8,
           "description": "Currency the fee schedule is denominated in."
         }

--- a/packages/appview/src/api/read-router-bytes.test.ts
+++ b/packages/appview/src/api/read-router-bytes.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { decodeBytesFields } from "./read-router.ts";
+
+describe("decodeBytesFields (verifyReceipt lexicon pass)", () => {
+  it("decodes every bytes field of a receipt, including the brokerage witness sig", () => {
+    const sig = Buffer.from([1, 2, 3]).toString("base64");
+    const out = decodeBytesFields({
+      enclaveSignature: sig,
+      price: { amount: 2100, currency: "CC" },
+      brokerageCountersignature: {
+        authority: "did:web:advisor.cocore.dev",
+        machineId: "m1",
+        nonce: "n",
+        sig,
+      },
+    });
+    expect(out["enclaveSignature"]).toEqual(Uint8Array.from([1, 2, 3]));
+    const cs = out["brokerageCountersignature"] as Record<string, unknown>;
+    expect(cs["sig"]).toEqual(Uint8Array.from([1, 2, 3]));
+    expect(cs["authority"]).toBe("did:web:advisor.cocore.dev");
+    // Untouched fields pass through by reference-equal value.
+    expect(out["price"]).toEqual({ amount: 2100, currency: "CC" });
+  });
+
+  it("leaves a receipt without a countersignature alone and never throws on odd shapes", () => {
+    expect(
+      decodeBytesFields({ enclaveSignature: "AQ==" })["brokerageCountersignature"],
+    ).toBeUndefined();
+    expect(
+      decodeBytesFields({ brokerageCountersignature: "nope" })["brokerageCountersignature"],
+    ).toBe("nope");
+    expect(decodeBytesFields({ brokerageCountersignature: { sig: 7 } })).toEqual({
+      brokerageCountersignature: { sig: 7 },
+    });
+  });
+});

--- a/packages/appview/src/api/read-router.ts
+++ b/packages/appview/src/api/read-router.ts
@@ -41,17 +41,24 @@ import { err, ok, searchParams } from "./http-app.ts";
 // Lexicon `bytes` fields ship as base64 strings on the wire; decode them for
 // the schema-validation pass in verifyReceipt (the cryptographic verify runs
 // on the original string-bearing JSON so canonical bytes match what was signed).
+// Every `bytes` field of dev.cocore.compute.receipt must be listed here, or the
+// record is reported `lexicon-invalid` ("... must be a byte array") no matter
+// how sound it is — which is how every ADR-0004 receipt read as invalid.
 const BYTES_FIELDS = new Set(["enclaveSignature", "selfSignature"]);
-function decodeBytesFields(body: Record<string, unknown>): Record<string, unknown> {
+function b64ToBytes(v: unknown): unknown {
+  return typeof v === "string" ? Uint8Array.from(Buffer.from(v, "base64")) : v;
+}
+export function decodeBytesFields(body: Record<string, unknown>): Record<string, unknown> {
   const out: Record<string, unknown> = { ...body };
-  for (const k of BYTES_FIELDS) {
-    const v = out[k];
-    if (typeof v === "string") out[k] = Uint8Array.from(Buffer.from(v, "base64"));
-  }
+  for (const k of BYTES_FIELDS) out[k] = b64ToBytes(out[k]);
   if (Array.isArray(out["mdaCertChain"])) {
-    out["mdaCertChain"] = (out["mdaCertChain"] as unknown[]).map((b) =>
-      typeof b === "string" ? Uint8Array.from(Buffer.from(b, "base64")) : b,
-    );
+    out["mdaCertChain"] = (out["mdaCertChain"] as unknown[]).map(b64ToBytes);
+  }
+  // ADR-0004 brokerage witness: `brokerageCountersignature.sig` is `bytes`.
+  const cs = out["brokerageCountersignature"];
+  if (cs && typeof cs === "object" && !Array.isArray(cs)) {
+    const c = cs as Record<string, unknown>;
+    out["brokerageCountersignature"] = { ...c, sig: b64ToBytes(c["sig"]) };
   }
   return out;
 }


### PR DESCRIPTION
## Summary
`verifyReceipt` returned `ok:false` for **every** real receipt. Two lexicon-pass bugs in a row:

1. **`lexicon-invalid: Record/price/currency must not be shorter than 3 characters`** — the network prices and settles everything in `CC` (two letters), but the compute lexicons required `minLength: 3` on every currency field. Widened to 2 on `money.currency`, `modelPrice.currency`, `tokenRate.currency`, `exchangePolicy.supportedCurrencies[]` and the fee-schedule `currency`; `CC` named in the descriptions; `@cocore/sdk/lex` regenerated.
2. **`lexicon-invalid: Record/brokerageCountersignature/sig must be a byte array`** (surfaced once 1 was fixed) — the AppView decodes base64→bytes before schema validation only for `enclaveSignature` / `selfSignature` / `mdaCertChain`; the ADR-0004 witness `sig` is `bytes` too. `decodeBytesFields` now covers it, with a unit test.

## Verification
- `make lex-validate`, `make lex-codegen-check`, sdk oxlint, appview + console `tsc`, oxfmt, knip clean.
- Live (AppView deployed from this branch): https://appview.cocore.dev/xrpc/dev.cocore.compute.verifyReceipt?uri=at://did:plc:oyare47r4kf6nw6ut6ky6el4/dev.cocore.compute.receipt/3mvbe6h7tef22 no longer reports any `lexicon-invalid` finding.

## Related
The same receipt's `brokerage-countersignature-invalid` finding is a different bug (advisor signs a stale attestation URI) — fixed in #221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)