### PR TITLE
fix(advisor,provider): bind the brokerage countersignature to the live attestation

### DIFF
--- a/infra/advisor/src/connection.ts
+++ b/infra/advisor/src/connection.ts
@@ -516,6 +516,29 @@ export function handleConnection(
         }
         return;
       }
+      case "attestation_refreshed": {
+        if (!registeredDid || !registeredMachineId) {
+          console.error(`[ws] attestation_refreshed before register peer=${peer}; closing`);
+          return close(1002, "attestation-refreshed-before-register");
+        }
+        // Owner-bound: the brokerage countersignature will name this URI, so
+        // it must be a record in THIS provider's own repo — a machine can't
+        // point its witness at another provider's (or a self-minted foreign)
+        // attestation. Same collection the Register frame's URI lives in.
+        const expectedPrefix = `at://${registeredDid}/dev.cocore.compute.attestation/`;
+        const uri = msg.attestation_uri;
+        if (!uri.startsWith(expectedPrefix) || uri.length <= expectedPrefix.length) {
+          console.error(
+            `[ws] attestation_refreshed rejected did=${registeredDid} machine=${registeredMachineId}: uri ${uri} is not in the provider's own attestation collection`,
+          );
+          return;
+        }
+        registry.setAttestationUri(registeredDid, registeredMachineId, uri);
+        console.error(
+          `[ws] attestation refreshed did=${registeredDid} machine=${registeredMachineId} uri=${uri}`,
+        );
+        return;
+      }
       case "attestation_response": {
         if (!registeredDid || !registeredMachineId || !pendingChallenge) {
           console.error(`[ws] unsolicited attestation peer=${peer}`);

--- a/infra/advisor/src/protocol.test.ts
+++ b/infra/advisor/src/protocol.test.ts
@@ -131,3 +131,24 @@ describe("stream resume wire contract", () => {
     if (!result.ok) expect(result.reason).toContain(field);
   });
 });
+
+describe("attestation_refreshed wire contract", () => {
+  it("accepts the additive frame", () => {
+    const frame = {
+      type: "attestation_refreshed",
+      attestation_uri: "at://did:plc:test1/dev.cocore.compute.attestation/fresh",
+    };
+    expect(validateFrame(frame)).toEqual({ ok: true, msg: frame });
+  });
+
+  it.each([
+    [{ type: "attestation_refreshed" }],
+    [{ type: "attestation_refreshed", attestation_uri: "" }],
+    [{ type: "attestation_refreshed", attestation_uri: 7 }],
+  ])("rejects a frame without a usable attestation_uri (%j)", (frame) => {
+    expect(validateFrame(frame)).toEqual({
+      ok: false,
+      reason: "attestation_refreshed: attestation_uri",
+    });
+  });
+});

--- a/infra/advisor/src/protocol.ts
+++ b/infra/advisor/src/protocol.ts
@@ -314,11 +314,26 @@ interface RecoverResult {
   detail?: string;
 }
 
+/** Provider → advisor: the agent republished its attestation record (it
+ *  re-attests ~hourly before the 24h expiry and swaps the fresh strong-ref
+ *  into the cell every receipt reads). The advisor's ADR-0004 brokerage
+ *  countersignature binds `attestation` — signing the URI learned at Register
+ *  time means every receipt after the first refresh names a DIFFERENT
+ *  attestation than the witness, and `verifyReceipt` reports
+ *  `brokerage-countersignature-invalid`. This frame keeps the registry's
+ *  `attestationUri` current so the witness and the receipt agree. Owner-bound
+ *  on receipt: the URI must live in the registered provider's own repo.
+ *  Additive — old advisors ignore the unknown frame. */
+interface AttestationRefreshed {
+  attestation_uri: string;
+}
+
 export type AdvisorMessage =
   | ({ type: "register" } & Register)
   | ({ type: "heartbeat" } & Heartbeat)
   | ({ type: "attestation_challenge" } & AttestationChallenge)
   | ({ type: "attestation_response" } & AttestationResponse)
+  | ({ type: "attestation_refreshed" } & AttestationRefreshed)
   | ({ type: "code_attestation_response" } & CodeAttestationResponse)
   | ({ type: "inference_request" } & InferenceRequest)
   | ({ type: "inference_chunk" } & InferenceChunk)
@@ -393,6 +408,11 @@ export function validateFrame(raw: unknown): FrameCheck {
       // and byte-shaped so verify can't throw on undefined.
       if (!isBytes(raw["signature"]))
         return { ok: false, reason: "attestation_response: signature" };
+      break;
+    }
+    case "attestation_refreshed": {
+      if (!isStr(raw["attestation_uri"]) || raw["attestation_uri"].length === 0)
+        return { ok: false, reason: "attestation_refreshed: attestation_uri" };
       break;
     }
     case "code_attestation_response": {

--- a/infra/advisor/src/registry.test.ts
+++ b/infra/advisor/src/registry.test.ts
@@ -896,3 +896,24 @@ describe("ProviderRegistry failure ledger / cooldown", () => {
     });
   });
 });
+
+describe("ProviderRegistry.setAttestationUri (attestation_refreshed)", () => {
+  it("moves a connected machine to its republished attestation and leaves siblings alone", () => {
+    const r = new ProviderRegistry();
+    r.upsert(baseReg, noop, noopSend, noopPing);
+    const sibling = { ...baseReg, machine_id: "m2", attestation_pub_key: "p256-pub-2" };
+    r.upsert(sibling, noop, noopSend, noopPing);
+
+    const fresh = "at://did:plc:test1/dev.cocore.compute.attestation/fresh";
+    expect(r.setAttestationUri(DID, MID, fresh)).toBe(true);
+    expect(r.get(DID, MID)?.attestationUri).toBe(fresh);
+    expect(r.get(DID, "m2")?.attestationUri).toBe(baseReg.attestation_uri);
+  });
+
+  it("returns false for a machine that is not connected", () => {
+    const r = new ProviderRegistry();
+    expect(
+      r.setAttestationUri(DID, "ghost", "at://did:plc:test1/dev.cocore.compute.attestation/x"),
+    ).toBe(false);
+  });
+});

--- a/infra/advisor/src/registry.ts
+++ b/infra/advisor/src/registry.ts
@@ -388,6 +388,17 @@ export class ProviderRegistry {
     return true;
   }
 
+  /** Point a connected machine at its freshly republished attestation record
+   *  (`attestation_refreshed`). Only the URI moves: the signing key is the same
+   *  Secure-Enclave/software key the challenge cycle keeps verifying, so
+   *  attested standing is untouched. Returns false for an unknown machine. */
+  setAttestationUri(did: string, machineId: string, attestationUri: string): boolean {
+    const e = this.byKey.get(ProviderRegistry.key(did, machineId));
+    if (!e) return false;
+    e.attestationUri = attestationUri;
+    return true;
+  }
+
   private static key(did: string, machineId: string): string {
     return `${did}${KEY_SEP}${machineId}`;
   }

--- a/provider/src/advisor.rs
+++ b/provider/src/advisor.rs
@@ -27,7 +27,7 @@ use crate::hypervisor;
 use crate::pds::{effective_tool_calls, PdsClient, ProBonoPolicy};
 use crate::pricing;
 use crate::protocol::{
-    AdvisorMessage, AttestationChallenge, AttestationResponse, ChunkChannel,
+    AdvisorMessage, AttestationChallenge, AttestationRefreshed, AttestationResponse, ChunkChannel,
     CodeAttestationResponse, HealthStanding, Heartbeat, InferenceAck, InferenceChunk,
     InferenceComplete, InferenceKeepalive, InferenceRequest, InferenceResume,
     InferenceResumeResult, Pong, Register, ResumeStatus, SessionKey,
@@ -713,6 +713,19 @@ impl AdvisorClient {
             }
         }
 
+        // Register with the attestation that is live NOW, not the one built at
+        // boot: `register` is constructed once per serve and this is a
+        // reconnect path, so after a refresh the boot URI is stale. The
+        // advisor countersigns dispatches against this URI (ADR-0004) and
+        // receipts reference the live cell, so the two must agree.
+        let mut registered_attestation_uri = register.attestation_uri.clone();
+        if let Some(live) = attestation.read().await.as_ref() {
+            if live.uri != register.attestation_uri {
+                register.attestation_uri = live.uri.clone();
+                registered_attestation_uri = live.uri.clone();
+            }
+        }
+
         // Register
         let payload = serde_json::to_string(&AdvisorMessage::Register(register))
             .map_err(|e| ProviderError::Advisor(e.to_string()))?;
@@ -777,7 +790,7 @@ impl AdvisorClient {
             signer: signer.as_ref(),
             encryption: encryption.as_ref(),
             pds,
-            attestation,
+            attestation: attestation.clone(),
             engines,
             pro_bono,
         };
@@ -906,6 +919,25 @@ impl AdvisorClient {
                     write.send(Message::Text(s.into()))
                         .await
                         .map_err(|e| ProviderError::Advisor(e.to_string()))?;
+                    // The refresh task swapped a new attestation into the shared
+                    // cell since we registered: tell the advisor, so its brokerage
+                    // countersignature binds the same attestation the next
+                    // receipt strong-refs. Piggybacks on the heartbeat cadence —
+                    // a refresh is ~hourly, so a heartbeat of delay is nothing.
+                    let live_uri = attestation.read().await.as_ref().map(|r| r.uri.clone());
+                    if let Some(uri) = live_uri {
+                        if uri != registered_attestation_uri {
+                            let m = AdvisorMessage::AttestationRefreshed(AttestationRefreshed {
+                                attestation_uri: uri.clone(),
+                            });
+                            let s = serde_json::to_string(&m).map_err(|e| ProviderError::Advisor(e.to_string()))?;
+                            write.send(Message::Text(s.into()))
+                                .await
+                                .map_err(|e| ProviderError::Advisor(e.to_string()))?;
+                            tracing::info!(uri = %uri, "told advisor about the refreshed attestation");
+                            registered_attestation_uri = uri;
+                        }
+                    }
                 }
                 // Slow poll: re-read the owner's start/stop switch off our
                 // PDS as the fallback for a missed nudge. The read runs in
@@ -1746,6 +1778,9 @@ async fn handle_inbound(text: &str, ctx: &ServeContext<'_>) -> Result<Vec<Adviso
         | AdvisorMessage::InferenceResumeResult(_)
         | AdvisorMessage::InferenceAck(_)
         | AdvisorMessage::AttestationResponse(_)
+        // AttestationRefreshed is provider→advisor only (sent from the
+        // heartbeat arm when the refresh task swaps in a new attestation).
+        | AdvisorMessage::AttestationRefreshed(_)
         | AdvisorMessage::Ping(_)
         | AdvisorMessage::Pong(_)
         | AdvisorMessage::HealthNotice(_)

--- a/provider/src/protocol.rs
+++ b/provider/src/protocol.rs
@@ -40,6 +40,14 @@ pub enum AdvisorMessage {
     AttestationChallenge(AttestationChallenge),
     /// Provider → advisor: signed challenge response.
     AttestationResponse(AttestationResponse),
+    /// Provider → advisor: this machine republished its attestation record
+    /// (the ~hourly re-attest before the 24h expiry). The advisor's ADR-0004
+    /// brokerage countersignature binds the attestation URI, and every
+    /// receipt strong-refs whatever attestation is live at publish time — so
+    /// the advisor has to learn the new URI or the witness and the receipt
+    /// name different records and `verifyReceipt` fails the countersignature.
+    /// Additive: an old advisor ignores the unknown frame.
+    AttestationRefreshed(AttestationRefreshed),
     /// Provider → advisor (→ requester): per-request ephemeral session key for
     /// the confidential tier. Minted fresh inside the measured engine and
     /// SE-signed over the requester's nonce + the active attestation CID, so a
@@ -129,6 +137,12 @@ pub struct HealthNotice {
     pub standing: HealthStanding,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AttestationRefreshed {
+    /// at://… of the attestation record receipts reference from now on.
+    pub attestation_uri: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Problem
`verifyReceipt` reports `brokerage-countersignature-invalid` on every receipt from a machine connected longer than one attestation refresh (e.g. `at://did:plc:oyare47r4kf6nw6ut6ky6el4/dev.cocore.compute.receipt/3mvbe6h7tef22`).

Verified locally with `@cocore/sdk/brokerage` and the advisor's published key: the countersignature **does** verify when the witness message uses the attestation URI the provider registered with (`…/attestation/3mtp26mezpg23`), but the receipt strong-refs the attestation live at publish time (`…/3mvajnnk7m522`, refreshed hourly before the 24h expiry). The advisor never learns about refreshes, so witness ≠ receipt.

## Fix
**Provider**
- `Register` carries the attestation live at (re)connect time, not the boot one.
- New additive frame `attestation_refreshed { attestation_uri }`, sent from the heartbeat arm once the refresh task swaps in a new record.

**Advisor**
- `validateFrame` + `connection.ts` handler: owner-bound (URI must be in the registered provider's own `dev.cocore.compute.attestation` collection), then `registry.setAttestationUri` updates what the brokerage signer reads.
- Tests: registry setter, wire contract.

## Checks
- `cargo check`, `cargo clippy -D warnings`, `cargo fmt --check` clean.
- advisor: 187 vitest pass, `tsc`, `oxfmt`, `oxlint`, `knip` clean.

## Rollout
Deploy the Advisor; receipts from a machine start verifying as soon as it reconnects (every advisor deploy does that) or runs a provider build with this change. Pairs with #220 (the `CC` currency `lexicon-invalid` finding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)