### PR TITLE
feat: verified app identity for Sign in with co/core

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,14 @@ Either way the agent pairs to your identity, attests the machine, loads a
 local model, and starts publishing receipts as it earns. See
 [`docs/install-mac.md`](docs/install-mac.md) for the details.
 
+## Connecting your app ("Sign in with co/core")
+
+An application can connect its users' co/core accounts in one click — publish a
+`dev.cocore.app.registration` record on your app's account, serve a well-known
+file on your domain, and use the device-pairing XRPC. Users approve
+"Connect *Your App* to co/core" and come straight back. See
+[`docs/connect-with-cocore.md`](docs/connect-with-cocore.md).
+
 ## Choosing where (and how) a job runs
 
 The completions API and the in-app chat take optional routing controls beyond

--- a/docs/api-keys.md
+++ b/docs/api-keys.md
@@ -193,6 +193,9 @@ step, while leaving a `revokedAt` audit marker behind.
 
 ## Connecting an application on a user's behalf
 
+> Full guide, including how to register your app so the approve screen shows a
+> verified identity: [`docs/connect-with-cocore.md`](connect-with-cocore.md).
+
 An application that wants to run inference for its users (Graze's Feed Pulse
 is the first) should not ask them to copy keys around, and cannot mint keys
 through their PDS unless its own OAuth client requested the `rpc` scope above.

--- a/docs/connect-with-cocore.md
+++ b/docs/connect-with-cocore.md
@@ -1,0 +1,138 @@
+# Connect with co/core (for applications)
+
+Let your users connect their co/core account to your app in one click, so your
+app can run inference billed to their credits — no key copying, no OAuth client
+registration with us, no scopes to negotiate. This is the same device-pairing
+flow `cocore agent pair` uses, with your app's identity attached. Graze's
+"Connect co/core" is the reference implementation.
+
+## What the user sees
+
+1. They press **Connect co/core** in your app.
+2. Their browser lands on `https://cocore.dev/devices/new?code=…`. If they are
+   not signed in at co/core they sign in first (a Bluesky handle works).
+3. The approve screen reads *"Connect **Your App** to co/core — Verified
+   application: @yourapp.example · yourapp.example"*, explains that the key can
+   run inference on their credits and nothing else, and offers **Allow Your App**.
+4. Approval sends them straight back to your app. Your server already has the
+   key.
+
+## What you do — once
+
+### 1. Publish a registration record on your app's account
+
+Your app is identified by a DID with a repo: usually the Bluesky account you
+run your app from. Publish one `dev.cocore.app.registration` record at rkey
+`self`:
+
+```json
+{
+  "$type": "dev.cocore.app.registration",
+  "name": "Your App",
+  "description": "What the connection is used for, in one sentence.",
+  "website": "https://yourapp.example",
+  "iconUrl": "https://yourapp.example/icon.png",
+  "returnUrls": ["https://yourapp.example/settings/connections"],
+  "createdAt": "2026-09-11T00:00:00Z"
+}
+```
+
+```sh
+# with the atproto CLI of your choice; e.g. via com.atproto.repo.putRecord on your PDS
+curl -sS -X POST "$PDS/xrpc/com.atproto.repo.putRecord" -H "authorization: Bearer $ACCESS_JWT" \
+  -H 'content-type: application/json' \
+  -d '{"repo":"did:plc:yourapp","collection":"dev.cocore.app.registration","rkey":"self","record":{…}}'
+```
+
+`name` is what users see; `returnUrls` are the only places the approve screen
+will ever send a browser. There is no central registry: the record on your
+account *is* the registration, and you can change or delete it any time.
+
+### 2. Prove you control the return host
+
+Serve `https://<return host>/.well-known/cocore-app.json`:
+
+```json
+{ "did": "did:plc:yourapp" }
+```
+
+(`{"dids": [...]}` is accepted when one host fronts several apps.) Without
+this, users can still connect — the approve screen just labels your app
+**unverified** and does not redirect them back to you.
+
+## What you do — per user
+
+### 3. Start a pairing, server-side
+
+```sh
+curl -sS -X POST https://cocore.dev/api/xrpc/dev.cocore.devicePair.start \
+  -H 'content-type: application/json' \
+  -d '{"appDid":"did:plc:yourapp","keyName":"Your App","returnUrl":"https://yourapp.example/settings/connections?cocore=connected"}'
+```
+
+```json
+{ "deviceId": "…32 hex…", "userCode": "K7PX2M4Q",
+  "verificationUri": "https://cocore.dev/devices/new?code=K7PX2M4Q",
+  "pollIntervalSecs": 3, "expiresInSecs": 600 }
+```
+
+Keep `deviceId` on your server: it is the credential that collects the key.
+`returnUrl` must match one of your registered `returnUrls` on origin and path;
+its query string is yours to use.
+
+### 4. Send the user to `verificationUri`
+
+A plain top-level navigation. Same-tab works best: co/core returns them to your
+`returnUrl` afterwards.
+
+### 5. Poll for the key
+
+```sh
+curl -sS "https://cocore.dev/api/xrpc/dev.cocore.devicePair.poll?deviceId=…"
+```
+
+`{"status":"pending"}` until they act; then, exactly once,
+
+```json
+{ "status": "session", "session": { "did": "did:plc:…", "handle": "alice.bsky.social",
+  "apiKey": "cocore-…", "apiBase": "https://cocore.dev" } }
+```
+
+Terminal states: `denied` (403), `expired` / `consumed` (410), `unknown` (404;
+the attempt is gone — start again). **Check `session.did` is the user you
+expected** before storing `apiKey`; the key belongs to whoever was signed in at
+co/core. Store it encrypted; it is shown once.
+
+### 6. Use the key
+
+Point any OpenAI-compatible client at `https://cocore.dev/v1` with the key as
+the bearer token. Jobs are billed to the user's credits; every response's
+`x_cocore` block names the provider and the signed receipt.
+
+## SDK helpers
+
+```ts
+import { startAppPairing, waitForAppPairing } from "@cocore/sdk";
+const pairing = await startAppPairing({ appDid, keyName: "Your App", returnUrl });
+// redirect the user to pairing.verificationUri, then:
+const session = await waitForAppPairing(pairing);
+```
+
+```python
+from cocore import start_app_pairing, wait_for_app_pairing
+pairing = start_app_pairing("did:plc:yourapp", key_name="Your App", return_url=return_url)
+# redirect the user to pairing.verification_uri, then:
+session = wait_for_app_pairing(pairing)
+```
+
+## Limits and behaviour
+
+- `start`, `describe` and `confirm` are rate-limited per client IP (30 / 120 /
+  30 per ten minutes). Start pairings from your server, not the browser.
+- Pairings expire after ten minutes and are held in memory; a co/core deploy
+  drops them (`unknown`). Handle that by starting again.
+- `dev.cocore.devicePair.describe?userCode=` is the public read the approve
+  screen uses; it echoes your registration and never the `deviceId`.
+- The approve screen shows **Unregistered request** for a `start` with an
+  `appName` but no `appDid`. That path still works for CLIs and prototypes, but
+  users are told the name was self-declared.

--- a/lexicons/dev/cocore/app/registration.json
+++ b/lexicons/dev/cocore/app/registration.json
@@ -1,0 +1,29 @@
+{
+  "lexicon": 1,
+  "id": "dev.cocore.app.registration",
+  "description": "How an application announces itself to co/core so it can connect users' accounts with one click (\"Sign in with co/core\"). Published by the application on ITS OWN account (a did:plc or did:web with a repo), one record per DID at rkey `self` — there is no central app registry. When the app calls `dev.cocore.devicePair.start` with `appDid`, the AppView reads this record from the app's PDS: `name` is what the approve screen shows, and `returnUrls` are the only places the approve screen may send the browser afterwards. A return URL is additionally honoured only when its host proves it belongs to this DID by serving `https://<host>/.well-known/cocore-app.json` containing `{\"did\": \"<this DID>\"}` — so a record on a stranger's account cannot borrow a real app's domain.",
+  "defs": {
+    "main": {
+      "type": "record",
+      "key": "literal:self",
+      "record": {
+        "type": "object",
+        "required": ["name", "returnUrls", "createdAt"],
+        "properties": {
+          "name": { "type": "string", "maxLength": 40, "description": "Human name of the application, shown on the approve screen." },
+          "description": { "type": "string", "maxLength": 300, "description": "One sentence on what the app does with the connection. Plain text." },
+          "website": { "type": "string", "format": "uri", "maxLength": 2048, "description": "The app's home page, linked from the approve screen." },
+          "iconUrl": { "type": "string", "format": "uri", "maxLength": 2048, "description": "Square icon, https. Optional." },
+          "returnUrls": {
+            "type": "array",
+            "maxLength": 10,
+            "items": { "type": "string", "format": "uri", "maxLength": 2048 },
+            "description": "Where the approve screen may send the browser after approval. https only. A requested return URL must match one of these on origin and path (its query string may differ)."
+          },
+          "createdAt": { "type": "string", "format": "datetime" },
+          "updatedAt": { "type": "string", "format": "datetime" }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/dev/cocore/devicePair/describe.json
+++ b/lexicons/dev/cocore/devicePair/describe.json
@@ -7,27 +7,99 @@
       "description": "Describe a pending pairing attempt by its `userCode`, so the approve screen can say who is asking and for what. Public: it only echoes what the requester supplied at `start` (application name, key name, return URL) plus the attempt's status and remaining lifetime. It never returns the `deviceId` or a session.",
       "parameters": {
         "type": "params",
-        "required": ["userCode"],
-        "properties": { "userCode": { "type": "string", "description": "The code the requester displayed (case-insensitive)." } }
+        "required": [
+          "userCode"
+        ],
+        "properties": {
+          "userCode": {
+            "type": "string",
+            "description": "The code the requester displayed (case-insensitive)."
+          }
+        }
       },
       "output": {
         "encoding": "application/json",
         "schema": {
           "type": "object",
-          "required": ["status", "expiresInSecs"],
+          "required": [
+            "status",
+            "expiresInSecs"
+          ],
           "properties": {
-            "status": { "type": "string", "enum": ["pending", "approved", "denied", "expired", "consumed"] },
-            "appName": { "type": "string" },
-            "keyName": { "type": "string" },
-            "returnUrl": { "type": "string", "format": "uri" },
-            "expiresInSecs": { "type": "integer" }
+            "status": {
+              "type": "string",
+              "enum": [
+                "pending",
+                "approved",
+                "denied",
+                "expired",
+                "consumed"
+              ]
+            },
+            "appName": {
+              "type": "string"
+            },
+            "keyName": {
+              "type": "string"
+            },
+            "returnUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "expiresInSecs": {
+              "type": "integer"
+            },
+            "app": {
+              "type": "object",
+              "required": [
+                "did",
+                "name",
+                "verified"
+              ],
+              "description": "The registered application behind this code, when `start` carried `appDid`. `verified` means the return host proved it belongs to the app's DID; an unverified app still gets a key if the user approves, but the browser is never sent to it.",
+              "properties": {
+                "did": {
+                  "type": "string",
+                  "format": "did"
+                },
+                "handle": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "website": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "iconUrl": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "verified": {
+                  "type": "boolean"
+                },
+                "verifiedHost": {
+                  "type": "string"
+                }
+              }
+            }
           }
         }
       },
       "errors": [
-        { "name": "InvalidRequest", "description": "The `userCode` parameter is missing." },
-        { "name": "NotFound", "description": "No pairing attempt matches the `userCode`." },
-        { "name": "RateLimited", "description": "Too many describe calls from this client; retry later." }
+        {
+          "name": "InvalidRequest",
+          "description": "The `userCode` parameter is missing."
+        },
+        {
+          "name": "NotFound",
+          "description": "No pairing attempt matches the `userCode`."
+        },
+        {
+          "name": "RateLimited",
+          "description": "Too many describe calls from this client; retry later."
+        }
       ]
     }
   }

--- a/lexicons/dev/cocore/devicePair/start.json
+++ b/lexicons/dev/cocore/devicePair/start.json
@@ -10,6 +10,11 @@
         "schema": {
           "type": "object",
           "properties": {
+            "appDid": {
+              "type": "string",
+              "format": "did",
+              "description": "The requesting application's DID. When present the AppView reads the app's `dev.cocore.app.registration` record: the approve screen shows that record's `name` (the `appName` field is ignored) and `returnUrl` is honoured only if it matches one of the record's `returnUrls` AND the return host proves ownership via `/.well-known/cocore-app.json`. A DID with no registration record is rejected with InvalidRequest (AppNotRegistered)."
+            },
             "appName": {
               "type": "string",
               "maxLength": 40,
@@ -67,6 +72,10 @@
         {
           "name": "RateLimited",
           "description": "Too many pairing attempts from this client; retry later."
+        },
+        {
+          "name": "InvalidRequest",
+          "description": "`appDid` is not a DID, or has no `dev.cocore.app.registration` record (message begins `AppNotRegistered`)."
         }
       ]
     }

--- a/packages/appview/src/devicepair/app-registration.test.ts
+++ b/packages/appview/src/devicepair/app-registration.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createAppResolver,
+  matchesRegisteredReturnUrl,
+  parseRegistration,
+} from "./app-registration.ts";
+
+const APP = "did:plc:graze";
+const RECORD = {
+  $type: "dev.cocore.app.registration",
+  name: "  Graze  ",
+  description: "Daily feed summaries",
+  website: "https://www.graze.social",
+  returnUrls: [
+    "https://www.graze.social/app/account",
+    "http://insecure.example/x",
+    "javascript:alert(1)",
+  ],
+  createdAt: "2026-09-11T00:00:00Z",
+};
+
+function fakeFetch(routes: Record<string, () => Response | Promise<Response>>): typeof fetch {
+  return (async (input: string | URL | Request) => {
+    const url =
+      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    for (const [prefix, handler] of Object.entries(routes)) {
+      if (url.startsWith(prefix)) return handler();
+    }
+    return new Response("not found", { status: 404 });
+  }) as typeof fetch;
+}
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+
+describe("parseRegistration", () => {
+  it("cleans the name and keeps only https return URLs", () => {
+    const reg = parseRegistration(APP, RECORD)!;
+    expect(reg.name).toBe("Graze");
+    expect(reg.returnUrls).toEqual(["https://www.graze.social/app/account"]);
+    expect(reg.website).toBe("https://www.graze.social/");
+  });
+  it("is null without a name", () => {
+    expect(parseRegistration(APP, { returnUrls: [] })).toBeNull();
+    expect(parseRegistration(APP, "nope")).toBeNull();
+  });
+});
+
+describe("matchesRegisteredReturnUrl", () => {
+  const registered = ["https://www.graze.social/app/account"];
+  it("matches on origin + path, allowing a query string", () => {
+    expect(
+      matchesRegisteredReturnUrl(
+        "https://www.graze.social/app/account?cocore=connected",
+        registered,
+      ),
+    ).toBe(true);
+    expect(matchesRegisteredReturnUrl("https://www.graze.social/app/account/", registered)).toBe(
+      true,
+    );
+  });
+  it("rejects other paths, hosts, and schemes", () => {
+    expect(matchesRegisteredReturnUrl("https://www.graze.social/app/other", registered)).toBe(
+      false,
+    );
+    expect(matchesRegisteredReturnUrl("https://evil.example/app/account", registered)).toBe(false);
+    expect(matchesRegisteredReturnUrl("http://www.graze.social/app/account", registered)).toBe(
+      false,
+    );
+  });
+});
+
+describe("createAppResolver", () => {
+  it("reads the record from the app's PDS and verifies the host via well-known", async () => {
+    let recordFetches = 0;
+    const resolver = createAppResolver({
+      resolvePds: async (did) => (did === APP ? "https://pds.example" : null),
+      fetch: fakeFetch({
+        "https://pds.example/xrpc/com.atproto.repo.getRecord": () => {
+          recordFetches += 1;
+          return json({ uri: "at://x", value: RECORD });
+        },
+        "https://www.graze.social/.well-known/cocore-app.json": () => json({ did: APP }),
+        "https://evil.example/.well-known/cocore-app.json": () =>
+          json({ did: "did:plc:someoneelse" }),
+      }),
+    });
+    const reg = await resolver.resolve(APP);
+    expect(reg?.name).toBe("Graze");
+    await resolver.resolve(APP);
+    expect(recordFetches).toBe(1); // cached
+    expect(await resolver.verifyHost("www.graze.social", APP)).toBe(true);
+    expect(await resolver.verifyHost("evil.example", APP)).toBe(false);
+    expect(await resolver.verifyHost("nowhere.example", APP)).toBe(false);
+  });
+  it("returns null for an unregistered DID and for a non-DID", async () => {
+    const resolver = createAppResolver({
+      resolvePds: async () => "https://pds.example",
+      fetch: fakeFetch({}),
+    });
+    expect(await resolver.resolve("did:plc:nobody")).toBeNull();
+    expect(await resolver.resolve("not-a-did")).toBeNull();
+  });
+});

--- a/packages/appview/src/devicepair/app-registration.ts
+++ b/packages/appview/src/devicepair/app-registration.ts
@@ -1,0 +1,230 @@
+// Who is asking? Resolving an application's identity for device pairing.
+//
+// An application that connects users' co/core accounts ("Sign in with
+// co/core") announces itself with a `dev.cocore.app.registration` record on
+// its OWN account — there is no central app registry, consistent with the
+// rest of co/core. When `devicePair.start` carries `appDid`, this module:
+//
+//   1. resolves the DID document → PDS endpoint, and reads the record;
+//   2. decides whether a requested return URL is one the record allows; and
+//   3. checks the return host proves it belongs to that DID by serving
+//      `https://<host>/.well-known/cocore-app.json` with `{"did": "<appDid>"}`.
+//
+// (3) is what stops a record on a stranger's account from borrowing a real
+// app's domain: the record can claim any URL, but the browser is only sent
+// somewhere that vouches for the DID. Everything here is cached in memory;
+// `fetch` and the DID resolver are injectable so the tests need no network.
+
+import { getPdsEndpoint } from "@atcute/identity";
+import {
+  CompositeDidDocumentResolver,
+  PlcDidDocumentResolver,
+  WebDidDocumentResolver,
+} from "@atcute/identity-resolver";
+import type { Did } from "@atcute/lexicons";
+import { isDid } from "@atcute/lexicons/syntax";
+
+const APP_REGISTRATION_COLLECTION = "dev.cocore.app.registration";
+const WELL_KNOWN_PATH = "/.well-known/cocore-app.json";
+
+const NAME_MAX = 40;
+const DESCRIPTION_MAX = 300;
+const RETURN_URLS_MAX = 10;
+const REGISTRATION_TTL_MS = 10 * 60 * 1000;
+const REGISTRATION_MISS_TTL_MS = 60 * 1000;
+const HOST_OK_TTL_MS = 60 * 60 * 1000;
+const HOST_FAIL_TTL_MS = 5 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 6000;
+
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARS = /[\u0000-\u001f\u007f]/g;
+
+/** The validated content of an app's registration record. */
+export interface AppRegistration {
+  did: string;
+  name: string;
+  description?: string;
+  website?: string;
+  iconUrl?: string;
+  returnUrls: string[];
+}
+
+/** What the approve screen shows about the app; stored on the pairing. */
+export interface AppIdentity {
+  did: string;
+  handle?: string;
+  name: string;
+  website?: string;
+  iconUrl?: string;
+  /** The return host proved it belongs to `did`. */
+  verified: boolean;
+  verifiedHost?: string;
+}
+
+export interface AppResolver {
+  resolve(did: string): Promise<AppRegistration | null>;
+  /** Does `https://<host>/.well-known/cocore-app.json` name `did`? */
+  verifyHost(host: string, did: string): Promise<boolean>;
+}
+
+export interface AppResolverDeps {
+  fetch?: typeof fetch;
+  /** DID → PDS base URL, or null when unresolvable. Defaults to plc/web resolution. */
+  resolvePds?: (did: string) => Promise<string | null>;
+  now?: () => number;
+}
+
+function httpsUrl(value: unknown, max = 2048): string | undefined {
+  if (typeof value !== "string" || !value || value.length > max) return undefined;
+  try {
+    const u = new URL(value);
+    return u.protocol === "https:" && !u.username && !u.password ? u.toString() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function text(value: unknown, max: number): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const cleaned = value.replace(CONTROL_CHARS, "").replace(/\s+/g, " ").trim();
+  return cleaned ? cleaned.slice(0, max) : undefined;
+}
+
+/** Validate a raw record value into an AppRegistration, or null if unusable. */
+export function parseRegistration(did: string, value: unknown): AppRegistration | null {
+  if (typeof value !== "object" || value === null) return null;
+  const v = value as Record<string, unknown>;
+  const name = text(v.name, NAME_MAX);
+  if (!name) return null;
+  const returnUrls = Array.isArray(v.returnUrls)
+    ? v.returnUrls
+        .map((u) => httpsUrl(u))
+        .filter((u): u is string => Boolean(u))
+        .slice(0, RETURN_URLS_MAX)
+    : [];
+  const description = text(v.description, DESCRIPTION_MAX);
+  const website = httpsUrl(v.website);
+  const iconUrl = httpsUrl(v.iconUrl);
+  return {
+    did,
+    name,
+    ...(description ? { description } : {}),
+    ...(website ? { website } : {}),
+    ...(iconUrl ? { iconUrl } : {}),
+    returnUrls,
+  };
+}
+
+/** A requested return URL matches a registered one when origin and path
+ *  agree; the query string may differ (apps pass state in it). https only. */
+export function matchesRegisteredReturnUrl(
+  candidate: string,
+  registered: readonly string[],
+): boolean {
+  let c: URL;
+  try {
+    c = new URL(candidate);
+  } catch {
+    return false;
+  }
+  if (c.protocol !== "https:" || c.username || c.password) return false;
+  const path = c.pathname.replace(/\/+$/, "") || "/";
+  return registered.some((r) => {
+    try {
+      const ru = new URL(r);
+      return ru.origin === c.origin && (ru.pathname.replace(/\/+$/, "") || "/") === path;
+    } catch {
+      return false;
+    }
+  });
+}
+
+const defaultDidResolver = new CompositeDidDocumentResolver({
+  methods: { plc: new PlcDidDocumentResolver(), web: new WebDidDocumentResolver() },
+});
+
+async function defaultResolvePds(did: string): Promise<string | null> {
+  if (!isDid(did)) return null;
+  try {
+    const doc = await defaultDidResolver.resolve(did as Did<"plc" | "web">);
+    return getPdsEndpoint(doc) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchWithTimeout(f: typeof fetch, url: string, ms: number): Promise<Response> {
+  const ac = new AbortController();
+  const t = setTimeout(() => ac.abort(), ms);
+  try {
+    return await f(url, {
+      signal: ac.signal,
+      redirect: "follow",
+      headers: { accept: "application/json" },
+    });
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+export function createAppResolver(deps: AppResolverDeps = {}): AppResolver {
+  const f = deps.fetch ?? fetch;
+  const resolvePds = deps.resolvePds ?? defaultResolvePds;
+  const now = deps.now ?? (() => Date.now());
+  const registrations = new Map<string, { at: number; value: AppRegistration | null }>();
+  const hosts = new Map<string, { at: number; ok: boolean }>();
+
+  return {
+    async resolve(did) {
+      if (!isDid(did)) return null;
+      const cached = registrations.get(did);
+      if (cached) {
+        const ttl = cached.value ? REGISTRATION_TTL_MS : REGISTRATION_MISS_TTL_MS;
+        if (now() - cached.at < ttl) return cached.value;
+      }
+      let value: AppRegistration | null = null;
+      try {
+        const pds = await resolvePds(did);
+        if (pds) {
+          const url =
+            `${pds.replace(/\/$/, "")}/xrpc/com.atproto.repo.getRecord?repo=${encodeURIComponent(did)}` +
+            `&collection=${APP_REGISTRATION_COLLECTION}&rkey=self`;
+          const res = await fetchWithTimeout(f, url, FETCH_TIMEOUT_MS);
+          if (res.ok) {
+            const body = (await res.json()) as { value?: unknown };
+            value = parseRegistration(did, body.value);
+          }
+        }
+      } catch {
+        value = null;
+      }
+      registrations.set(did, { at: now(), value });
+      return value;
+    },
+
+    async verifyHost(host, did) {
+      const key = `${host.toLowerCase()}|${did}`;
+      const cached = hosts.get(key);
+      if (cached && now() - cached.at < (cached.ok ? HOST_OK_TTL_MS : HOST_FAIL_TTL_MS)) {
+        return cached.ok;
+      }
+      let ok = false;
+      try {
+        const res = await fetchWithTimeout(
+          f,
+          `https://${host}${WELL_KNOWN_PATH}`,
+          FETCH_TIMEOUT_MS,
+        );
+        if (res.ok) {
+          const body = (await res.json()) as { did?: unknown; dids?: unknown };
+          const listed = Array.isArray(body.dids) ? body.dids : [body.did];
+          ok = listed.some((d) => typeof d === "string" && d === did);
+        }
+      } catch {
+        ok = false;
+      }
+      hosts.set(key, { at: now(), ok });
+      return ok;
+    },
+  };
+}

--- a/packages/appview/src/devicepair/pair-store.ts
+++ b/packages/appview/src/devicepair/pair-store.ts
@@ -16,6 +16,8 @@
 
 import { randomBytes } from "node:crypto";
 
+import type { AppIdentity } from "./app-registration.ts";
+
 type PairStatus = "pending" | "approved" | "denied" | "expired" | "consumed";
 
 /** Session blob handed to a paired agent. The agent authenticates to its
@@ -41,6 +43,8 @@ export interface PairMeta {
   keyName?: string;
   /** Where to send the browser after approval. */
   returnUrl?: string;
+  /** The registered app behind the request, when `start` carried `appDid`. */
+  app?: AppIdentity;
 }
 
 export interface PairEntry {
@@ -60,6 +64,7 @@ export interface DescribeResult {
   appName?: string;
   keyName?: string;
   returnUrl?: string;
+  app?: AppIdentity;
   expiresInSecs: number;
 }
 
@@ -130,6 +135,7 @@ export class PairStore {
       ...(entry.meta.appName ? { appName: entry.meta.appName } : {}),
       ...(entry.meta.keyName ? { keyName: entry.meta.keyName } : {}),
       ...(entry.meta.returnUrl ? { returnUrl: entry.meta.returnUrl } : {}),
+      ...(entry.meta.app ? { app: entry.meta.app } : {}),
       expiresInSecs: remaining,
     };
   }

--- a/packages/appview/src/devicepair/routes.test.ts
+++ b/packages/appview/src/devicepair/routes.test.ts
@@ -144,3 +144,107 @@ describe("devicePair routes: application metadata", () => {
     );
   });
 });
+
+describe("devicePair routes: registered applications (appDid)", () => {
+  const APP = "did:plc:grazeapp";
+  const registration = {
+    did: APP,
+    name: "Graze",
+    website: "https://www.graze.social/",
+    returnUrls: ["https://www.graze.social/app/account"],
+  };
+  const fakeResolver = (verified: boolean) => ({
+    resolve: async (did: string) => (did === APP ? registration : null),
+    verifyHost: async () => verified,
+  });
+
+  it("takes the name from the record, verifies the return host, and describes the app", async () => {
+    await withAppviewServer(
+      router({ returnHosts: [], appResolver: fakeResolver(true) }),
+      async (base) => {
+        const r = await fetch(`${base}/xrpc/dev.cocore.devicePair.start`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            appDid: APP,
+            appName: "Totally Not Graze",
+            keyName: "Graze Feed Pulse",
+            returnUrl: "https://www.graze.social/app/account?cocore=connected",
+          }),
+        });
+        expect(r.status).toBe(200);
+        const started = (await r.json()) as { userCode: string };
+        const described = (await (
+          await fetch(`${base}/xrpc/dev.cocore.devicePair.describe?userCode=${started.userCode}`)
+        ).json()) as Record<string, unknown>;
+        expect(described.appName).toBe("Graze");
+        expect(described.returnUrl).toBe("https://www.graze.social/app/account?cocore=connected");
+        expect(described.app).toMatchObject({
+          did: APP,
+          name: "Graze",
+          verified: true,
+          verifiedHost: "www.graze.social",
+        });
+      },
+    );
+  });
+
+  it("drops the return URL for an unverified host but still pairs, marked unverified", async () => {
+    await withAppviewServer(
+      router({ returnHosts: [], appResolver: fakeResolver(false) }),
+      async (base) => {
+        const r = await fetch(`${base}/xrpc/dev.cocore.devicePair.start`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ appDid: APP, returnUrl: "https://www.graze.social/app/account" }),
+        });
+        expect(r.status).toBe(200);
+        const started = (await r.json()) as { userCode: string };
+        const described = (await (
+          await fetch(`${base}/xrpc/dev.cocore.devicePair.describe?userCode=${started.userCode}`)
+        ).json()) as Record<string, unknown>;
+        expect(described).not.toHaveProperty("returnUrl");
+        expect(described.app).toMatchObject({ did: APP, verified: false });
+      },
+    );
+  });
+
+  it("rejects a return URL the record does not list, and an unregistered or malformed appDid", async () => {
+    await withAppviewServer(
+      router({ returnHosts: [], appResolver: fakeResolver(true) }),
+      async (base) => {
+        const other = await fetch(`${base}/xrpc/dev.cocore.devicePair.start`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            appDid: APP,
+            returnUrl: "https://www.graze.social/somewhere-else",
+          }),
+        });
+        const described = (await (
+          await fetch(
+            `${base}/xrpc/dev.cocore.devicePair.describe?userCode=${((await other.json()) as { userCode: string }).userCode}`,
+          )
+        ).json()) as Record<string, unknown>;
+        expect(described).not.toHaveProperty("returnUrl");
+
+        const unregistered = await fetch(`${base}/xrpc/dev.cocore.devicePair.start`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ appDid: "did:plc:nobody" }),
+        });
+        expect(unregistered.status).toBe(400);
+        expect(((await unregistered.json()) as { message: string }).message).toContain(
+          "AppNotRegistered",
+        );
+
+        const malformed = await fetch(`${base}/xrpc/dev.cocore.devicePair.start`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ appDid: "graze" }),
+        });
+        expect(malformed.status).toBe(400);
+      },
+    );
+  });
+});

--- a/packages/appview/src/devicepair/routes.ts
+++ b/packages/appview/src/devicepair/routes.ts
@@ -32,8 +32,16 @@ import { verifyServiceAuthToken } from "../auth/service-auth.ts";
 import type { AccountStore } from "../operational/account-store.ts";
 import { hydrateDids } from "../bsky-hydrate.ts";
 import { bearer, err, header, jsonBody, ok, searchParams } from "../api/http-app.ts";
+import { isDid } from "@atcute/lexicons/syntax";
+
+import {
+  type AppIdentity,
+  type AppResolver,
+  createAppResolver,
+  matchesRegisteredReturnUrl,
+} from "./app-registration.ts";
 import { clientKey, createRateLimiter, sanitizePairMeta, type RateLimiter } from "./pair-meta.ts";
-import { PairError, type PairStore, type ProviderSession } from "./pair-store.ts";
+import { type PairMeta, PairError, type PairStore, type ProviderSession } from "./pair-store.ts";
 
 /** Constant-time compare that tolerates length differences (never short-
  *  circuits on unequal lengths in a timing-observable way). */
@@ -84,6 +92,9 @@ export interface DevicePairContext {
   returnHosts?: readonly string[];
   /** Override the per-client budgets (tests). */
   rateLimits?: DevicePairRateLimits;
+  /** Resolves `appDid` → the app's registration record and verifies return
+   *  hosts. Defaults to live plc/web + https resolution; tests inject one. */
+  appResolver?: AppResolver;
 }
 
 function isProviderSession(v: unknown): v is ProviderSession {
@@ -128,6 +139,51 @@ export function buildDevicePairRouter(
   const describeLimiter = createRateLimiter(limits.describe, limits.windowMs);
   const confirmLimiter = createRateLimiter(limits.confirm, limits.windowMs);
   const returnHosts = ctx.returnHosts ?? [];
+  const appResolver = ctx.appResolver ?? createAppResolver();
+
+  /** Build the pairing metadata for a `start` body.
+   *
+   *  Without `appDid` this is the legacy path: a self-declared `appName`, and
+   *  a return URL only for operator-allowlisted hosts. With `appDid`, identity
+   *  comes from the app's own `dev.cocore.app.registration` record and the
+   *  return URL must be one the record lists AND on a host that vouches for the
+   *  DID (or that the operator allowlists). An unverified app still pairs — the
+   *  approve screen just says so and never sends the browser to it. */
+  async function metaForStart(body: unknown): Promise<{ meta: PairMeta } | { error: string }> {
+    const meta = sanitizePairMeta(body, returnHosts);
+    const b = (typeof body === "object" && body !== null ? body : {}) as Record<string, unknown>;
+    if (b.appDid === undefined || b.appDid === null) return { meta };
+    if (typeof b.appDid !== "string" || !isDid(b.appDid)) return { error: "appDid must be a DID" };
+    const appDid = b.appDid;
+    const registration = await appResolver.resolve(appDid);
+    if (!registration) {
+      return {
+        error: `AppNotRegistered: no dev.cocore.app.registration record at ${appDid}; publish one on the app's account first`,
+      };
+    }
+    const handle = (await hydrateDids([appDid]).catch(() => new Map())).get(appDid)?.handle;
+    const app: AppIdentity = {
+      did: appDid,
+      ...(handle ? { handle } : {}),
+      name: registration.name,
+      ...(registration.website ? { website: registration.website } : {}),
+      ...(registration.iconUrl ? { iconUrl: registration.iconUrl } : {}),
+      verified: false,
+    };
+    // The record's name wins over anything the request typed.
+    const withApp: PairMeta = { ...meta, appName: registration.name, app };
+    delete withApp.returnUrl;
+    const requested = typeof b.returnUrl === "string" ? b.returnUrl : undefined;
+    if (requested && matchesRegisteredReturnUrl(requested, registration.returnUrls)) {
+      const host = new URL(requested).hostname.toLowerCase();
+      const verified = returnHosts.includes(host) || (await appResolver.verifyHost(host, appDid));
+      if (verified) {
+        withApp.returnUrl = requested;
+        withApp.app = { ...app, verified: true, verifiedHost: host };
+      }
+    }
+    return { meta: withApp };
+  }
 
   return HttpRouter.empty.pipe(
     // start is mounted with `all` so a wrong method reaches the handler and
@@ -143,8 +199,10 @@ export function buildDevicePairRouter(
         // unparseable is treated as "no metadata", never as an error, so a
         // requester that sends a stray content-type still gets paired.
         const parsed = yield* Effect.either(jsonBody);
-        const meta = parsed._tag === "Right" ? sanitizePairMeta(parsed.right, returnHosts) : {};
-        return ok(store.start(meta));
+        const body = parsed._tag === "Right" ? parsed.right : undefined;
+        const built = yield* Effect.promise(() => metaForStart(body));
+        if ("error" in built) return err(400, { error: "InvalidRequest", message: built.error });
+        return ok(store.start(built.meta));
       }).pipe(Effect.withSpan("appview.devicePair.start")),
     ),
 

--- a/packages/console/src/components/PairConfirm.tsx
+++ b/packages/console/src/components/PairConfirm.tsx
@@ -23,11 +23,23 @@ interface Props {
 }
 
 /** What `dev.cocore.devicePair.describe` says about the code: who is asking. */
+interface DescribedApp {
+  did: string;
+  handle?: string;
+  name: string;
+  website?: string;
+  iconUrl?: string;
+  verified: boolean;
+  verifiedHost?: string;
+}
+
 interface Described {
   status: "pending" | "approved" | "denied" | "expired" | "consumed";
   appName?: string;
   keyName?: string;
   returnUrl?: string;
+  /** Present when the requester is a registered application (`appDid`). */
+  app?: DescribedApp;
   expiresInSecs: number;
 }
 
@@ -83,6 +95,7 @@ export function PairConfirm({ initialCode }: Props) {
   }, [status, returnUrl]);
 
   const appName = described?.appName;
+  const app = described?.app;
 
   async function approve() {
     setStatus("approving");
@@ -162,6 +175,34 @@ export function PairConfirm({ initialCode }: Props) {
       {appName ? (
         <>
           <Heading1>Connect {appName} to co/core</Heading1>
+          {app ? (
+            <Body>
+              {app.verified ? (
+                <>
+                  Verified application: {app.handle ? `@${app.handle}` : app.did}
+                  {app.verifiedHost ? ` · ${app.verifiedHost}` : ""}
+                  {app.website ? (
+                    <>
+                      {" "}
+                      · <a href={app.website}>{new URL(app.website).host}</a>
+                    </>
+                  ) : null}
+                </>
+              ) : (
+                <>
+                  <strong>Unverified application</strong> ({app.handle ? `@${app.handle}` : app.did}
+                  ). co/core could not confirm this app controls a website, so it will not be sent
+                  your browser afterwards. Only continue if you started this from {appName}{" "}
+                  yourself.
+                </>
+              )}
+            </Body>
+          ) : (
+            <Body>
+              <strong>Unregistered request.</strong> This name was typed by whoever started the
+              pairing and has not been checked. Only continue if you started this yourself.
+            </Body>
+          )}
           <Body>
             <strong>{appName}</strong> is asking for an API key on your co/core account
             {described?.keyName ? (

--- a/packages/console/src/lib/pair-store.ts
+++ b/packages/console/src/lib/pair-store.ts
@@ -40,10 +40,24 @@ export interface ProviderSession {
 /** What the requester told us about itself at `start`. All optional; a bare
  *  `cocore agent pair` sends none of it. Validated by the route layer before it
  *  reaches the store. */
+/** The registered application behind a pairing (see the AppView's
+ *  app-registration.ts). Mirrored here for the legacy in-process store. */
+interface AppIdentity {
+  did: string;
+  handle?: string;
+  name: string;
+  website?: string;
+  iconUrl?: string;
+  verified: boolean;
+  verifiedHost?: string;
+}
+
 export interface PairMeta {
   appName?: string;
   keyName?: string;
   returnUrl?: string;
+  /** The registered app behind the request, when `start` carried `appDid`. */
+  app?: AppIdentity;
 }
 
 export interface PairEntry {
@@ -61,6 +75,7 @@ export interface DescribeResult {
   appName?: string;
   keyName?: string;
   returnUrl?: string;
+  app?: AppIdentity;
   expiresInSecs: number;
 }
 
@@ -134,6 +149,7 @@ export class PairStore {
       ...(entry.meta.appName ? { appName: entry.meta.appName } : {}),
       ...(entry.meta.keyName ? { keyName: entry.meta.keyName } : {}),
       ...(entry.meta.returnUrl ? { returnUrl: entry.meta.returnUrl } : {}),
+      ...(entry.meta.app ? { app: entry.meta.app } : {}),
       expiresInSecs: remaining,
     };
   }

--- a/packages/sdk/src/connect.ts
+++ b/packages/sdk/src/connect.ts
@@ -1,0 +1,120 @@
+// "Sign in with co/core" for applications: the requester side of device pairing.
+//
+// An app that wants to act on a user's co/core account (run inference billed
+// to their credits) does not ask them to copy keys around. It starts a
+// pairing, sends the user to co/core to approve "Connect <app> to co/core",
+// and collects a key scoped to that user. The app is identified by a
+// `dev.cocore.app.registration` record on its own account (`appDid`), and
+// the user is returned to one of that record's `returnUrls` — provided the
+// return host serves `/.well-known/cocore-app.json` naming the app's DID.
+//
+// Server-side only: the `deviceId` returned by `start` is the credential
+// that collects the key, so it must never reach a browser.
+
+export const DEFAULT_CONSOLE_URL = "https://cocore.dev";
+
+export interface StartAppPairingInput {
+  /** The application's DID; it must have published a registration record. */
+  appDid: string;
+  /** Name for the minted key, so the user can recognise and revoke it. */
+  keyName?: string;
+  /** Where the approve screen sends the browser afterwards. Must match one of
+   *  the registration's `returnUrls` on origin + path. */
+  returnUrl?: string;
+  consoleUrl?: string;
+  fetch?: typeof fetch;
+}
+
+export interface AppPairing {
+  deviceId: string;
+  userCode: string;
+  verificationUri: string;
+  pollIntervalSecs: number;
+  expiresInSecs: number;
+}
+
+export interface PairedSession {
+  did: string;
+  handle: string;
+  apiKey: string;
+  apiBase: string;
+}
+
+export type AppPairingPoll =
+  | { status: "pending" }
+  | { status: "session"; session: PairedSession }
+  | { status: "denied" | "expired" | "consumed" | "unknown" };
+
+export class AppPairingError extends Error {
+  readonly status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "AppPairingError";
+    this.status = status;
+  }
+}
+
+async function readError(res: Response): Promise<string> {
+  try {
+    const b = (await res.json()) as { message?: string; error?: string };
+    return b.message ?? b.error ?? `HTTP ${res.status}`;
+  } catch {
+    return `HTTP ${res.status}`;
+  }
+}
+
+/** Begin a pairing. Send the user to `verificationUri`; keep `deviceId` on the server. */
+export async function startAppPairing(input: StartAppPairingInput): Promise<AppPairing> {
+  const f = input.fetch ?? fetch;
+  const base = (input.consoleUrl ?? DEFAULT_CONSOLE_URL).replace(/\/$/, "");
+  const res = await f(`${base}/api/xrpc/dev.cocore.devicePair.start`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      appDid: input.appDid,
+      ...(input.keyName ? { keyName: input.keyName } : {}),
+      ...(input.returnUrl ? { returnUrl: input.returnUrl } : {}),
+    }),
+  });
+  if (!res.ok) throw new AppPairingError(res.status, await readError(res));
+  return (await res.json()) as AppPairing;
+}
+
+/** One poll. `session` arrives exactly once; after that the attempt is `consumed`. */
+export async function pollAppPairing(
+  deviceId: string,
+  opts: { consoleUrl?: string; fetch?: typeof fetch } = {},
+): Promise<AppPairingPoll> {
+  const f = opts.fetch ?? fetch;
+  const base = (opts.consoleUrl ?? DEFAULT_CONSOLE_URL).replace(/\/$/, "");
+  const res = await f(
+    `${base}/api/xrpc/dev.cocore.devicePair.poll?deviceId=${encodeURIComponent(deviceId)}`,
+  );
+  const body = (await res.json().catch(() => ({}))) as { status?: string; session?: PairedSession };
+  if (res.ok && body.status === "session" && body.session) {
+    return { status: "session", session: body.session };
+  }
+  if (res.ok && body.status === "pending") return { status: "pending" };
+  if (res.status === 403) return { status: "denied" };
+  if (res.status === 404) return { status: "unknown" };
+  if (res.status === 410) return { status: body.status === "consumed" ? "consumed" : "expired" };
+  throw new AppPairingError(res.status, await readError(res));
+}
+
+/** Poll until the user acts or the attempt expires. Resolves with the session
+ *  on approval; throws AppPairingError otherwise. */
+export async function waitForAppPairing(
+  pairing: Pick<AppPairing, "deviceId" | "pollIntervalSecs" | "expiresInSecs">,
+  opts: { consoleUrl?: string; fetch?: typeof fetch; signal?: AbortSignal } = {},
+): Promise<PairedSession> {
+  const intervalMs = Math.max(1000, pairing.pollIntervalSecs * 1000);
+  const deadline = Date.now() + pairing.expiresInSecs * 1000 + 5000;
+  while (Date.now() < deadline) {
+    if (opts.signal?.aborted) throw new AppPairingError(0, "aborted");
+    const r = await pollAppPairing(pairing.deviceId, opts);
+    if (r.status === "session") return r.session;
+    if (r.status !== "pending") throw new AppPairingError(0, `pairing ${r.status}`);
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new AppPairingError(0, "pairing expired");
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./canonical.ts";
+export * from "./connect.ts";
 export * from "./firehose.ts";
 export * from "./mda.ts";
 export * from "./appattest.ts";

--- a/sdk/py/cocore/__init__.py
+++ b/sdk/py/cocore/__init__.py
@@ -3,6 +3,15 @@
 Mirrors the TypeScript SDK's verification surface so ML practitioners can verify
 a provider's confidential-tier attestation (fail-closed) before sealing a prompt.
 """
+from .connect import (
+    AppPairing,
+    AppPairingError,
+    AppPairingPoll,
+    PairedSession,
+    poll_app_pairing,
+    start_app_pairing,
+    wait_for_app_pairing,
+)
 
 from .appattest import (
     APP_ATTEST_APP_ID,
@@ -35,6 +44,13 @@ from .validate import (
 from .verify import VerifyResult, session_key_message, verify_provider_for_seal
 
 __all__ = [
+    "AppPairing",
+    "AppPairingError",
+    "AppPairingPoll",
+    "PairedSession",
+    "poll_app_pairing",
+    "start_app_pairing",
+    "wait_for_app_pairing",
     "CanonicalError",
     "canonicalize",
     "canonical_bytes",

--- a/sdk/py/cocore/connect.py
+++ b/sdk/py/cocore/connect.py
@@ -1,0 +1,126 @@
+"""``Sign in with co/core`` for applications: the requester side of device pairing.
+
+An app that wants to act on a user's co/core account starts a pairing, sends
+the user to co/core to approve "Connect <app> to co/core", and collects an
+API key scoped to that user. The app identifies itself with a
+``dev.cocore.app.registration`` record on its own account (``app_did``); the
+user is returned to one of that record's ``returnUrls`` provided the return
+host serves ``/.well-known/cocore-app.json`` naming the app's DID.
+
+Server-side only: the ``device_id`` returned by :func:`start_app_pairing` is the
+credential that collects the key, so it must never reach a browser.
+
+Standard library only — no dependencies.
+"""
+from __future__ import annotations
+
+import json
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Optional
+
+DEFAULT_CONSOLE_URL = "https://cocore.dev"
+
+
+class AppPairingError(Exception):
+    def __init__(self, status: int, message: str):
+        super().__init__(f"{message} (HTTP {status})" if status else message)
+        self.status = status
+
+
+@dataclass(frozen=True)
+class AppPairing:
+    device_id: str
+    user_code: str
+    verification_uri: str
+    poll_interval_secs: int
+    expires_in_secs: int
+
+
+@dataclass(frozen=True)
+class PairedSession:
+    did: str
+    handle: str
+    api_key: str
+    api_base: str
+
+
+@dataclass(frozen=True)
+class AppPairingPoll:
+    status: str  # pending | session | denied | expired | consumed | unknown
+    session: Optional[PairedSession] = None
+
+
+def _request(url: str, *, method: str = "GET", body: Optional[dict] = None, timeout: float = 15.0):
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method, headers={"content-type": "application/json", "accept": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 - fixed https host
+            return resp.status, json.loads(resp.read() or b"{}")
+    except urllib.error.HTTPError as exc:
+        try:
+            payload = json.loads(exc.read() or b"{}")
+        except ValueError:
+            payload = {}
+        return exc.code, payload
+
+
+def start_app_pairing(
+    app_did: str,
+    *,
+    key_name: Optional[str] = None,
+    return_url: Optional[str] = None,
+    console_url: str = DEFAULT_CONSOLE_URL,
+) -> AppPairing:
+    """Begin a pairing. Send the user to ``verification_uri``; keep ``device_id`` server-side."""
+    body = {"appDid": app_did}
+    if key_name:
+        body["keyName"] = key_name
+    if return_url:
+        body["returnUrl"] = return_url
+    status, payload = _request(f"{console_url.rstrip('/')}/api/xrpc/dev.cocore.devicePair.start", method="POST", body=body)
+    if status != 200:
+        raise AppPairingError(status, str(payload.get("message") or payload.get("error") or "start failed"))
+    return AppPairing(
+        device_id=payload["deviceId"],
+        user_code=payload["userCode"],
+        verification_uri=payload["verificationUri"],
+        poll_interval_secs=int(payload.get("pollIntervalSecs") or 3),
+        expires_in_secs=int(payload.get("expiresInSecs") or 600),
+    )
+
+
+def poll_app_pairing(device_id: str, *, console_url: str = DEFAULT_CONSOLE_URL) -> AppPairingPoll:
+    """One poll. ``session`` arrives exactly once; afterwards the attempt is ``consumed``."""
+    url = f"{console_url.rstrip('/')}/api/xrpc/dev.cocore.devicePair.poll?deviceId={urllib.parse.quote(device_id)}"
+    status, payload = _request(url)
+    state = str(payload.get("status") or "")
+    if status == 200 and state == "session" and isinstance(payload.get("session"), dict):
+        s = payload["session"]
+        return AppPairingPoll("session", PairedSession(s["did"], s.get("handle") or s["did"], s["apiKey"], s["apiBase"]))
+    if status == 200 and state == "pending":
+        return AppPairingPoll("pending")
+    if status == 403:
+        return AppPairingPoll("denied")
+    if status == 404:
+        return AppPairingPoll("unknown")
+    if status == 410:
+        return AppPairingPoll("consumed" if state == "consumed" else "expired")
+    raise AppPairingError(status, str(payload.get("message") or payload.get("error") or "poll failed"))
+
+
+def wait_for_app_pairing(pairing: AppPairing, *, console_url: str = DEFAULT_CONSOLE_URL) -> PairedSession:
+    """Poll until the user acts or the attempt expires. Returns the session on approval."""
+    deadline = time.monotonic() + pairing.expires_in_secs + 5
+    interval = max(1, pairing.poll_interval_secs)
+    while time.monotonic() < deadline:
+        result = poll_app_pairing(pairing.device_id, console_url=console_url)
+        if result.status == "session" and result.session is not None:
+            return result.session
+        if result.status != "pending":
+            raise AppPairingError(0, f"pairing {result.status}")
+        time.sleep(interval)
+    raise AppPairingError(0, "pairing expired")


### PR DESCRIPTION
## Why
The device-pairing consent screen names an app only by the raw `appDid` it sends. The registration record + verified-return-host feature that turns that into a named, **verified** identity was written but never merged — so "Sign in with co/core" shows an unverified DID. This deploys it.

## What
- **AppView** `devicepair/app-registration.ts`: resolves an app's `dev.cocore.app.registration` record (DID → PDS → getRecord), then `verifyHost` confirms the app's return host serves `/.well-known/cocore-app.json` naming the app DID. Cached, fail-closed. Wired into `devicePair.describe` so its output carries `app{did,handle,name,website,iconUrl,verified,verifiedHost}`.
- **lexicons** describe/start/registration for the fields.
- **Console** `PairConfirm.tsx` renders the verified (or unverified) identity.
- **SDK** `startAppPairing`/`pollAppPairing`/`waitForAppPairing` (TS + Python) and docs.

## Verification (live-ready)
Graze already satisfies both halves: its `dev.cocore.app.registration` record is published on `did:plc:i6y3jdklpvkjvynvsrnqfdoq` (website `www.graze.social`), and `https://www.graze.social/.well-known/cocore-app.json` lists that DID. Once the AppView deploys this, `devicePair.describe` for a Graze pairing returns `verified: true, verifiedHost: www.graze.social`.

## Checks
`make lex-validate` + `lex-codegen-check` clean; appview/console/sdk `tsc` clean; `app-registration` tests 6/6; oxfmt/oxlint/knip clean. (The sqlite-backed `routes.test.ts` runs on CI Node 22, not this Mac's Node 26.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)