### PR TITLE
fix(advisor,console): stop recycling provider sockets out from under live jobs

### DIFF
--- a/infra/advisor/src/connection.test.ts
+++ b/infra/advisor/src/connection.test.ts
@@ -290,7 +290,13 @@ interface DropHarness {
   sessions: SessionManager;
 }
 
-async function startDropHarness(opts: { maxConnectionMs?: number } = {}): Promise<DropHarness> {
+async function startDropHarness(
+  opts: {
+    maxConnectionMs?: number;
+    maxConnectionDrainMs?: number;
+    recycleDrainPollMs?: number;
+  } = {},
+): Promise<DropHarness> {
   const registry = new ProviderRegistry();
   const sessions = new SessionManager({ idleTimeoutMs: 10_000 });
   const server = createServer();
@@ -573,8 +579,10 @@ describe("provider mid-job socket drop", () => {
     }
   }, 5_000);
 
-  it("fails legacy sessions but preserves resumable sessions on advisor recycle", async () => {
-    const h = await startDropHarness({ maxConnectionMs: 150 });
+  it("fails legacy sessions but preserves resumable sessions when a recycle is forced", async () => {
+    // drain 0 = the old close-on-the-dot behavior, which is also what a
+    // machine that stays busy right through the drain window ends up with.
+    const h = await startDropHarness({ maxConnectionMs: 150, maxConnectionDrainMs: 0 });
     try {
       const ws = await registerProvider(h.url, "did:plc:recycle", true);
       const legacyRes = fakeSseRes();
@@ -604,6 +612,118 @@ describe("provider mid-job socket drop", () => {
       expect(resumableRes.writableEnded).toBe(false);
       expect(failSpy).not.toHaveBeenCalled();
       h.sessions.close("sess-resume");
+    } finally {
+      await new Promise<void>((r) => h.server.close(() => r()));
+    }
+  }, 5_000);
+
+  it("holds the recycle open while a job is in flight, then recycles once idle", async () => {
+    // The recycle is advisor housekeeping on a timer. Firing it into a live
+    // job kills that job outright on a provider without stream-resume — the
+    // caller sees `provider-disconnected` for something the advisor did. So
+    // the recycle goes looking for an idle moment ahead of the hard deadline,
+    // and takes the first one.
+    const h = await startDropHarness({
+      maxConnectionMs: 5_000,
+      maxConnectionDrainMs: 4_900, // start hunting for an idle moment at ~100ms
+      recycleDrainPollMs: 20,
+    });
+    try {
+      const ws = await registerProvider(h.url, "did:plc:drain");
+      const res = fakeSseRes();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      h.sessions.open("sess-drain", "did:plc:drain", "a", "did:plc:req", res as any);
+
+      let closed = false;
+      const reason = new Promise<string>((resolve) => {
+        ws.once("close", (_c, r) => {
+          closed = true;
+          resolve(r.toString("utf-8"));
+        });
+      });
+
+      // Long past the drain deadline the socket is still up and the job is
+      // still alive: the in-flight session is holding the recycle off.
+      await new Promise((r) => setTimeout(r, 400));
+      expect(closed).toBe(false);
+      expect(h.sessions.has("sess-drain")).toBe(true);
+      expect(res.writableEnded).toBe(false);
+
+      // Job finishes → the next poll finds the machine idle and recycles
+      // immediately, rather than idling on until the hard deadline (~4.6s
+      // away — the bound that makes this assertion discriminating).
+      const completedAt = Date.now();
+      h.sessions.complete("sess-drain", { tokensIn: 1, tokensOut: 1, receiptUri: "at://r" });
+      expect(await reason).toBe("recycle");
+      expect(Date.now() - completedAt).toBeLessThan(500);
+    } finally {
+      await new Promise<void>((r) => h.server.close(() => r()));
+    }
+  }, 10_000);
+
+  it("counts a completion that produced no tokens against the machine", async () => {
+    // The silent stall: the provider takes the job, sends no chunk, and
+    // completes with zero output tokens. That is a wedged engine wearing a
+    // success frame — it must not clear the machine's standing, and it must
+    // not read as a served job.
+    const h = await startDropHarness();
+    try {
+      const ws = await registerProvider(h.url, "did:plc:silent");
+      const res = fakeSseRes();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      h.sessions.open("sess-empty", "did:plc:silent", "a", "did:plc:req", res as any);
+      const failSpy = vi.spyOn(h.registry, "recordFailure");
+      const okSpy = vi.spyOn(h.registry, "recordCompletion");
+
+      ws.send(
+        JSON.stringify({
+          type: "inference_complete",
+          session_id: "sess-empty",
+          tokens_in: 591,
+          tokens_out: 0,
+          receipt_uri: "at://receipt/empty",
+        }),
+      );
+
+      await vi.waitFor(() =>
+        expect(failSpy).toHaveBeenCalledWith("did:plc:silent", "a", "empty-completion"),
+      );
+      expect(okSpy).not.toHaveBeenCalled();
+      ws.close();
+    } finally {
+      await new Promise<void>((r) => h.server.close(() => r()));
+    }
+  }, 5_000);
+
+  it("still counts a completion that streamed tokens as a success", async () => {
+    const h = await startDropHarness();
+    try {
+      const ws = await registerProvider(h.url, "did:plc:served");
+      const res = fakeSseRes();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      h.sessions.open("sess-served", "did:plc:served", "a", "did:plc:req", res as any);
+      h.sessions.acceptChunk("sess-served", 0, {
+        type: "chunk",
+        sessionId: "sess-served",
+        seq: 0,
+        ciphertext: [1],
+      });
+      const failSpy = vi.spyOn(h.registry, "recordFailure");
+      const okSpy = vi.spyOn(h.registry, "recordCompletion");
+
+      ws.send(
+        JSON.stringify({
+          type: "inference_complete",
+          session_id: "sess-served",
+          tokens_in: 591,
+          tokens_out: 12,
+          receipt_uri: "at://receipt/good",
+        }),
+      );
+
+      await vi.waitFor(() => expect(okSpy).toHaveBeenCalledWith("did:plc:served", "a"));
+      expect(failSpy).not.toHaveBeenCalled();
+      ws.close();
     } finally {
       await new Promise<void>((r) => h.server.close(() => r()));
     }

--- a/infra/advisor/src/connection.ts
+++ b/infra/advisor/src/connection.ts
@@ -101,6 +101,26 @@ export interface ConnectionConfig {
    *  inevitable cut into a predictable, graceful cycle we control instead
    *  of an edge-initiated reset. 0 / unset disables. */
   maxConnectionMs?: number;
+  /** How long BEFORE {@link maxConnectionMs} to start looking for an idle
+   *  moment to recycle in. The recycle is advisor housekeeping on a timer, not
+   *  a deadline the requester agreed to: closing a socket with a job on it
+   *  kills that job outright on any provider without stream-resume support
+   *  (< 0.9.52), which is how the advisor's own scheduled maintenance turned
+   *  into a `provider-disconnected` 502 for the caller. So from
+   *  `maxConnectionMs - maxConnectionDrainMs` onward we re-check on
+   *  {@link recycleDrainPollMs} and close at the first moment the machine has
+   *  nothing in flight; at `maxConnectionMs` we close regardless.
+   *
+   *  Note this window comes OUT of the connection budget rather than extending
+   *  it — total socket lifetime is still capped at `maxConnectionMs`, so the
+   *  margin against the edge's own ~15-min cut is unchanged. Defaults to 180s
+   *  (longer than essentially any single job); 0 restores the old
+   *  close-on-the-dot behavior. */
+  maxConnectionDrainMs?: number;
+  /** Re-check cadence while a recycle is waiting for jobs to drain. Defaults
+   *  to 2s — short enough that the socket recycles promptly once the last job
+   *  completes, cheap enough to poll. */
+  recycleDrainPollMs?: number;
   /** APNs sender config for the code-identity challenge. Null/absent disables
    *  it: no challenges are sent and confidential eligibility is NOT gated on
    *  code-attestation (the pre-APNs behavior). Set exactly when the advisor has
@@ -187,16 +207,52 @@ export function handleConnection(
     // (clean close → backoff stays at the floor) instead of eating an
     // abrupt edge-initiated `1006` at the cap. Predictable, advisor-driven
     // recycling rather than at-the-mercy-of-the-edge resets.
-    recycleTimer = setTimeout(() => {
+    //
+    // But NEVER pull the rug out from under a job that's mid-flight if we can
+    // help it. On a provider without stream-resume (< 0.9.52) the close ends
+    // the session with `provider-disconnected`, which the caller sees as a
+    // 502 — the advisor's own maintenance failing a request that was running
+    // fine. So we start looking for an idle moment a few minutes EARLY and
+    // recycle in one; a machine that stays busy right through the window is
+    // still closed on the dot, because the edge's abrupt cut is worse.
+    const drainMs = Math.min(config.maxConnectionDrainMs ?? 180_000, config.maxConnectionMs);
+    const pollMs = config.recycleDrainPollMs ?? 2_000;
+    const hardDeadline = Date.now() + config.maxConnectionMs;
+
+    const attemptRecycle = (): void => {
+      const inflight =
+        registeredDid && registeredMachineId
+          ? sessions.inflightFor(registeredDid, registeredMachineId)
+          : 0;
+      const forced = Date.now() >= hardDeadline;
+      if (inflight > 0 && !forced) {
+        // Busy — hold the socket open and look again shortly.
+        recycleTimer = setTimeout(attemptRecycle, Math.min(pollMs, hardDeadline - Date.now()));
+        recycleTimer.unref();
+        return;
+      }
       console.error(
-        `[ws] recycling connection peer=${peer} did=${registeredDid ?? "?"} (pre-empting the edge connection cap)`,
+        `[ws] recycling connection peer=${peer} did=${registeredDid ?? "?"} machine=${registeredMachineId ?? "?"} (pre-empting the edge connection cap)` +
+          (inflight > 0 ? `; forced with ${inflight} job(s) still in flight` : ""),
       );
       close(1000, "recycle");
-    }, config.maxConnectionMs);
+    };
+
+    recycleTimer = setTimeout(attemptRecycle, config.maxConnectionMs - drainMs);
     recycleTimer.unref();
   }
 
+  // Set when the ADVISOR is the one hanging up (recycle / replaced), so the
+  // close handler can tell its own housekeeping apart from a provider that
+  // genuinely dropped. The close REASON can't carry this: the provider tears
+  // the TCP connection down rather than echoing our close frame, so the
+  // `close` event lands as `1006`/`""` every single time in production — which
+  // silently made the old `reason === "recycle"` test always false and had the
+  // advisor charging providers a failure for its own scheduled recycle.
+  let advisorClosing: string | null = null;
+
   const close = (code = 1000, reason = "normal"): void => {
+    if (reason === "recycle" || reason === "replaced") advisorClosing = reason;
     try {
       socket.close(code, reason);
     } catch {
@@ -712,6 +768,24 @@ export function handleConnection(
           });
         }
         if (!completion.accepted) return;
+        // A completion that produced NOTHING — no chunk ever relayed and zero
+        // output tokens — is a wedged engine wearing a success frame, not a
+        // served job. It reaches the caller as a 200 with an empty message,
+        // so every client ends up reimplementing stall detection. Count it
+        // against the machine's standing (it takes repeated, clustered
+        // failures to trip a cooldown, so a genuinely empty answer now and
+        // then is forgiven) and leave a log line the operator can find.
+        if (!completion.streamed && msg.tokens_out === 0) {
+          const tripped = registry.recordFailure(
+            registeredDid,
+            registeredMachineId,
+            "empty-completion",
+          );
+          console.error(
+            `[ws] empty completion did=${registeredDid} machine=${registeredMachineId} session=${msg.session_id}; accepted the job and produced no tokens${tripped ? ", repeated → cooldown" : ""}`,
+          );
+          return;
+        }
         // Count only the first valid terminal delivery; replayed completion is
         // answered from the tombstone and never reaches this branch.
         registry.recordCompletion(registeredDid, registeredMachineId);
@@ -772,10 +846,23 @@ export function handleConnection(
       const entry = registry.get(registeredDid, registeredMachineId);
       if (entry && entry.send === send) {
         const reasonStr = reason?.toString() ?? "";
-        const advisorInitiated = reasonStr === "replaced" || reasonStr === "recycle";
+        // Trust our OWN flag first; the wire reason is advisory at best (a
+        // provider that drops TCP instead of echoing the close frame gives us
+        // `1006`/`""` no matter what we sent).
+        const advisorInitiated =
+          advisorClosing !== null || reasonStr === "replaced" || reasonStr === "recycle";
         const { detached, closed } = sessions.detachForMachine(registeredDid, registeredMachineId);
         // Legacy sessions retain fail-fast behavior. Resume-capable sessions
         // are not failures unless their bounded grace actually expires.
+        if (advisorInitiated && closed > 0) {
+          // WE hung up on live work — in practice a recycle forced because the
+          // machine stayed busy through the whole drain window. The requester's
+          // job died, but that's on the advisor, so it must not cost the
+          // machine its standing.
+          console.error(
+            `[ws] advisor-initiated close (${advisorClosing ?? reasonStr}) ended ${closed} in-flight legacy session(s) did=${registeredDid} machine=${registeredMachineId}; NOT counted against the provider`,
+          );
+        }
         if (!advisorInitiated && closed > 0) {
           const tripped = registry.recordFailure(
             registeredDid,

--- a/infra/advisor/src/main.ts
+++ b/infra/advisor/src/main.ts
@@ -88,6 +88,9 @@ const CONFIG = Effect.runSync(
     wsMaxConnectionMs: Config.integer("COCORE_ADVISOR_WS_MAX_CONNECTION_MS").pipe(
       Config.withDefault(840_000),
     ),
+    wsMaxConnectionDrainMs: Config.integer("COCORE_ADVISOR_WS_MAX_CONNECTION_DRAIN_MS").pipe(
+      Config.withDefault(180_000),
+    ),
     reprobeIntervalMs: Config.integer("COCORE_ADVISOR_REPROBE_INTERVAL_MS").pipe(
       Config.withDefault(5_000),
     ),
@@ -213,6 +216,15 @@ const WS_KEEPALIVE_MAX_MISSED = CONFIG.wsKeepaliveMaxMissed;
  *  provider reconnect on its graceful, backoff-resetting path instead.
  *  Set to 0 to disable (rely on the edge cap). */
 const WS_MAX_CONNECTION_MS = CONFIG.wsMaxConnectionMs;
+/** How long BEFORE {@link WS_MAX_CONNECTION_MS} the advisor starts hunting
+ *  for an idle moment to recycle in. The recycle is housekeeping on a timer,
+ *  not a deadline the requester signed up for — and on a provider without
+ *  stream-resume (< 0.9.52) closing the socket kills the job outright, which
+ *  the caller sees as a `provider-disconnected` 502. This window is carved OUT
+ *  of the connection budget, not added to it: total socket lifetime is still
+ *  capped at WS_MAX_CONNECTION_MS, so the margin against Railway's own ~15-min
+ *  cut is unchanged. 0 restores the old close-on-the-dot behavior. */
+const WS_MAX_CONNECTION_DRAIN_MS = CONFIG.wsMaxConnectionDrainMs;
 /** How often to re-probe machines currently in bad standing, to detect that
  *  one has self-righted and restore it to routing. Short so a recovered
  *  machine — especially the only one serving a model — rejoins within
@@ -662,6 +674,7 @@ async function main(): Promise<void> {
           keepaliveIntervalMs: WS_KEEPALIVE_INTERVAL_MS,
           keepaliveMaxMissed: WS_KEEPALIVE_MAX_MISSED,
           maxConnectionMs: WS_MAX_CONNECTION_MS,
+          maxConnectionDrainMs: WS_MAX_CONNECTION_DRAIN_MS,
           apns: apnsConfig,
           // C1: DID-bound registration. advisorDid unset → auth off.
           ...(ADVISOR_DID ? { advisorDid: ADVISOR_DID } : {}),
@@ -751,7 +764,7 @@ async function main(): Promise<void> {
   const boundAddr = http.address();
   const boundPort = boundAddr && typeof boundAddr === "object" ? boundAddr.port : PORT;
   console.error(
-    `advisor: http+ws on :${boundPort} (heartbeat-timeout=${HEARTBEAT_TIMEOUT_MS}ms, session-idle=${SESSION_IDLE_TIMEOUT_MS}ms, session-first-chunk=${SESSION_FIRST_CHUNK_TIMEOUT_MS}ms, session-resume-grace=${SESSION_RESUME_GRACE_MS}ms, rechallenge=${RECHALLENGE_INTERVAL_MS}ms, challenge-response-timeout=${CHALLENGE_RESPONSE_TIMEOUT_MS}ms, attestation-max-age=${ATTESTATION_MAX_AGE_MS}ms, ws-keepalive=${WS_KEEPALIVE_INTERVAL_MS}ms, ws-keepalive-max-missed=${WS_KEEPALIVE_MAX_MISSED}, ws-max-connection=${WS_MAX_CONNECTION_MS}ms, perMessageDeflate=off)`,
+    `advisor: http+ws on :${boundPort} (heartbeat-timeout=${HEARTBEAT_TIMEOUT_MS}ms, session-idle=${SESSION_IDLE_TIMEOUT_MS}ms, session-first-chunk=${SESSION_FIRST_CHUNK_TIMEOUT_MS}ms, session-resume-grace=${SESSION_RESUME_GRACE_MS}ms, rechallenge=${RECHALLENGE_INTERVAL_MS}ms, challenge-response-timeout=${CHALLENGE_RESPONSE_TIMEOUT_MS}ms, attestation-max-age=${ATTESTATION_MAX_AGE_MS}ms, ws-keepalive=${WS_KEEPALIVE_INTERVAL_MS}ms, ws-keepalive-max-missed=${WS_KEEPALIVE_MAX_MISSED}, ws-max-connection=${WS_MAX_CONNECTION_MS}ms, ws-max-connection-drain=${WS_MAX_CONNECTION_DRAIN_MS}ms, perMessageDeflate=off)`,
   );
   console.error(
     "advisor: WS connection-stability config tuned for Railway's edge (frequent keepalive under the idle cutoff, compression off, proactive recycle under the 15-min cap)",

--- a/infra/advisor/src/sessions.test.ts
+++ b/infra/advisor/src/sessions.test.ts
@@ -117,11 +117,42 @@ test("resume reattaches the same invocation and suppresses replayed chunks", () 
     accepted: true,
     nextSeq: 2,
     resumeToken: "secret",
+    streamed: true,
   });
   expect(res.chunks.join("").match(/"type":"complete"/g)).toHaveLength(1);
   expect(sm.resume("s", "did:plc:p", "m", "secret", 2)).toEqual({
     status: "completed",
     nextSeq: 2,
+  });
+});
+
+test("complete reports whether the session ever streamed a chunk", () => {
+  // `streamed` is what lets the advisor tell a served job from a silent stall
+  // (accepted the work, finished it, produced nothing). Legacy sessions never
+  // advance nextSeq, so the sequence number can't stand in for this.
+  const sm = new SessionManager({ idleTimeoutMs: 10_000 });
+  const silent = fakeRes();
+  sm.open("s-silent", "did:plc:p", "m", "did:plc:r", asRes(silent));
+  expect(sm.complete("s-silent", { tokensIn: 7, tokensOut: 0, receiptUri: "at://r" })).toEqual({
+    accepted: true,
+    nextSeq: 0,
+    resumeToken: null,
+    streamed: false,
+  });
+
+  const served = fakeRes();
+  sm.open("s-served", "did:plc:p", "m", "did:plc:r", asRes(served));
+  sm.acceptChunk("s-served", 0, {
+    type: "chunk",
+    sessionId: "s-served",
+    seq: 0,
+    ciphertext: [1],
+  });
+  expect(sm.complete("s-served", { tokensIn: 7, tokensOut: 1, receiptUri: "at://r" })).toEqual({
+    accepted: true,
+    nextSeq: 0,
+    resumeToken: null,
+    streamed: true,
   });
 });
 
@@ -139,6 +170,7 @@ test("complete rejects a finalSeq that races ahead of a missing chunk", () => {
     accepted: false,
     nextSeq: 1,
     resumeToken: "secret",
+    streamed: true,
   });
   // No completion was written and the session is still live.
   expect(res.chunks.join("")).not.toContain('"type":"complete"');
@@ -148,6 +180,7 @@ test("complete rejects a finalSeq that races ahead of a missing chunk", () => {
     accepted: true,
     nextSeq: 1,
     resumeToken: "secret",
+    streamed: true,
   });
 });
 
@@ -288,6 +321,7 @@ test("resume replays a multi-chunk gap in order until completion", () => {
     accepted: true,
     nextSeq: 3,
     resumeToken: "tok",
+    streamed: true,
   });
   const sse = res.chunks.join("");
   expect(sse.match(/"type":"chunk"/g)).toHaveLength(3);

--- a/infra/advisor/src/sessions.ts
+++ b/infra/advisor/src/sessions.ts
@@ -424,13 +424,30 @@ export class SessionManager {
     sessionId: string,
     summary: { tokensIn: number; tokensOut: number; receiptUri: string },
     finalSeq?: number,
-  ): { accepted: boolean; nextSeq: number; resumeToken: string | null } | null {
+  ): {
+    accepted: boolean;
+    nextSeq: number;
+    resumeToken: string | null;
+    /** Did this session ever relay a real chunk to the requester? A
+     *  completion with `streamed: false` means the provider took the job and
+     *  finished it without producing a single token — the "silent stall" that
+     *  otherwise reaches the caller as a perfectly-shaped 200 with an empty
+     *  message. Legacy sessions don't advance `nextSeq`, so this (not the
+     *  sequence number) is the reliable signal. */
+    streamed: boolean;
+  } | null {
     const entry = this.bySessionId.get(sessionId);
     if (!entry) return null;
+    const streamed = entry.lastChunkAt !== null;
     // Resume-capable completion is valid only after every produced chunk was
     // accepted. Legacy frames omit finalSeq and retain their old behavior.
     if (entry.resumeToken && finalSeq !== entry.nextSeq) {
-      return { accepted: false, nextSeq: entry.nextSeq, resumeToken: entry.resumeToken };
+      return {
+        accepted: false,
+        nextSeq: entry.nextSeq,
+        resumeToken: entry.resumeToken,
+        streamed,
+      };
     }
     this.write(sessionId, {
       type: "complete",
@@ -471,7 +488,7 @@ export class SessionManager {
         timer,
       });
     }
-    return { accepted: true, nextSeq: entry.nextSeq, resumeToken: entry.resumeToken };
+    return { accepted: true, nextSeq: entry.nextSeq, resumeToken: entry.resumeToken, streamed };
   }
 
   /** A provider "still working" signal during a long generation (slow

--- a/packages/console/src/lib/inference-dispatch.server.ts
+++ b/packages/console/src/lib/inference-dispatch.server.ts
@@ -225,6 +225,10 @@ export type DispatchErrorCode =
   | "advisor-rejected"
   | "advisor-transport"
   | "no-capacity"
+  /** The provider completed the job without producing a single token. A
+   *  success frame over a wedged engine — surfaced as an error so callers
+   *  don't have to detect an empty 200 themselves. */
+  | "empty-completion"
   | "unknown";
 
 /** Who ran a job, resolved from the provider's AppView footprint, so a

--- a/packages/console/src/lib/openai-chat-completions.server.ts
+++ b/packages/console/src/lib/openai-chat-completions.server.ts
@@ -664,6 +664,13 @@ export function dispatchErrorToHttpResponse(errorCode: DispatchErrorCode): {
       return { status: 502, type: "server_error", code: "chunk_decrypt_failed" };
     case "advisor-rejected":
       return { status: 502, type: "server_error", code: "advisor_rejected" };
+    case "empty-completion":
+      // The provider reported success but produced nothing. 502 rather than a
+      // 200 with an empty message: it's a failed job, and every client would
+      // otherwise have to detect the empty-string case itself. Retryable — the
+      // advisor has already counted it against that machine, so a retry tends
+      // to land somewhere else.
+      return { status: 502, type: "server_error", code: "empty_completion" };
     case "advisor-transport":
       return { status: 502, type: "server_error", code: "advisor_transport" };
     case "no-capacity":
@@ -686,6 +693,9 @@ export function streamingResponse(
     async start(controller) {
       const send = (s: string) => controller.enqueue(encoder.encode(`data: ${s}\n\n`));
       let emittedToolCalls = false;
+      // Did the provider ever give us anything at all? Used to catch the
+      // silent stall — a `complete` on a stream that emitted nothing.
+      let emittedAnything = false;
       // OpenAI clients expect a leading role-only delta.
       send(chunkPayload(id, model, { role: "assistant" }, null));
 
@@ -698,6 +708,7 @@ export function streamingResponse(
               try {
                 const toolCalls = JSON.parse(ev.text);
                 emittedToolCalls = true;
+                emittedAnything = true;
                 send(chunkPayload(id, model, { tool_calls: toolCalls }, null));
               } catch {
                 // Malformed tool_call JSON — skip rather than crash the stream.
@@ -707,9 +718,30 @@ export function streamingResponse(
               // vLLM/DeepSeek convention; the answer rides delta.content.
               const delta =
                 ev.channel === "reasoning" ? { reasoning_content: ev.text } : { content: ev.text };
+              if (ev.text) emittedAnything = true;
               send(chunkPayload(id, model, delta, null));
             }
           } else if (ev.kind === "complete") {
+            // The silent stall, streaming edition: the provider finished the
+            // job having emitted nothing and metered zero output tokens.
+            // Terminate with the same mid-stream error frame a dispatch
+            // failure uses, rather than a `stop` that tells the client the
+            // empty response was the answer.
+            if (!emittedAnything && ev.tokensOut === 0) {
+              const mapped = dispatchErrorToHttpResponse("empty-completion");
+              send(
+                JSON.stringify({
+                  error: {
+                    message:
+                      "The provider completed the job without producing any output. Please retry.",
+                    type: mapped.type,
+                    code: mapped.code,
+                    param: null,
+                  },
+                }),
+              );
+              return;
+            }
             // The final chunk carries the x_cocore credit so a streaming
             // client gets the same "who ran it" metadata the buffered path
             // returns. If the stream emitted tool_call deltas, use the OpenAI
@@ -824,6 +856,23 @@ export async function bufferedResponse(
     return jsonError(
       mapped.status,
       "Inference stream ended before completion.",
+      mapped.type,
+      mapped.code,
+    );
+  }
+
+  // The silent stall: the provider completed the job having emitted nothing at
+  // all — no content, no reasoning, no tool call, zero output tokens. Shaped
+  // like a success, useless as one. Answer with an error so callers get a
+  // retryable signal instead of an empty string they have to recognize
+  // themselves. Deliberately conjunctive: a model that legitimately answers
+  // with only reasoning, or only a tool call, or an empty string after really
+  // spending tokens, is NOT this case.
+  if (!content && !reasoning && toolCallChunks.length === 0 && tokensOut === 0) {
+    const mapped = dispatchErrorToHttpResponse("empty-completion");
+    return jsonError(
+      mapped.status,
+      "The provider completed the job without producing any output. Please retry.",
       mapped.type,
       mapped.code,
     );

--- a/packages/console/src/lib/openai-chat-completions.test.ts
+++ b/packages/console/src/lib/openai-chat-completions.test.ts
@@ -257,6 +257,45 @@ describe("bufferedResponse error mapping", () => {
     assert.match(body.error.message, /before completion/i);
   });
 
+  test("a completion that produced nothing is an error, not an empty 200", async () => {
+    // The silent stall: the provider finishes the job having emitted no text
+    // and metered zero output tokens. Shaped like a success, useless as one —
+    // every client would otherwise have to detect the empty string itself.
+    const res = await bufferedResponse(
+      "chatcmpl-id",
+      "stub",
+      yieldEvents([{ kind: "complete", tokensIn: 591, tokensOut: 0, receiptUri: "at://x" }]),
+    );
+    assert.equal(res.status, 502);
+    const body = (await res.json()) as { error: { code: string; message: string } };
+    assert.equal(body.error.code, "empty_completion");
+    assert.match(body.error.message, /without producing any output/i);
+  });
+
+  test("an empty answer that actually spent output tokens is still a 200", async () => {
+    // Only the conjunction (no text, no reasoning, no tool call, AND zero
+    // metered tokens) is the stall. A model that genuinely burned tokens and
+    // landed on an empty string served the request.
+    const res = await bufferedResponse(
+      "chatcmpl-id",
+      "stub",
+      yieldEvents([{ kind: "complete", tokensIn: 591, tokensOut: 4, receiptUri: "at://x" }]),
+    );
+    assert.equal(res.status, 200);
+  });
+
+  test("a reasoning-only completion is not mistaken for a stall", async () => {
+    const res = await bufferedResponse(
+      "chatcmpl-id",
+      "stub",
+      yieldEvents([
+        { kind: "chunk", seq: 0, channel: "reasoning", text: "hmm" },
+        { kind: "complete", tokensIn: 591, tokensOut: 0, receiptUri: "at://x" },
+      ]),
+    );
+    assert.equal(res.status, 200);
+  });
+
   test("reasoning chunks surface as message.reasoning_content, separate from content", async () => {
     const res = await bufferedResponse(
       "chatcmpl-id",
@@ -477,6 +516,32 @@ describe("streamingResponse is an SSE stream", () => {
     const terminal = parseJson<{ error: { code: string; message: string } }>(data.at(-1)!);
     assert.equal(terminal.error.code, "advisor_transport");
     assert.match(terminal.error.message, /before completion/i);
+  });
+
+  test("a completion that produced nothing terminates the stream with an error", async () => {
+    const res = streamingResponse(
+      "chatcmpl-id",
+      "stub",
+      yieldEvents([{ kind: "complete", tokensIn: 591, tokensOut: 0, receiptUri: "at://x" }]),
+    );
+    const data = await readSseData(res);
+    assert.equal(data.includes("[DONE]"), false);
+    const terminal = parseJson<{ error: { code: string; message: string } }>(data.at(-1)!);
+    assert.equal(terminal.error.code, "empty_completion");
+    assert.match(terminal.error.message, /without producing any output/i);
+  });
+
+  test("a stream that emitted text still terminates with stop + [DONE]", async () => {
+    const res = streamingResponse(
+      "chatcmpl-id",
+      "stub",
+      yieldEvents([
+        { kind: "chunk", seq: 0, channel: "content", text: "hi" },
+        { kind: "complete", tokensIn: 591, tokensOut: 0, receiptUri: "at://x" },
+      ]),
+    );
+    const data = await readSseData(res);
+    assert.equal(data.at(-1), "[DONE]");
   });
 
   test("reasoning chunks ride delta.reasoning_content, content rides delta.content", async () => {


### PR DESCRIPTION
Graze's Feed Pulse hit intermittent hard errors against `cocore.dev` on 2026-09-11/12: 502 `provider-disconnected`, and HTTP 200 with `content: ""` / `completion_tokens: 0`. Both turn out to be ours, and neither is edge churn.

## The 502 is the advisor shooting its own in-flight jobs

The advisor recycles every provider socket at `ws-max-connection` (840s) to pre-empt Railway's ~15-min cut. That recycle never checked whether a job was on the socket. On a provider without stream resume (< 0.9.52) the close ends the session with `provider-disconnected`, which the caller sees as a 502.

Both 502s in the retained prod window land within 60–160ms of the advisor's own recycle log:

```
01:39:45.802  [ws] recycling connection did=did:plc:oyare47r4kf6… (pre-empting the edge connection cap)
01:39:45.856  [ws] mid-job drop did=did:plc:oyare47r4kf6… machine=3mrv6lzmezu2a; closed 1 legacy session(s)
01:39:45.894  POST /v1/chat/completions → 502   (21825 ms in)

12:01:58.777  [ws] recycling connection did=did:plc:oyare47r4kf6…
12:01:58.940  [ws] mid-job drop … closed 1 legacy session(s)
12:01:58.941  POST /v1/chat/completions → 502   (17813 ms in)
```

That machine's sockets live 13m58s–13m59s — the recycle timer, not the edge. A job of length *t* on such a machine has roughly a `t/840` chance of being shot, which for the 10–110s jobs Feed Pulse runs is 1–13% per request (observed: 2 of 33).

It lands on the un-upgraded machines because resume shipped in **0.9.52** (#203), and 4 of 14 live machines are still on 0.9.50 — which happen to be the sole server of `google/gemma-4-12b`, `prism-ml/Ternary-Bonsai-27B-mlx-2bit` and `mlx-community/gemma-3-4b-it-qat-4bit`. That's the reported "failures cluster on 1–2 machine models": it isn't the machine count, it's that those machines can't resume. Corroborating: **zero** `mid-job transport reset` lines in 20h — the resume path has never once been exercised in production.

**Fix:** the recycle now starts hunting for an idle moment `maxConnectionDrainMs` (default 180s) *before* the deadline and closes at the first one. The window is carved **out of** the existing budget rather than added to it — total socket lifetime is still capped at `ws-max-connection`, so the margin against the edge's own cut is unchanged, and a machine that stays busy through the whole window is still closed on the dot.

## The advisor was also billing providers for its own housekeeping

`advisorInitiated` read the close reason off the wire. Providers drop TCP rather than echoing the close frame, so **every** close in 20h of prod logs is `code=1006 reason=""` — the check was always false, and a forced recycle called `recordFailure(…, "provider-disconnected")` against the machine, walking it toward a cooldown for something the advisor did. Now tracked with a local flag set when we initiate the close.

## The silent stall now surfaces as an error

A provider that completes a job having relayed no chunk and metered zero output tokens is a wedged engine wearing a success frame. `bufferedResponse` returned it as a 200 with `content: ""` and `finish_reason: "stop"`, so every client has to reimplement stall detection (Graze does this in `app/feed_pulse/cocore_client.py`).

- Advisor: counts it against the machine's standing as `empty-completion` (needs repeated, clustered failures to trip a cooldown, so an occasional genuinely-empty answer is forgiven) and logs it.
- Console: 502 `empty_completion` on both the buffered and streaming paths, the latter via the existing OpenAI mid-stream error frame.

Deliberately conjunctive — a reasoning-only answer, a tool-call-only answer, or an empty string that really did spend tokens is **not** this case, and each has a test.

## Why there's no advisor-side failover here

The advisor structurally cannot re-dispatch: the console seals the prompt with X25519 to one machine's key and pins `targetMachineId`, and the advisor never holds plaintext. Failover belongs in the console, which already has a 3-attempt re-pick/re-seal loop — but only for a non-OK `/jobs` response. Once the SSE stream is open, a mid-stream `error` is terminal. Extending that to retry on a pre-first-token, retry-safe mid-stream error is the durable fix and is deliberately **not** in this PR; it's a bigger, riskier change that deserves its own review.

Also out of scope, worth their own issues:
- **No absolute session deadline.** `inference_keepalive` re-arms the idle timer with no cap, and detach/resume re-arms it too. The 180s hang Graze reported shows up in the logs as a 499 with `totalDuration=180089` and **no advisor session event at all** — no `idle-timeout`, no `resume-expired`. The caller's own timeout is currently the only bound on a wedged job.
- **One machine is in a reconnect storm.** `3mrdlufuqfl2r` (0.9.52, one of two machines serving `Qwen3.5-9B-MLX-4bit`) did 4714 register→close cycles in 3.7h — one every ~2.4s, 94% of all advisor connection work. No `keepalive missed` terminations, so the agent is re-dialing. It's always the freshest heartbeat, which distorts routing on a 2-machine model.
- **Get the four 0.9.50 machines to ≥ 0.9.52.** That's what makes resume real, and it's what stops any *genuine* drop from being a hard 502.
- **Client log spam.** The Client service's logs are 100% `"slow console→appview call"` / `"slow appview read"` WARNs at `ms=3`, `ms=5`, `ms=13` — 5000 lines per 76 minutes. The threshold is miscalibrated, and it crowded the real dispatch logs out of retention entirely while diagnosing this.

## Testing

- `infra/advisor`: 191 pass (4 new). The drain test is discriminating — it fails at `expected 4551 to be less than 500` against the old behavior.
- `packages/console`: 394 pass (5 new).
- `tsc` clean across advisor, services, console, appview, sdk, exchange, o11y; `oxlint` 0 warnings, `oxfmt` clean.

## Ops

No env changes required; the defaults are the intended behavior. `COCORE_ADVISOR_WS_MAX_CONNECTION_DRAIN_MS=0` restores the previous close-on-the-dot behavior if the drain needs disabling without a revert.

⚠️ `main` auto-deploys Advisor, AppView and Client on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
