### PR TITLE
release: cocore tray app 0.9.55

### DIFF
--- a/provider-shell/Sources/CoCoreShell/Resources/Info.plist
+++ b/provider-shell/Sources/CoCoreShell/Resources/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleName</key>
 	<string>co/core</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.54</string>
+	<string>0.9.55</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -22,7 +22,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>954</string>
+	<string>955</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/provider/Cargo.lock
+++ b/provider/Cargo.lock
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "cocore-provider"
-version = "0.9.54"
+version = "0.9.55"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cocore-provider"
-version = "0.9.54"
+version = "0.9.55"
 edition = "2021"
 description = "co/core provider agent: runs hardened compute and publishes signed receipts to AT Protocol."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Version bump only (Info.plist 0.9.55 / build 955, provider Cargo.toml + Cargo.lock), same shape as the 0.9.54 release commit.

Provider change since v0.9.54: #221 — Register carries the live attestation URI and the agent announces attestation refreshes, so the advisor's brokerage countersignature binds the attestation the receipt strong-refs and `verifyReceipt` stops reporting `brokerage-countersignature-invalid`.

Release steps after merge (the `v0.9.55` tag is pushed only once the notarized `cocore.app.zip` is ready, because the console's `latest` is strictly GitHub's latest release):
1. `make mac-release` with `COCORE_NOTARY_PROFILE` + `COCORE_PROVISION_PROFILE` set → `dist/cocore.app.zip`, `dist/cocore-mac-arm64.tar.gz`, `dist/SHA256SUMS`, `dist/cdhash.json`.
2. Register the new confidential cdHash (append) in the Advisor's `COCORE_KNOWN_GOOD_CDHASHES`.
3. Tag `v0.9.55` on the merge commit → CI publishes the release; upload `cocore.app.zip`, `SHA256SUMS`, `cdhash.json` to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)