### PR TITLE
feat(console): enforce the admission floor before paid dispatch (observe-only until flipped)

### DIFF
--- a/packages/console/public/openapi.yaml
+++ b/packages/console/public/openapi.yaml
@@ -68,6 +68,11 @@ paths:
           content:
             application/json:
               schema: { $ref: "#/components/schemas/ErrorEnvelope" }
+        "402":
+          description: Not enough co/core credits (`insufficient_credits`) — the requester's balance cannot cover the job's price ceiling plus the exchange's admission floor. Credits refresh weekly; serving earns more. Enforced only when the console runs with admission enforcement on.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorEnvelope" }
         "404":
           description: No connected provider serves the requested model (`model_not_found`).
           content:
@@ -108,6 +113,11 @@ paths:
               schema: { type: string }
         "401":
           description: Missing or invalid API key.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorEnvelope" }
+        "402":
+          description: Not enough co/core credits (`insufficient_credits`) — the requester's balance cannot cover the job's price ceiling plus the exchange's admission floor. Credits refresh weekly; serving earns more. Enforced only when the console runs with admission enforcement on.
           content:
             application/json:
               schema: { $ref: "#/components/schemas/ErrorEnvelope" }
@@ -170,6 +180,11 @@ paths:
               schema: { $ref: "#/components/schemas/ErrorEnvelope" }
         "401":
           description: Missing or invalid API key.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorEnvelope" }
+        "402":
+          description: Not enough co/core credits (`insufficient_credits`) — the requester's balance cannot cover the job's price ceiling plus the exchange's admission floor. Credits refresh weekly; serving earns more. Enforced only when the console runs with admission enforcement on.
           content:
             application/json:
               schema: { $ref: "#/components/schemas/ErrorEnvelope" }

--- a/packages/console/src/components/inference-docs/pages/api-reference.tsx
+++ b/packages/console/src/components/inference-docs/pages/api-reference.tsx
@@ -254,6 +254,9 @@ export function InferenceApiReferencePage({ baseUrl }: { baseUrl: string }) {
                   code={`// 404 — no provider is serving this model
 { "error": { "type": "invalid_request_error", "code": "model_not_found", "message": "..." } }
 
+// 402 — not enough credits: balance must cover the price ceiling plus the admission floor
+{ "error": { "type": "insufficient_credits_error", "code": "insufficient_credits", "message": "Not enough co/core credits: balance 12,000 CC, needs 200,000 CC ..." } }
+
 // 503 — no providers are connected
 { "error": { "type": "service_unavailable_error", "code": "no_providers_connected", "message": "..." } }
 

--- a/packages/console/src/lib/admission.server.ts
+++ b/packages/console/src/lib/admission.server.ts
@@ -1,0 +1,81 @@
+// Admission floor for paid dispatch (co/core terms, "Admission floor").
+//
+// The exchange's ledger has always had `checkAdmission` (balance must cover
+// the job's price ceiling AND leave `tokenFloor` headroom), and the terms
+// promise that a job under the floor is refused — but nothing called it before
+// dispatch, so balances could be pushed negative at settlement. This module is
+// that call, inserted ahead of `runDispatch` for the paid routes (v1/chat,
+// v1/private, v1/verified; pro bono is zero-price and skips it).
+//
+// Rollout is gated on `COCORE_ENFORCE_ADMISSION` (unset/"0" = observe only:
+// the check runs, a refusal is LOGGED but the job still dispatches; "1"/"true"
+// = refuse with HTTP 402). Fail-open on a ledger outage either way: an
+// unreachable bridge is not "under the floor", and refusing every job because
+// the ledger blinked would be an outage of our own making.
+import { checkAdmission, type AdmissionResponse } from "@/lib/exchange-balance.server.ts";
+import { jsonError } from "@/lib/openai-chat-completions.server.ts";
+
+/** The OpenAI-style error `code` a refused requester sees. Clients (Graze's
+ *  Feed Pulse among them) switch on it to park the account instead of retrying. */
+export const INSUFFICIENT_CREDITS = "insufficient_credits";
+
+export function admissionEnforced(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = (env["COCORE_ENFORCE_ADMISSION"] ?? "").trim().toLowerCase();
+  return v === "1" || v === "true" || v === "yes";
+}
+
+export interface AdmissionDecision {
+  /** null = dispatch; a Response = return it to the caller instead. */
+  refusal: Response | null;
+  /** The ledger's verdict, when it answered. */
+  result: AdmissionResponse | null;
+  /** Why we let the job through despite no `ok` (observe mode / ledger down). */
+  note: string | null;
+}
+
+/** Decide whether `did` may dispatch a job priced up to `priceCeilingTokens`. */
+export async function admit(
+  did: string,
+  priceCeilingTokens: number,
+  opts: {
+    enforce?: boolean;
+    check?: (did: string, priceCeilingTokens: number) => Promise<AdmissionResponse>;
+    log?: (line: string) => void;
+  } = {},
+): Promise<AdmissionDecision> {
+  const enforce = opts.enforce ?? admissionEnforced();
+  const check = opts.check ?? checkAdmission;
+  const log = opts.log ?? ((line: string) => console.error(line));
+
+  let result: AdmissionResponse;
+  try {
+    result = await check(did, priceCeilingTokens);
+  } catch (e) {
+    const note = `admission: ledger unreachable for ${did}, dispatching anyway (${(e as Error).message})`;
+    log(note);
+    return { refusal: null, result: null, note };
+  }
+  if (result.ok) return { refusal: null, result, note: null };
+
+  const summary =
+    `balance ${result.balance.toLocaleString("en-US")} CC, ` +
+    `needs ${result.required.toLocaleString("en-US")} CC ` +
+    `(price ceiling ${priceCeilingTokens.toLocaleString("en-US")} + admission floor), ` +
+    `short by ${result.shortBy.toLocaleString("en-US")}`;
+  if (!enforce) {
+    const note = `admission: would refuse ${did} — ${summary} (COCORE_ENFORCE_ADMISSION off)`;
+    log(note);
+    return { refusal: null, result, note };
+  }
+  log(`admission: refused ${did} — ${summary}`);
+  return {
+    refusal: jsonError(
+      402,
+      `Not enough co/core credits: ${summary}. Credits refresh weekly, and serving on your own Mac earns more.`,
+      "insufficient_credits_error",
+      INSUFFICIENT_CREDITS,
+    ),
+    result,
+    note: null,
+  };
+}

--- a/packages/console/src/lib/admission.test.ts
+++ b/packages/console/src/lib/admission.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { admissionEnforced, admit, INSUFFICIENT_CREDITS } from "./admission.server.ts";
+
+const rich = async () => ({
+  ok: true,
+  balance: 2_806_415,
+  required: 200_000,
+  shortBy: 0,
+  pendingGrant: false,
+});
+const broke = async () => ({
+  ok: false,
+  balance: 12_000,
+  required: 200_000,
+  shortBy: 188_000,
+  pendingGrant: false,
+});
+const down = async () => {
+  throw new Error("connect ECONNREFUSED");
+};
+
+describe("admission floor", () => {
+  it("is off unless COCORE_ENFORCE_ADMISSION is truthy", () => {
+    expect(admissionEnforced({})).toBe(false);
+    expect(admissionEnforced({ COCORE_ENFORCE_ADMISSION: "0" })).toBe(false);
+    expect(admissionEnforced({ COCORE_ENFORCE_ADMISSION: "1" })).toBe(true);
+    expect(admissionEnforced({ COCORE_ENFORCE_ADMISSION: "true" })).toBe(true);
+  });
+
+  it("lets a funded requester through in either mode", async () => {
+    for (const enforce of [false, true]) {
+      const d = await admit("did:plc:rich", 100_000, { enforce, check: rich, log: () => {} });
+      expect(d.refusal).toBeNull();
+      expect(d.result?.ok).toBe(true);
+    }
+  });
+
+  it("observe mode logs the would-be refusal and still dispatches", async () => {
+    const lines: string[] = [];
+    const d = await admit("did:plc:broke", 100_000, {
+      enforce: false,
+      check: broke,
+      log: (l) => lines.push(l),
+    });
+    expect(d.refusal).toBeNull();
+    expect(d.note).toMatch(/would refuse/);
+    expect(lines[0]).toMatch(/short by 188,000/);
+  });
+
+  it("enforce mode answers 402 with the insufficient_credits code and the numbers", async () => {
+    const d = await admit("did:plc:broke", 100_000, { enforce: true, check: broke, log: () => {} });
+    expect(d.refusal?.status).toBe(402);
+    const body = await d.refusal!.json();
+    expect(body.error.code).toBe(INSUFFICIENT_CREDITS);
+    expect(body.error.message).toMatch(/balance 12,000 CC/);
+    expect(body.error.message).toMatch(/needs 200,000 CC/);
+  });
+
+  it("fails open when the ledger is unreachable, even in enforce mode", async () => {
+    const lines: string[] = [];
+    const d = await admit("did:plc:any", 100_000, {
+      enforce: true,
+      check: down,
+      log: (l) => lines.push(l),
+    });
+    expect(d.refusal).toBeNull();
+    expect(d.result).toBeNull();
+    expect(lines[0]).toMatch(/ledger unreachable/);
+  });
+});

--- a/packages/console/src/lib/exchange-balance.server.ts
+++ b/packages/console/src/lib/exchange-balance.server.ts
@@ -48,6 +48,48 @@ export async function getBalance(did: string): Promise<BalanceResponse> {
   return (await r.json()) as BalanceResponse;
 }
 
+/** The ledger's dispatch-admission verdict (packages/exchange token-balance
+ *  `checkAdmission`): `ok` when `balance >= priceCeilingTokens + tokenFloor`. */
+export interface AdmissionResponse {
+  ok: boolean;
+  balance: number;
+  required: number;
+  shortBy: number;
+  pendingGrant: boolean;
+}
+
+export async function checkAdmission(
+  did: string,
+  priceCeilingTokens: number,
+): Promise<AdmissionResponse> {
+  const r = await fetch(bridgeUrl("/xrpc/dev.cocore.exchange.checkAdmission"), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ did, priceCeilingTokens }),
+    signal: AbortSignal.timeout(5_000),
+  });
+  if (!r.ok) {
+    throw new Error(
+      `checkAdmission(${did}) returned ${r.status}: ${await r.text().catch(() => "")}`,
+    );
+  }
+  const body = (await r.json()) as Partial<AdmissionResponse> | null;
+  // Shape-check before anyone trusts it: a proxy error page, a wrong route or
+  // a stubbed fetch must read as "ledger unreachable" (fail-open upstream),
+  // never as a verdict.
+  if (
+    !body ||
+    typeof body !== "object" ||
+    typeof body.ok !== "boolean" ||
+    typeof body.balance !== "number" ||
+    typeof body.required !== "number" ||
+    typeof body.shortBy !== "number"
+  ) {
+    throw new Error(`checkAdmission(${did}) returned a malformed verdict`);
+  }
+  return body as AdmissionResponse;
+}
+
 export interface LedgerEvent {
   did: string;
   kind: string;

--- a/packages/console/src/lib/openai-routes.server.ts
+++ b/packages/console/src/lib/openai-routes.server.ts
@@ -20,6 +20,7 @@ import { isDid } from "@atcute/lexicons/syntax";
 import type { OAuthSession } from "@atcute/oauth-node-client";
 
 import { runTraced } from "@/lib/o11y.server.ts";
+import { admit } from "@/lib/admission.server.ts";
 
 import { restoreAtprotoSessionEffect } from "@/integrations/auth/atproto.server.ts";
 import { appviewBackedSession, appviewSessionInfo } from "@/lib/appview-backed-session.server.ts";
@@ -310,6 +311,12 @@ export async function handleChatCompletions(request: Request): Promise<Response>
     ...(parsed.toolChoiceFunction ? { toolChoiceFunction: parsed.toolChoiceFunction } : {}),
   };
 
+  // Admission floor (co/core terms): refuse a job the requester's balance
+  // cannot cover with `tokenFloor` headroom. Observe-only until
+  // COCORE_ENFORCE_ADMISSION is on; fail-open when the ledger is unreachable.
+  const admission = await admit(auth.did, DEFAULT_PRICE_CEILING.amount);
+  if (admission.refusal) return admission.refusal;
+
   if (parsed.stream) {
     return streamingResponse(id, parsed.model, runDispatch(inputs));
   }
@@ -385,6 +392,12 @@ export async function handlePrivateChatCompletions(request: Request): Promise<Re
     ...(parsed.toolChoice ? { toolChoice: parsed.toolChoice } : {}),
     ...(parsed.toolChoiceFunction ? { toolChoiceFunction: parsed.toolChoiceFunction } : {}),
   };
+
+  // Admission floor (co/core terms): refuse a job the requester's balance
+  // cannot cover with `tokenFloor` headroom. Observe-only until
+  // COCORE_ENFORCE_ADMISSION is on; fail-open when the ledger is unreachable.
+  const admission = await admit(auth.did, DEFAULT_PRICE_CEILING.amount);
+  if (admission.refusal) return admission.refusal;
 
   if (parsed.stream) {
     return streamingResponse(id, parsed.model, runDispatch(inputs));
@@ -481,6 +494,12 @@ export async function handleVerifiedChatCompletions(request: Request): Promise<R
     ...(parsed.toolChoice ? { toolChoice: parsed.toolChoice } : {}),
     ...(parsed.toolChoiceFunction ? { toolChoiceFunction: parsed.toolChoiceFunction } : {}),
   };
+
+  // Admission floor (co/core terms): refuse a job the requester's balance
+  // cannot cover with `tokenFloor` headroom. Observe-only until
+  // COCORE_ENFORCE_ADMISSION is on; fail-open when the ledger is unreachable.
+  const admission = await admit(auth.did, DEFAULT_PRICE_CEILING.amount);
+  if (admission.refusal) return admission.refusal;
 
   if (parsed.stream) {
     return streamingResponse(id, parsed.model, runDispatch(inputs));

--- a/provider/src/advisor.rs
+++ b/provider/src/advisor.rs
@@ -923,7 +923,7 @@ impl AdvisorClient {
                     // cell since we registered: tell the advisor, so its brokerage
                     // countersignature binds the same attestation the next
                     // receipt strong-refs. Piggybacks on the heartbeat cadence —
-                    // a refresh is ~hourly, so a heartbeat of delay is nothing.
+                    // a refresh is ~daily (23h), so a heartbeat of delay is nothing.
                     let live_uri = attestation.read().await.as_ref().map(|r| r.uri.clone());
                     if let Some(uri) = live_uri {
                         if uri != registered_attestation_uri {


### PR DESCRIPTION
## Why
The terms ("Admission floor") say a job is refused if it would leave the requester under `tokenFloor` (100,000 CC). The ledger has `checkAdmission`, but nothing called it before dispatch — `applyReceipt` happily takes a balance negative. Graze's Feed Pulse now enforces the floor on its side; every other client has nothing.

## What
- `checkAdmission(did, priceCeilingTokens)` client for the services bridge (shape-checked).
- `admit()`: funded → dispatch. Under the floor → **402 `insufficient_credits`** with balance / required / short-by in the message — **only when `COCORE_ENFORCE_ADMISSION=1`**. Otherwise it logs `admission: would refuse <did> — …` and dispatches. Ledger unreachable → dispatch (fail-open) in both modes.
- Gated on `v1/chat`, `v1/private`, `v1/verified` ahead of `runDispatch`. Pro bono is zero-price and untouched.
- OpenAPI + API reference document the 402.
- Drive-by: provider comment said attestation refresh is hourly; it is ~23h.

## Rollout
Merging is safe: default is observe-only. Watch `railway logs -s Client | grep "admission: would refuse"` to see how many requesters the floor would actually hit (with the default 100,000 CC price ceiling the effective requirement is **200,000 CC**), then flip:

```bash
railway variable set -p a46692ef-f462-4801-9a64-0af69ea7143d -e 9584945f-7b2f-4369-87a9-4eea8ffd7eae -s Client COCORE_ENFORCE_ADMISSION=1
```

Graze already classifies a 402 as `out_of_credits` and parks the owner's connection. If enforcement goes on, Graze's `FEED_PULSE_MIN_CREDITS` should move from 100,000 to 200,000 to match.

## Checks
48 console tests pass (5 new for `admit`), `tsc`, oxfmt, oxlint, knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)