### PR TITLE
feat(oauth): grant repo write for dev.cocore.app.registration

### DIFF
--- a/packages/sdk/src/oauth-scope.ts
+++ b/packages/sdk/src/oauth-scope.ts
@@ -10,6 +10,10 @@
 //   * dev.cocore.compute.provider             — pair-machine flow
 //   * dev.cocore.compute.job                  — inference dispatch
 //   * dev.cocore.compute.paymentAuthorization — inference dispatch
+//   * dev.cocore.app.registration            — "Sign in with co/core": an app
+//                                               publishes its own name/website/
+//                                               icon/returnUrls so the pairing
+//                                               consent screen can name + verify it
 //   * dev.cocore.account.profile              — /account auto-provision + edits
 //   * dev.cocore.account.friend               — /friends add / remove
 //   * dev.cocore.account.tokenGrant           — exchange-side onboarding grants
@@ -55,6 +59,7 @@ export const oauthScopes = [
       "dev.cocore.compute.exchangeAttestation",
       "dev.cocore.compute.termsAcceptance",
       "dev.cocore.compute.dispute",
+      "dev.cocore.app.registration",
       "dev.cocore.account.profile",
       "dev.cocore.account.friend",
       "dev.cocore.account.tokenGrant",


### PR DESCRIPTION
## Why
"Sign in with co/core" (device pairing for apps) lets an application publish a `dev.cocore.app.registration` record on its own repo so the consent screen can name and verify it. But that collection was never in the OAuth scope list, so an app writing its own record through its co/core key hit `ScopeMissingError: Missing required scope "repo:dev.cocore.app.registration?action=create"`. Apps had to publish the record out-of-band (Graze did it through its own AIP session). This closes that gap so the co/core key alone is enough.

## What
One line added to the shared `oauthScopes` repo grant in `@cocore/sdk/oauth-scope`, plus a comment. Both the console (minting) and the AppView (restoring) import this constant, so they must deploy together — which they do from one commit.

## Rollout note
Granular OAuth does not backfill: existing sessions keep every grant they had but do not gain the new one until the user re-authorizes (disconnect + reconnect at cocore.dev). No existing capability regresses.

## Checks
sdk `tsc` + oxfmt clean; console + appview `tsc` clean against the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)